### PR TITLE
Switch package main to compiled build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "animation",
     "3d"
   ],
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "browserify": {
     "transform": [
       "babelify",


### PR DESCRIPTION
It appears that we build for distribution, but the package wasn't pointing to the built file.