### PR TITLE
Fix shader paths and upgrade glslify-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-react": "^4.2.3",
     "faucet": "0.0.1",
     "glslify": "^5.0.2",
-    "glslify-babel": "^1.0.0",
+    "glslify-babel": "^1.0.1",
     "husky": "^0.10.2",
     "tap-browser-color": "^0.1.2",
     "tape-catch": "^1.0.4",

--- a/src/model.js
+++ b/src/model.js
@@ -340,7 +340,7 @@ export default class Model extends Object3D {
       throw new Error(`${this.id} Bad uniform ${uniform}`);
     }
     return this;
- }
+  }
 
   // Todo move to attributes manager
   getAttributesTable(attributes, {

--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -4,10 +4,10 @@ const glslify = require('glslify');
 // TODO - adopt glslify
 const Shaders = {
   Vertex: {
-    Default: glslify('./default-vertex')
+    Default: glslify('./default-vertex.glsl')
   },
   Fragment: {
-    Default: glslify('./default-fragment')
+    Default: glslify('./default-fragment.glsl')
   }
 };
 
@@ -15,4 +15,3 @@ Shaders.vs = Shaders.Vertex.Default;
 Shaders.fs = Shaders.Fragment.Default;
 
 export default Shaders;
-


### PR DESCRIPTION
This patch upgrades glslify-babel to fix a problem with paths and also fixes up the usage of glslify in shaders/index.js.  (The .glsl extensions were missing)