### PR TITLE
Implement rest of image loading operations and add test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _docs
 examples/winds/data/*.html
 node_modules
 npm-debug.log
+test/data/test.png

--- a/io/browser/browser-fs.js
+++ b/io/browser/browser-fs.js
@@ -17,7 +17,7 @@ const Blob = window.Blob;
  * @param {Function} callback - Standard node (err, data) callback
  * @return {Promise} - promise, can be used instead of callback
  */
-export function writeFile(file, data, options, callback) {
+function writeFile(file, data, options, callback) {
   // options is optional
   if (callback === undefined && typeof options === 'function') {
     options = undefined;
@@ -51,7 +51,7 @@ export function writeFile(file, data, options, callback) {
  * @param {File|Blob} file  HTML File or Blob object to read as string
  * @returns {Promise.string}  Resolves to a string containing file contents
  */
-export function readFile(file) {
+function readFile(file) {
   return new Promise((resolve, reject) => {
     try {
       assert(File, 'window.File not defined. Must run under browser.');
@@ -104,4 +104,9 @@ function getFileErrorMessage(e) {
   default:
     return 'Read error.';
   }
+}
+
+export default {
+  writeFile,
+  readFile
 }

--- a/io/browser/index.js
+++ b/io/browser/index.js
@@ -1,5 +1,9 @@
-export {default as loadFile} from './browser-request';
-export * from './image-io';
+import loadFile from './browser-request';
+import imageIO from './image-io';
+import browserFS from './browser-fs';
 
-import * as browserFs from './browser-fs';
-export {browserFs};
+export default Object.assign(loadFile, {
+  loadFile,
+  ...browserFS,
+  ...imageIO
+});

--- a/io/index.js
+++ b/io/index.js
@@ -1,2 +1,7 @@
-export * from './io';
-export * from './load-files';
+import IO from './io';
+import loadFiles from './load-files';
+
+export default {
+  ...loadFiles,
+  ...IO
+}

--- a/io/io.js
+++ b/io/io.js
@@ -1,5 +1,5 @@
-import browser from './browser';
-import node from './node';
-
-const io = typeof window !== undefined ? browser : node;
-export default io;
+if (typeof window !== 'undefined') {
+  module.exports = require('./browser');
+} else {
+  module.exports = require('./node');
+}

--- a/io/load-files.js
+++ b/io/load-files.js
@@ -7,7 +7,7 @@ function noop() {}
 /*
  * Loads (Requests) multiple files asynchronously
  */
-export function loadFiles({urls, loader, onProgress = noop, ...opts}) {
+function loadFiles({urls, loader, onProgress = noop, ...opts}) {
   assert(loader, '');
   assert(urls.every(url => typeof url === 'string'),
     'loadImages: {urls} must be array of strings');
@@ -29,7 +29,7 @@ export function loadFiles({urls, loader, onProgress = noop, ...opts}) {
 /*
  * Loads (requests) multiple images asynchronously
  */
-export async function loadImages({urls, onProgress = noop, ...opts}) {
+async function loadImages({urls, onProgress = noop, ...opts}) {
   assert(urls.every(url => typeof url === 'string'),
     'loadImages: {urls} must be array of strings');
   let count = 0;
@@ -46,3 +46,8 @@ export async function loadImages({urls, onProgress = noop, ...opts}) {
     }
   ));
 }
+
+export default {
+  loadFiles,
+  loadImages
+};

--- a/io/node/image-io.js
+++ b/io/node/image-io.js
@@ -9,7 +9,7 @@ import savePixels from 'save-pixels';
  * @param {String} opt.type='png' - png, jpg or image/png, image/jpg are valid
  * @param {String} opt.dataURI= - Whether to include a data URI header
  */
-export function compressedImage(image, {
+function compressImage(image, {
   type = 'png',
   stream = false
 }) {
@@ -17,12 +17,13 @@ export function compressedImage(image, {
   return savePixels(image);
 }
 
-export function uncompressImage(imageData, {type}) {
-  return null;
-}
-
-export function loadImage(url) {
+function loadImage(url) {
   return new Promise((resolve, reject) => {
     resolve(getPixels(url));
   });
+}
+
+export default {
+  compressImage,
+  loadImage 
 }

--- a/io/node/image-io.js
+++ b/io/node/image-io.js
@@ -1,6 +1,7 @@
 // Use stackgl modules for DOM-less reading and writing of images
 import getPixels from 'get-pixels';
 import savePixels from 'save-pixels';
+import ndarray from 'ndarray';
 
 /*
  * Returns data bytes representing a compressed image in PNG or JPG format,
@@ -9,21 +10,31 @@ import savePixels from 'save-pixels';
  * @param {String} opt.type='png' - png, jpg or image/png, image/jpg are valid
  * @param {String} opt.dataURI= - Whether to include a data URI header
  */
-function compressImage(image, {
-  type = 'png',
-  stream = false
-}) {
-  type = type.replace('image/', '');
-  return savePixels(image);
+function compressImage(image, type = 'png') {
+  return savePixels(ndarray(
+    image.data,
+    [image.width, image.height, 4],
+    [4, image.width * 4, 1],
+    0), type.replace('image/', ''));
 }
 
 function loadImage(url) {
   return new Promise((resolve, reject) => {
-    resolve(getPixels(url));
+    getPixels(url, (err, result) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve({
+          width: result.shape[0],
+          height: result.shape[1],
+          data: result.data
+        })
+      }
+    });
   });
 }
 
 export default {
   compressImage,
-  loadImage 
+  loadImage
 }

--- a/io/node/index.js
+++ b/io/node/index.js
@@ -1,10 +1,10 @@
 // Node imports
 import {readFile, writeFile} from 'fs';
+import imageIO from './image-io';
 
-import getPixels from 'get-pixels';
-import savePixels from 'save-pixels';
-
-// export async function saveImageNode(canvas, filename) {
-//   savePixels();
-//   return await browserFs.writeFile(filename, blob);
-// }
+export default {
+  readFile,
+  writeFile,
+  compressImage,
+  loadImage
+}

--- a/io/node/index.js
+++ b/io/node/index.js
@@ -5,6 +5,5 @@ import imageIO from './image-io';
 export default {
   readFile,
   writeFile,
-  compressImage,
-  loadImage
+  ...imageIO
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^4.2.3",
     "faucet": "0.0.1",
+    "gl": "^3.0.6",
     "glslify": "^5.0.2",
     "glslify-babel": "^1.0.1",
     "husky": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "get-pixels": "^3.3.0",
     "gl-format-compiler-error": "^1.0.2",
     "global": "^4.3.0",
-    "save-pixels": "^2.3.2"
+    "save-pixels": "^2.3.2",
+    "through": "^2.3.8"
   },
   "devDependencies": {
     "babel-cli": "6.5.1",
@@ -55,6 +56,7 @@
     "babel-preset-es2015": "6.5.0",
     "babel-preset-stage-2": "^6.5.0",
     "babelify": "^7.2.0",
+    "bl": "^1.1.2",
     "browserify": "^13.0.0",
     "budo": "^8.0.3",
     "electron-prebuilt": "^0.37.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "glslify": "^5.0.2",
     "glslify-babel": "^1.0.1",
     "husky": "^0.10.2",
+    "mkdirp": "^0.5.1",
     "tap-browser-color": "^0.1.2",
     "tape-catch": "^1.0.4",
     "testron": "^1.2.0",

--- a/src/webgl/buffer.js
+++ b/src/webgl/buffer.js
@@ -1,6 +1,8 @@
 // Encapsulates a WebGLBuffer object
 
 import {getExtension, glCheckError} from './context';
+import glGet from './get';
+
 import assert from 'assert';
 
 export default class Buffer {
@@ -63,12 +65,12 @@ export default class Buffer {
     const {gl} = this;
     assert(data, 'Buffer needs data argument');
     this.attribute = attribute || this.attribute;
-    this.bufferType = gl.get(bufferType) || this.bufferType;
+    this.bufferType = glGet(gl, bufferType) || this.bufferType;
     this.size = size || this.size;
-    this.dataType = gl.get(dataType) || this.dataType;
+    this.dataType = glGet(gl, dataType) || this.dataType;
     this.stride = stride || this.stride;
     this.offset = offset || this.offset;
-    this.drawMode = gl.get(drawMode) || this.drawMode;
+    this.drawMode = glGet(gl, drawMode) || this.drawMode;
     this.instanced = instanced || this.instanced;
 
     this.data = data || this.data;

--- a/src/webgl/context.js
+++ b/src/webgl/context.js
@@ -30,18 +30,7 @@ export function createGLContext(canvas, opt = {}) {
   // Set as debug handler
   gl = opt.debug ? createDebugContext(gl) : gl;
 
-  // Add a safe get method
-  gl.get = function glGet(name) {
-    let value = name;
-    if (typeof name === 'string') {
-      value = this[name];
-      assert(value, `Accessing gl.${name}`);
-    }
-    return value;
-  };
-
   return gl;
-
 }
 
 export function hasWebGL() {

--- a/src/webgl/draw.js
+++ b/src/webgl/draw.js
@@ -2,6 +2,7 @@
 // TODO - generic draw call
 // One of the good things about GL is that there are so many ways to draw things
 import {getExtension} from './context';
+import glGet from './get';
 import {GL_INDEX_TYPES, GL_DRAW_MODES} from './types';
 import assert from 'assert';
 
@@ -14,8 +15,8 @@ export function draw(gl, {
   indexed, indexType = null,
   instanced = false, instanceCount = 0
 }) {
-  drawMode = drawMode ? gl.get(drawMode) : gl.TRIANGLES;
-  indexType = indexType ? gl.get(indexType) : gl.UNSIGNED_SHORT;
+  drawMode = drawMode ? glGet(gl, drawMode) : gl.TRIANGLES;
+  indexType = indexType ? glGet(gl, indexType) : gl.UNSIGNED_SHORT;
 
   assert(GL_DRAW_MODES(gl).indexOf(drawMode) > -1, 'Invalid draw mode');
   assert(GL_INDEX_TYPES(gl).indexOf(indexType) > -1, 'Invalid index type');

--- a/src/webgl/get.js
+++ b/src/webgl/get.js
@@ -1,0 +1,11 @@
+// Add a safe get method
+import assert from 'assert';
+
+export default function glGet(gl, name) {
+  let value = name;
+  if (typeof name === 'string') {
+    value = this[name];
+    assert(value, `Accessing gl.${name}`);
+  }
+  return value;
+};

--- a/src/webgl/texture.js
+++ b/src/webgl/texture.js
@@ -8,6 +8,12 @@ class Texture {
     this.gl = gl;
     this.target = gl.TEXTURE_2D;
 
+    if (typeof Image !== 'undefined' && opts instanceof Image) {
+      opts = {
+        data: opts
+      };
+    }
+
     opts = merge({
       flipY: true,
       alignment: 1,
@@ -91,6 +97,12 @@ export class Texture2D extends Texture {
   /* eslint-disable max-statements */
   update(opts) {
     const gl = this.gl;
+
+    if (typeof Image !== 'undefined' && opts instanceof Image) {
+      opts = {
+        data: opts
+      }
+    }
     this.width = opts.width;
     this.height = opts.height;
     this.border = opts.border || 0;

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,3 +2,4 @@ require('babel-polyfill');
 require('tap-browser-color')();
 require('./node');
 require('./gpu');
+require('./io');

--- a/test/electron.js
+++ b/test/electron.js
@@ -1,3 +1,4 @@
 require('babel-polyfill');
 require('./node');
 require('./gpu');
+require('./io');

--- a/test/gpu/index.js
+++ b/test/gpu/index.js
@@ -2,3 +2,4 @@ import './webgl-spec.js';
 import './buffer-spec.js';
 import './program-spec.js';
 import './draw-spec.js';
+import './read-texture.js';

--- a/test/gpu/read-texture.js
+++ b/test/gpu/read-texture.js
@@ -1,0 +1,72 @@
+import test from 'tape';
+import io from '../../io'
+
+/* global document */
+import {WebGLRenderingContext} from '../../src/webgl/webgl-types';
+
+import createContext from 'gl';
+import {Program, Texture2D, Buffer} from '../../src/webgl';
+
+const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVQIW2P8z/D/PwMDAwMjjAEAQOwF/W1Dp54AAAAASUVORK5CYII='
+
+test('WebGL#read-texture', t => {
+  const gl = createContext(2, 2);
+
+  const program = new Program(gl, {
+    vs: `
+    precision mediump float;
+    attribute vec2 position;
+    varying vec2 uv;
+    void main () {
+      uv = 0.5 * (1.0 + position);
+      gl_Position = vec4(position, 0.0, 1.0);
+    }`,
+
+    fs: `
+    precision mediump float;
+    uniform sampler2D tex;
+    varying vec2 uv;
+    void main () {
+      gl_FragColor = texture2D(tex, uv);
+    }`
+  });
+  t.ok(program instanceof Program, 'Program construction successful');
+
+
+  var triangle = new Buffer(gl, {
+    attribute: 'position',
+    data: new Float32Array([
+      -4, 4,
+      4, 4,
+      0, -4]),
+    size: 2
+  });
+  t.ok(triangle instanceof Buffer, 'Buffer construction successful');
+
+  io.loadImage(DATA_URL)
+    .then((image) => {
+      const texture = new Texture2D(gl, image);
+      t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
+      texture.bind()
+
+      program.use();
+      program
+        .setBuffer(triangle)
+        .setUniforms({
+          tex: 0
+        });
+
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+      const pixels = new Uint8Array(2 * 2 * 4);
+      gl.readPixels(0, 0, 2, 2, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+      t.same(pixels, new Uint8Array([
+        255, 0, 255, 255,
+        255, 0, 255, 255,
+        255, 0, 255, 255,
+        255, 0, 255, 255
+      ]), 'pixels ok');
+
+      t.end();
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
 require('babel-core/register');
 require('babel-polyfill');
-require('./node');
+// require('./node');
+require('./io');

--- a/test/io/index.js
+++ b/test/io/index.js
@@ -1,0 +1,1 @@
+import './read-write-image'

--- a/test/io/index.js
+++ b/test/io/index.js
@@ -1,1 +1,1 @@
-import './read-write-image'
+import './read-image';

--- a/test/io/read-image.js
+++ b/test/io/read-image.js
@@ -1,18 +1,14 @@
 import test from 'tape';
 import io from '../../io'
-import bl from 'bl';
 
 const PNG_BITS = 'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVQIW2P8z/D/PwMDAwMjjAEAQOwF/W1Dp54AAAAASUVORK5CYII='
 const DATA_URL = 'data:image/png;base64,' + PNG_BITS
 
 test('io#read-write-image', t => {
-  t.plan(3)
+  t.plan(2);
   io.loadImage(DATA_URL)
     .then((image) => {
-      t.equals(image.width, 2, 'width')
-      t.equals(image.height, 2, 'height')
-      io.compressImage(image).pipe(bl(function (err, data) {
-        t.equals(data.toString('base64'), PNG_BITS, 'data')
-      }))
+      t.equals(image.width, 2, 'width');
+      t.equals(image.height, 2, 'height');
     });
 });

--- a/test/io/read-write-image.js
+++ b/test/io/read-write-image.js
@@ -1,0 +1,18 @@
+import test from 'tape';
+import io from '../../io'
+import bl from 'bl';
+
+const PNG_BITS = 'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVQIW2P8z/D/PwMDAwMjjAEAQOwF/W1Dp54AAAAASUVORK5CYII='
+const DATA_URL = 'data:image/png;base64,' + PNG_BITS
+
+test('io#read-write-image', t => {
+  t.plan(3)
+  io.loadImage(DATA_URL)
+    .then((image) => {
+      t.equals(image.width, 2, 'width')
+      t.equals(image.height, 2, 'height')
+      io.compressImage(image).pipe(bl(function (err, data) {
+        t.equals(data.toString('base64'), PNG_BITS, 'data')
+      }))
+    });
+});

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -2,3 +2,4 @@ import './core-spec.js';
 import './utils-spec.js';
 import './geometry-spec.js';
 import './math-spec.js';
+import './write-read-image.js';

--- a/test/node/write-read-image.js
+++ b/test/node/write-read-image.js
@@ -1,0 +1,36 @@
+import test from 'tape';
+import io from '../../io'
+import fs from 'fs';
+import path from 'path';
+import mkdirp from 'mkdirp';
+
+const TEST_DIR = path.join(__dirname, '..', 'data');
+const TEST_FILE = path.join(TEST_DIR, 'test.png');
+
+test('io#read-write-image', t => {
+  t.plan(1);
+
+  const image = {
+    width: 2,
+    height: 3,
+    data: new Uint8Array([
+      255, 0, 0, 255, 0, 255, 255, 255,
+      0, 0, 255, 255, 255, 255, 0, 255,
+      0, 255, 0, 255, 255, 0, 255, 255
+    ])
+  };
+
+  mkdirp(TEST_DIR, (err) => {
+    if (err) {
+      throw err;
+    }
+    const file = fs.createWriteStream(TEST_FILE);
+    file.on('close', (err) => {
+      io.loadImage(TEST_FILE)
+        .then((result) => {
+          t.same(result, image)
+        });
+    });
+    io.compressImage(image).pipe(file);
+  });
+});


### PR DESCRIPTION
This PR adds a test case for image loading and also finishes the work in progress version on the browser side. 

Right now this PR works fine with browser and electron tests, but currently node is failing.  The reason for this is that I am getting some weird error involving `FileSaver.js`.  Here is a stack trace:

```
/Users/mikolalysenko/GitHub/luma.gl/node_modules/filesaver.js/FileSaver.js:22
		  doc = view.document
		            ^

TypeError: Cannot read property 'document' of undefined
    at /Users/mikolalysenko/GitHub/luma.gl/node_modules/filesaver.js/FileSaver.js:22:15
    at Object.<anonymous> (/Users/mikolalysenko/GitHub/luma.gl/node_modules/filesaver.js/FileSaver.js:241:2)
    at Module._compile (module.js:413:34)
    at Module._extensions..js (module.js:422:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/mikolalysenko/GitHub/luma.gl/node_modules/babel-register/lib/node.js:166:7)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (browser-fs.js:3:1)
```

I think something is going wrong with babel-node, though I'm not sure.  Time permitting I can investigate more deeply tomorrow.