### PR TITLE
Update to use newer gl version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "^1.9.0",
     "eslint-plugin-react": "^4.2.3",
     "faucet": "0.0.1",
-    "gl": "^2.1.5",
+    "gl": "^3.0.5",
     "glslify": "^5.0.2",
     "husky": "^0.10.2",
     "tap-browser-color": "^0.1.2",


### PR DESCRIPTION
Fixes broken `npm install` due to old `gl` version required in `package.json`. Fixes #82.