### PR TITLE
avoid throwing an error when accessing gl.POINTS

### DIFF
--- a/src/webgl/context.js
+++ b/src/webgl/context.js
@@ -107,7 +107,7 @@ export function glGet(gl, name) {
   let value = name;
   if (typeof name === 'string') {
     value = gl[name];
-    assert(value, `Accessing gl.${name}`);
+    assert(value !== undefined, `Accessing gl.${name}`);
   }
   return value;
 }


### PR DESCRIPTION
gl.POINTS is 0x0000 and causes assert() to fail.