### PR TITLE
Add the fp64 projection matrix to Camera so that FP64 layers in deck.gl can be enabled.

### DIFF
--- a/src/core/camera.js
+++ b/src/core/camera.js
@@ -27,6 +27,7 @@ export class Camera {
     this.uniforms = {};
 
     this.projection = new Mat4();
+    this.projectionFP64 = new Float32Array(32);
     Object.seal(this);
 
     this.update();
@@ -53,7 +54,8 @@ export class Camera {
       viewMatrix: this.view,
       viewProjectionMatrix: viewProjection,
       viewInverseMatrix: this.view.invert(),
-      viewProjectionInverseMatrix: viewProjectionInverse
+      viewProjectionInverseMatrix: viewProjectionInverse,
+      projectionFP64: this.projectionFP64
     };
   }
 


### PR DESCRIPTION
Add high precision (fp64) projection matrix to Camera class for fp64 layers from deck.gl to function properly @gnavvy @ibgreen