### PR TITLE
Add TimerQuery and PendingQueryManager classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # Official releases
 
+### 2.9.0  TimerQuery support, Fixes context creation crash on Travis CI
+  - Support EXT_disjoint_timer_query
+  - Fix: context creation crash when WEBGL_debug_info extension was undefined
+
 ### 2.8.0  Debug log improvements, import fix
   - Debug logs now print unused attributes more compactly, number formatting
     improved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 
 # Official releases
 
-### 2.9.0  TimerQuery support, Fixes context creation crash on Travis CI
+### 2.9.0  TimerQuery, WebGL Extension doc, fix crash on Travis CI
   - Support EXT_disjoint_timer_query
+  - Document luma.gl use of WebGL extensions.
   - Fix: context creation crash when WEBGL_debug_info extension was undefined
+  - Add
 
 ### 2.8.0  Debug log improvements, import fix
   - Debug logs now print unused attributes more compactly, number formatting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luma.gl",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "A WebGL JavaScript visualization library.",
   "license": "MIT",
   "author": "Ib Green <ib@uber.com>",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "mkdirp": "^0.5.1",
     "ndarray": "^1.0.18",
     "save-pixels": "^2.3.2",
+    "source-map-support": "^0.4.2",
     "tap-browser-color": "^0.1.2",
     "tape-catch": "^1.0.4",
     "tape-promise": "^1.1.0",

--- a/src/webgl/helpers/query-manager.js
+++ b/src/webgl/helpers/query-manager.js
@@ -1,0 +1,121 @@
+
+const ERR_DELETED = 'Query was deleted before result was available';
+const ERR_CANCEL = 'Query was canceled before result was available';
+
+const noop = x => x;
+
+class QueryManager {
+
+  /**
+   * Internal class that helps "asynchronous WebGL query objects" manage
+   * pending requests (e.g. for EXT_disjoint_timer_query and WebGL2 queries)
+   *
+   * Creates and manages promises for the queries.
+   * Tracks pending queries enabling polling.
+   * Tracks pending queries enabling invalidation.
+   * Encapsulates some standard error messages.
+   *
+   * Remarks:
+   * - Maintains a minimal list of pending queries only to minimize GC impact
+   * - Exported as a singleton class instance.
+   */
+  constructor() {
+    this.pendingQueries = new Set();
+    this.invalidQueryType = null;
+    this.invalidErrorMessage = '';
+    this.checkInvalid = () => false;
+  }
+
+  // API THAT SHOULD BE EXPOSED TO APPLICATION
+
+  // Checks invalidation callback and then all pending queries for completion
+  // Should only be called once per tick
+  poll(gl) {
+    this.cancelInvalidQueries(gl);
+
+    // Now check availability of results and resolve promises as appropriate
+    for (const query of this.pendingQueries.values()) {
+      const resultAvailable = query.isResultAvailable();
+      if (resultAvailable) {
+        const result = query.getResult();
+        this.resolveQuery(query, result);
+      }
+    }
+  }
+
+  // API FOR MANAGED QUERY CLASSES
+
+  // Registers query invalidation method - used to detect disjoint timer queries
+  setInvalidator({queryType, errorMessage, checkInvalid}) {
+    this.invalidQueryType = queryType;
+    this.invalidErrorMessage = errorMessage;
+    this.checkInvalid = checkInvalid;
+  }
+
+  // Starts a query, sets up a new promise
+  beginQuery(query, onComplete = noop, onError = noop) {
+    // Make sure disjoint state is cleared, so that this query starts fresh
+    // Cancel other queries if needed
+    this.cancelInvalidQueries(query.gl);
+
+    // Cancel current promise - noop if already resolved or rejected
+    this.cancelQuery(query);
+
+    // Create a new promise with attached resolve and reject methods
+    const resolvers = {};
+    query.promise = new Promise((resolve, reject) => {
+      resolvers.resolve = resolve;
+      resolvers.reject = reject;
+    });
+    Object.assign(query.promise, resolvers);
+
+    // Add this query to the pending queries
+    this.pendingQueries.add(query);
+    // Register the callbacks
+    return query.promise.then(onComplete).catch(onError);
+  }
+
+  // Resolves a query with a result
+  resolveQuery(query, result) {
+    this.pendingQueries.delete(query);
+    query.promise.resolve(result);
+  }
+
+  // Rejects the promise
+  rejectQuery(query, errorMessage) {
+    this.pendingQueries.delete(query);
+    if (query.promise) {
+      query.promise.reject(new Error(errorMessage));
+    }
+  }
+
+  // Rejects promise with standard message for Query.delete()
+  deleteQuery(query) {
+    return this.rejectQuery(query, ERR_DELETED);
+  }
+
+  // Rejects promise with standard message for Query.cancel()
+  cancelQuery(query) {
+    return this.rejectQuery(query, ERR_CANCEL);
+  }
+
+  // Rejects promise with registered message for invalidation
+  invalidateQuery(query) {
+    if (query instanceof this.invalidQueryType) {
+      this.rejectQuery(query, this.invalidErrorMessage);
+    }
+  }
+
+  // Checks all queries to see if need to be invalidated
+  cancelInvalidQueries(gl) {
+    // We assume that we can cancel queries for all context.
+    // Should be OK since this is used to check for "disjoint" GPU state
+    if (this.checkInvalid(gl)) {
+      for (const query of this.pendingQueries.values()) {
+        this.invalidateQuery(query);
+      }
+    }
+  }
+}
+
+export default new QueryManager();

--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -17,6 +17,9 @@ export {Texture, Texture2D, TextureCube} from './texture';
 import * as VertexAttributes from './vertex-attributes';
 export {VertexAttributes};
 
+// Extensions
+export {default as TimerQuery} from './timer-query';
+
 // Functions
 export * from './context';
 export * from './draw';

--- a/src/webgl/timer-query.js
+++ b/src/webgl/timer-query.js
@@ -1,0 +1,239 @@
+// WebGL2 VertexArray Objects Helper
+import {assertWebGLRenderingContext} from '../webgl/webgl-checks';
+import {glCheckError} from '../webgl/context';
+import queryManager from './helpers/query-manager';
+
+/* eslint-disable no-multi-spaces */
+const GL_QUERY_COUNTER_BITS_EXT      = 0x8864;
+const GL_QUERY_RESULT_EXT            = 0x8866;
+const GL_QUERY_RESULT_AVAILABLE_EXT  = 0x8867;
+const GL_TIME_ELAPSED_EXT            = 0x88BF;
+const GL_TIMESTAMP_EXT               = 0x8E28;
+const GL_GPU_DISJOINT_EXT            = 0x8FBB;
+/* eslint-enable no-multi-spaces */
+
+const noop = x => x;
+
+const ERR_GPU_DISJOINT =
+  'Disjoint GPU operation invalidated timer queries';
+const ERR_TIMER_QUERY_NOT_SUPPORTED =
+  'Timer queries require "EXT_disjoint_timer_query" extension';
+
+export default class TimerQuery {
+  /**
+   * Returns true if TimerQuery is supported by the WebGL implementation
+   * (depends on the EXT_disjoint_timer_query extension)/
+   * Can also check whether timestamp queries are available.
+   *
+   * @param {WebGLRenderingContext} gl - gl context
+   * @param {Object} opts= - options
+   * @param {Object} opts.requireTimestamps=false -
+   *   If true, checks if timestamps are supported
+   * @return {Boolean} - TimerQueries are supported with specified configuration
+   */
+  static isSupported(gl, {requireTimestamps = false} = {}) {
+    assertWebGLRenderingContext(gl);
+    const ext = gl.getExtension('EXT_disjoint_timer_query');
+    const queryCounterBits = ext ?
+      ext.getQueryEXT(GL_TIMESTAMP_EXT, GL_QUERY_COUNTER_BITS_EXT) :
+      0;
+    const timestampsSupported = queryCounterBits > 0;
+    return Boolean(ext) && (!requireTimestamps || timestampsSupported);
+  }
+
+  /**
+   * @classdesc
+   * Provides a way to measure the duration of a set of GL commands,
+   * without stalling the rendering pipeline.
+   *
+   * Exposes a `promise` member that tracks the state of the query
+   * when `poll` is used to update queries.
+   *
+   * @example
+      const timerQuery = new TimerQuery({
+        onComplete: timestamp => console.log(timestamp)
+        onError: error => console.warn(error)
+      });
+
+      timerQuery.begin();
+
+      // Issue GPU calls
+
+      timerQuery.end();
+
+      // Poll for resolved queries
+      requestAnimationFrame(() => TimerQuery.poll(gl))
+   *
+   * Remarks:
+   * - On Chrome, go to chrome:flags and enable "WebGL Draft Extensions"
+   *
+   * - For full functionality, TimerQuery depends on a `poll` function being
+   *   called regularly. When this is done, completed queries will be
+   *   automatically detected and any callbacks called.
+   *
+   * - TimerQuery instance creation will always succeed, even when the required
+   *   extension is not supported. Instead any issued queries will fail
+   *   immediately. This allows applications to unconditionally use TimerQueries
+   *   without adding logic to check whether they are supported; the
+   *   difference being that the `onComplete` callback never gets called,
+   *   (the `onError` callback, if supplied, will be called instead).
+   *
+   * - Even when supported, timer queries can fail whenever a change in the
+   *   GPU occurs that will make the values returned by this extension unusable
+   *   for performance metrics. Power conservation might cause the GPU to go to
+   *   sleep at the lower levers. TimerQuery will detect this condition and
+   *   fail any outstanding queries (which calls the `onError` function,
+   *   if supplied).
+   *
+   * @class
+   * @param {WebGLRenderingContext} gl - gl context
+   * @param {Object} opts - options
+   * @param {Function} opts.onComplete - called with a timestamp.
+   *   Specifying this parameter causes a timestamp query to be initiated
+   * @param {Function} opts.onComplete - called with a timestamp.
+   *   Specifying this parameter causes a timestamp query to be initiated
+   */
+  constructor(gl, {
+    onComplete = noop,
+    onError = noop
+  } = {}) {
+    assertWebGLRenderingContext(gl);
+
+    this.gl = gl;
+    this.ext = this.gl.getExtension('EXT_disjoint_timer_query');
+    this.handle = this.ext ? this.ext.createQueryEXT() : null;
+    this.target = null;
+    this.userData = {};
+
+    this.onComplete = onComplete;
+    this.onError = onError;
+
+    // query manager needs a promise field
+    this.promise = null;
+
+    Object.seal(this);
+  }
+
+  /**
+   * Destroys the WebGL object
+   * Rejects any pending query
+   *
+   * @return {TimerQuery} - returns itself, to enable chaining of calls.
+   */
+  delete() {
+    if (this.handle) {
+      queryManager.deleteQuery(this);
+      this.ext.deleteQueryEXT(this.handle);
+      glCheckError(this.gl);
+      this.handle = null;
+    }
+    return this;
+  }
+
+  /**
+   * Measures GPU time delta between this call and a matching `end` call in the
+   * GPU instruction stream.
+   *
+   * Remarks:
+   * - Due to OpenGL API limitations, after calling `begin()` on one TimerQuery
+   *   instance, `end()` must be called on that same instance before
+   *   calling `begin()` on another query. While there can be multiple
+   *   outstanding queries representing disjoint `begin()`/`end()` intervals.
+   *   It is not possible to interleave or overlap `begin` and `end` calls.
+   *
+   * - Triggering a new query when a TimerQuery is already tracking an
+   *   unresolved query causes that query to be cancelled.
+   *
+   * @return {TimerQuery} - returns itself, to enable chaining of calls.
+   */
+  begin() {
+    queryManager.beginQuery(this, this.onComplete, this.onError);
+    if (this.ext) {
+      this.target = GL_TIME_ELAPSED_EXT;
+      this.ext.beginQueryEXT(this.target, this.handle);
+    } else {
+      queryManager.rejectQuery(this, ERR_TIMER_QUERY_NOT_SUPPORTED);
+    }
+    return this;
+  }
+
+  /**
+   * Inserts a query end marker into the GPU instruction stream.
+   * Can be called multiple times.
+   *
+   * @return {TimerQuery} - returns itself, to enable chaining of calls.
+   */
+  end() {
+    // Note: calling end does not affect the pending promise
+    if (this.target) {
+      this.ext.endQueryEXT(this.target);
+      this.target = null;
+    }
+    return this;
+  }
+
+  /**
+   * Generates a GPU time stamp when the GPU instruction stream reaches
+   * this instruction.
+   * To measure time deltas, two queries are needed.
+   *
+   * Remarks:
+   * - timestamp() queries may not be available even when the timer query
+   *   extension is. See TimeQuery.isSupported() flags.
+   *
+   * - Triggering a new query when a TimerQuery is already tracking an
+   *   unresolved query causes that query to be cancelled.
+   *
+   * @return {TimerQuery} - returns itself, to enable chaining of calls.
+   */
+  timestamp() {
+    queryManager.beginQuery(this, this.onComplete, this.onError);
+    if (this.ext) {
+      this.ext.queryCounterEXT(this.handle, GL_TIMESTAMP_EXT);
+    } else {
+      queryManager.rejectQuery(this, ERR_TIMER_QUERY_NOT_SUPPORTED);
+    }
+    return this;
+  }
+
+  /**
+   * Cancels a pending query
+   * Note - Cancel's the promise and calls end on the current query if needed.
+   *
+   * @return {TimerQuery} - returns itself, to enable chaining of calls.
+   */
+  cancel() {
+    this.end();
+    queryManager.cancelQuery(this);
+    return this;
+  }
+
+  /**
+   * @return {Boolean} - true if query result is available
+   */
+  isResultAvailable() {
+    return this.ext &&
+      this.ext.getQueryObjectEXT(this.handle, GL_QUERY_RESULT_AVAILABLE_EXT);
+  }
+
+  /**
+   * Returns the query result, converted to milliseconds to match
+   * JavaScript conventions.
+   *
+   * @return {Number} - measured time or timestamp, in milliseconds
+   */
+  getResult() {
+    return this.ext ?
+      this.ext.getQueryObjectEXT(this.handle, GL_QUERY_RESULT_EXT) / 1e6 : 0;
+  }
+}
+
+// NOTE: This call lets the queryManager know how to detect disjoint GPU state
+// It will check dsjoint state on polls and before adding a new query
+// and reject any outstanding TimerQueries with our supplied error message.
+queryManager.setInvalidator({
+  queryType: TimerQuery,
+  errorMessage: ERR_GPU_DISJOINT,
+  // Note: Querying the disjoint state resets it
+  checkInvalid: gl => gl.getParameter(GL_GPU_DISJOINT_EXT)
+});

--- a/src/webgl2/sampler.js
+++ b/src/webgl2/sampler.js
@@ -7,14 +7,6 @@ import assert from 'assert';
 
 const ERR_WEBGL2 = 'WebGL2 required';
 
-// WebGLSampler? createSampler();
-// void deleteSampler(WebGLSampler? sampler);
-// [WebGLHandlesContextLoss] GLboolean isSampler(WebGLSampler? sampler);
-// void bindSampler(GLuint unit, WebGLSampler? sampler);
-// void samplerParameteri(WebGLSampler? sampler, GLenum pname, GLint param);
-// void samplerParameterf(WebGLSampler? sampler, GLenum pname, GLfloat param);
-// any getSamplerParameter(WebGLSampler? sampler, GLenum pname);
-
 export default class Sampler {
 
   /**

--- a/test/headless.js
+++ b/test/headless.js
@@ -1,3 +1,4 @@
+require('source-map-support').install();
 require('babel-core/register');
 require('babel-polyfill');
 

--- a/test/webgl/helpers/query-manager.spec.js
+++ b/test/webgl/helpers/query-manager.spec.js
@@ -1,0 +1,8 @@
+import test from 'tape-catch';
+import queryManager
+  from '../../../src/webgl/helpers/query-manager';
+
+test('WebGL helpers#queryManager', t => {
+  t.ok(queryManager, 'Imported correctly');
+  t.end();
+});

--- a/test/webgl/index.js
+++ b/test/webgl/index.js
@@ -1,3 +1,5 @@
+import './helpers/query-manager.spec';
+
 // webgl
 import './webgl-spec';
 import './core-spec.js';
@@ -9,6 +11,9 @@ import './framebuffer-spec';
 import './renderbuffer-spec';
 import './draw-spec';
 import './uniforms-spec';
+
+// Extensions
+import './timer-query.spec';
 
 // import './fbo-spec';
 

--- a/test/webgl/texture-spec.js
+++ b/test/webgl/texture-spec.js
@@ -1,5 +1,5 @@
-import {createGLContext, Texture2D, Buffer} from '../../src/headless';
 import test from 'tape-catch';
+import {createGLContext, Texture2D, Buffer} from '../../src/headless';
 
 const fixture = {
   gl: createGLContext()

--- a/test/webgl/timer-query.spec.js
+++ b/test/webgl/timer-query.spec.js
@@ -1,0 +1,84 @@
+/* eslint-disable max-len, max-statements */
+import test from 'tape-catch';
+import {createGLContext, poll, TimerQuery} from '../../src/headless';
+
+const fixture = {
+  gl: createGLContext()
+};
+
+test('WebGL#TimerQuery construct/delete', t => {
+  const {gl} = fixture;
+
+  const supported = TimerQuery.isSupported(gl);
+  if (supported) {
+    t.comment('TimerQuery is supported, testing functionality');
+  } else {
+    t.comment('TimerQuery is not supported, testing graceful fallback');
+  }
+
+  t.throws(
+    () => new TimerQuery(),
+    /.*WebGLRenderingContext.*/,
+    'TimerQuery throws on missing gl context');
+
+  const timerQuery = new TimerQuery(gl);
+  t.ok(timerQuery instanceof TimerQuery, 'TimerQuery construction successful');
+
+  timerQuery.delete();
+  t.ok(timerQuery instanceof TimerQuery, 'TimerQuery delete successful');
+
+  timerQuery.delete();
+  t.ok(timerQuery instanceof TimerQuery, 'TimerQuery repeated delete successful');
+
+  t.end()
+});
+
+test('WebGL#TimerQuery begin/cancel', t => {
+  const {gl} = fixture;
+
+  // Cancelled query
+
+  const timerQuery = new TimerQuery(gl, {
+    onComplete: result => t.fail(`Query 1: ${result}`),
+    onError: error => t.pass(`Query 1: ${error}`)
+  });
+
+  timerQuery.cancel().cancel().cancel();
+  t.ok(timerQuery instanceof TimerQuery, 'TimerQuery multiple cancel successful');
+
+  timerQuery.begin();
+  t.ok(timerQuery instanceof TimerQuery, 'TimerQuery begin successful');
+
+  timerQuery.cancel().cancel().cancel();
+  t.ok(timerQuery instanceof TimerQuery, 'TimerQuery multiple cancel successful');
+
+  timerQuery.promise.catch(error => {
+    t.pass('TimerQuery promise reset by cancel or lack of implementation');
+    t.end();
+  });
+});
+
+
+test('WebGL#TimerQuery completed/failed queries', t => {
+  const {gl} = fixture;
+
+  // Completed query
+  const timerQuery = TimerQuery.isSupported(gl) ?
+    new TimerQuery(gl, {
+      onComplete: result => t.pass(`Query 2: ${result}ms`),
+      onError: error => t.fail(`Query 2: ${error}`)
+    }) :
+    new TimerQuery(gl);
+
+  timerQuery.begin().end();
+  t.ok(timerQuery.promise instanceof Promise, 'TimerQuery begin/end successful');
+
+  const interval = setInterval(() => poll(gl), 20);
+
+  function finalizer() {
+    clearInterval(interval);
+    t.end();
+  }
+
+  return timerQuery.promise.then(finalizer, finalizer);
+});


### PR DESCRIPTION
- Add support for getting GPU timings via the `WebGL EXT_disjoint_timer_query` extension.
- Add a `TimerQuery` class for working with the extension timer objects.
- Add a `QueryManager` singleton that implements a general polling architecture for asynchronous queries.
- Update the WebGL2 `Query` class to also use `QueryManager`.
- Add `poll` function that uses `QueryManager` to update any pending queries.
- Add test case coverage for TimerQuery
@gnavvy @shaojingli