### PR TITLE
Added luma.gl/luma import that does not include io

### DIFF
--- a/io.js
+++ b/io.js
@@ -1,0 +1,1 @@
+module.exports = require('dist/io');

--- a/luma.js
+++ b/luma.js
@@ -1,0 +1,1 @@
+module.exports = require('dist/luma');

--- a/probe.js
+++ b/probe.js
@@ -1,0 +1,1 @@
+module.exports = require('dist/probe');

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // Export all symbols for LumaGL
 /* global window */
 export * from './luma';
+export * from './io';
 
 // Assign global luma variable to help debugging
 import * as lumaSymbols from './luma';

--- a/src/luma.js
+++ b/src/luma.js
@@ -1,7 +1,6 @@
 // Export all symbols for LumaGL
 export * from './webgl';
 export * from './webgl2';
-export * from './io';
 export * from './math';
 export * from './scenegraph';
 export * from './geometry';


### PR DESCRIPTION
Reduces dependencies for non-io luma.gl apps, and will hopefully mitigate some issues seen when importing luma in Node.js in isomorphic react apps.

io-less import should be made the default import in next major version of luma.gl. Did not want to break backwards compatibility now, so added new entry point.