### PR TITLE
Very basic test that addEvents doesn't crash.

### DIFF
--- a/src/experimental/event/test/headless/add-events.spec.js
+++ b/src/experimental/event/test/headless/add-events.spec.js
@@ -1,0 +1,19 @@
+import test from 'tape-catch';
+import {addEvents} from '../../index.js';
+
+class MockDomElement {
+  _listenersByType = {}
+
+  addEventListener(type, listener) {
+    this._listenersByType[type] = listener;
+  }
+}
+
+test('Experimental#addEvents with no user handlers', t => {
+  const element = new MockDomElement();
+
+  addEvents(element, {});
+  t.pass('addEvents did not throw');
+
+  t.end();
+});

--- a/src/experimental/event/test/headless/index.js
+++ b/src/experimental/event/test/headless/index.js
@@ -1,0 +1,1 @@
+import './add-events.spec';

--- a/test/headless-nowebgl.js
+++ b/test/headless-nowebgl.js
@@ -7,3 +7,6 @@ require('babel-polyfill');
 // Quick test that webgl independent code works
 require('./webgl/context-no-headless.spec');
 require('./webgl-independent');
+
+// experimental
+require('../src/experimental/event/test/headless');


### PR DESCRIPTION
> In addition to manual tests, it would be great with a CI sanity test script that just checked that imports are working and that addEvents is called without crashing.

I'm not sure how valuable this alone is. I can't see a way to add more useful tests without starting to mock whole DOM events - that doesn't seem like a good test. Is this single simple test worth adding?