### PR TITLE
Performance query using EXT_disjoint_timer_query

### DIFF
--- a/src/core/model.js
+++ b/src/core/model.js
@@ -60,6 +60,7 @@ export default class Model extends Object3D {
     render = null,
     onBeforeRender = () => {},
     onAfterRender = () => {},
+    timerQueryEnabled = false,
     ...opts
   } = {}) {
     // assert(program || program instanceof Program);
@@ -118,10 +119,14 @@ export default class Model extends Object3D {
     this.onAfterRender = onAfterRender;
 
     this.timeElapsedQuery = undefined;
+    this.ext = this.program.gl.getExtension('EXT_disjoint_timer_query');
+
     this.lastQueryReturned = true;
     this.accumulatedFrameTime = 0;
     this.averageFrameTime = 0;
     this.profileFrameCount = 0;
+
+    this.timerQueryEnabled = timerQueryEnabled && this.ext !== null;
   }
   /* eslint-enable max-statements */
   /* eslint-enable complexity */
@@ -259,12 +264,11 @@ export default class Model extends Object3D {
     }
     const {isIndexed, indexType} = drawParams;
     const {geometry, isInstanced, instanceCount} = this;
-    const ext = this.program.gl.getExtension('EXT_disjoint_timer_query');
 
-    if (this.lastQueryReturned === true) {
-      this.program.gl.getParameter(ext.GPU_DISJOINT_EXT);
-      this.timeElapsedQuery = ext.createQueryEXT();
-      ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, this.timeElapsedQuery);
+    if (this.timerQueryEnabled === true && this.lastQueryReturned === true) {
+      this.program.gl.getParameter(this.ext.GPU_DISJOINT_EXT);
+      this.timeElapsedQuery = this.ext.createQueryEXT();
+      this.ext.beginQueryEXT(this.ext.TIME_ELAPSED_EXT, this.timeElapsedQuery);
     }
 
     draw(this.program.gl, {
@@ -276,34 +280,38 @@ export default class Model extends Object3D {
       instanceCount
     });
 
-    if (this.lastQueryReturned === true) {
-      ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
-      this.profileFrameCount++;
-      this.lastQueryReturned = false;
-    }
-// ...at some point in the future, after returning control to the browser and being called again:
-    const disjoint = this.program.gl.getParameter(ext.GPU_DISJOINT_EXT);
-    if (disjoint) {
-      // Have to redo all of the measurements.
-    } else {
-      const available = ext.getQueryObjectEXT(this.timeElapsedQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
-
-      if (available) {
-        const timeElapsed = ext.getQueryObjectEXT(this.timeElapsedQuery, ext.QUERY_RESULT_EXT) / 10e6;
-        this.accumulatedFrameTime += timeElapsed;
-        this.averageFrameTime = this.accumulatedFrameTime / this.profileFrameCount;
-        // Do something useful with the time.  Note that care should be
-        // taken to use all significant bits of the result, not just the
-        // least significant 32 bits.
-        console.log('program.id: ', this.program.id);
-        console.log('last frame time: ', timeElapsed, 'ms');
-        console.log('average frame time: ', this.averageFrameTime, 'ms');
-        console.log('accumulated frame time: ', this.accumulatedFrameTime, 'ms');
-        console.log('profile frame count: ', this.profileFrameCount);
+    if (this.timerQueryEnabled === true) {
+      if (this.lastQueryReturned === true) {
+        this.ext.endQueryEXT(this.ext.TIME_ELAPSED_EXT);
+        this.profileFrameCount++;
+        this.lastQueryReturned = false;
+      }
+  // ...at some point in the future, after returning control to the browser and being called again:
+      const disjoint = this.program.gl.getParameter(this.ext.GPU_DISJOINT_EXT);
+      if (disjoint) {
         this.lastQueryReturned = true;
+        // Have to redo all of the measurements.
+      } else {
+        const available = this.ext.getQueryObjectEXT(this.timeElapsedQuery,
+          this.ext.QUERY_RESULT_AVAILABLE_EXT);
+
+        if (available) {
+          const timeElapsed = this.ext.getQueryObjectEXT(this.timeElapsedQuery,
+            this.ext.QUERY_RESULT_EXT) / 1e6;
+          this.accumulatedFrameTime += timeElapsed;
+          this.averageFrameTime = this.accumulatedFrameTime / this.profileFrameCount;
+          // Do something useful with the time.  Note that care should be
+          // taken to use all significant bits of the result, not just the
+          // least significant 32 bits.
+          log.log(2, 'program.id: ', this.program.id);
+          log.log(2, 'last frame time: ', timeElapsed, 'ms');
+          log.log(2, 'average frame time: ', this.averageFrameTime, 'ms');
+          log.log(2, 'accumulated frame time: ', this.accumulatedFrameTime, 'ms');
+          log.log(2, 'profile frame count: ', this.profileFrameCount);
+          this.lastQueryReturned = true;
+        }
       }
     }
-
     this.onAfterRender();
 
     this.unsetProgramState();


### PR DESCRIPTION
Timer query using EXT_disjoint_timer_query. The implementation uses direct webgl calls instead of the TimerQuery class for simplicity. I'll do a cleanup of the TimerQuery class and migrate the code on top of it in the future.