### PR TITLE
add CORS setting for image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Official releases
 
+### 3.0.1
+- Add CORD setting to allow loading image from a different domain
+
 ## 3.0.0
 
 Codebase/Build tooling improvements
@@ -183,4 +186,3 @@ precedence when using wildcard installs.
 - BREAKING CHANGE: Move node IO (loadImage etc) out of main src tree
   and into `packages`. This allows luma.gl to drop a number of big dependencies.
   The node IO code may be published as a separate module later.
-

--- a/src/io/browser-load.js
+++ b/src/io/browser-load.js
@@ -9,7 +9,6 @@ export function loadFile(opts) {
 /*
  * Loads images asynchronously
  * returns a promise tracking the load
- * TODO - CORS support
  */
 export function loadImage(url) {
   return new Promise((resolve, reject) => {
@@ -17,6 +16,7 @@ export function loadImage(url) {
       const image = new Image();
       image.onload = () => resolve(image);
       image.onerror = () => reject(new Error(`Could not load image ${url}.`));
+      image.crossOrigin = 'anonymous';
       image.src = url;
     } catch (error) {
       reject(error);

--- a/src/io/browser-load.js
+++ b/src/io/browser-load.js
@@ -8,15 +8,18 @@ export function loadFile(opts) {
 
 /*
  * Loads images asynchronously
+ * image.crossOrigin can be set via opts.crossOrigin, default to 'anonymous'
  * returns a promise tracking the load
  */
-export function loadImage(url) {
+export function loadImage(url, opts = {
+  crossOrigin: 'anonymous'
+}) {
   return new Promise((resolve, reject) => {
     try {
       const image = new Image();
       image.onload = () => resolve(image);
       image.onerror = () => reject(new Error(`Could not load image ${url}.`));
-      image.crossOrigin = 'anonymous';
+      image.crossOrigin = opts.crossOrigin;
       image.src = url;
     } catch (error) {
       reject(error);


### PR DESCRIPTION
Current config prevents from loading images from another domain (e.g. S3) as texture to layers like the IconLayer.

ref:
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes