### PR TITLE
feat(dev): seer integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "gl-constants": "^1.0.0",
     "gl-matrix": "^2.3.2",
+    "seer": "^0.0.4",
     "webgl-debug": "^1.0.2"
   },
   "devDependencies": {

--- a/src/debug/seer-integration.js
+++ b/src/debug/seer-integration.js
@@ -1,0 +1,45 @@
+import seer from 'seer';
+
+const models = {};
+
+/**
+ * Add a model to our cache indexed by id
+ */
+export const addModel = model => {
+  if (models[model.id]) {
+    return;
+  }
+  models[model.id] = model;
+};
+
+/**
+ * Remove a previously set model from the cache
+ */
+export const removeModel = id => {
+  delete models[id];
+};
+
+/**
+ * Recursively traverse an object given a path of properties and set the given value
+ */
+const recursiveSet = (obj, path, value) => {
+  if (path.length > 1) {
+    recursiveSet(obj[path[0]], path.slice(1), value);
+  } else {
+    obj[path[0]] = value;
+  }
+};
+
+/**
+ * Listen for luma.gl edit events
+ */
+seer.listenFor('luma.gl', payload => {
+  const model = models[payload.itemKey];
+  if (!model || payload.type !== 'edit') {
+    return;
+  }
+
+  const uniforms = model.getUniforms();
+  recursiveSet(uniforms, payload.valuePath, payload.value);
+  model.setUniforms(uniforms);
+});

--- a/test/node.js
+++ b/test/node.js
@@ -1,6 +1,10 @@
 // Enables ES2015 import/export in Node.js
 require('reify');
 
+// Mock addEventListener on window, required for seer
+const {window} = require('../src/utils/globals');
+window.addEventListener = () => {};
+
 // Registers an alias for this module
 const path = require('path');
 const moduleAlias = require('module-alias');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,6 +3892,10 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+seer@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/seer/-/seer-0.0.4.tgz#d17b3db111f60171d0a85a7fb9bac183eb955b98"
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"


### PR DESCRIPTION
Add integration with the soon-to-be born seer.
No performance drawback for production on normal users given the checks over its presence.

Pass the model uniforms and allow to modify some of it. Does not persist across renders given the deck.gl overriding most of it, but can be done if deemed necessary.