### PR TITLE
Remove assert checks in draw function when non-debug context is used

### DIFF
--- a/src/webgl/context.js
+++ b/src/webgl/context.js
@@ -195,18 +195,24 @@ export function glContextWithState(gl, {scissorTest, framebuffer}, func) {
  * @param {WebGLRenderingContext} gl - context
  * @return {Object} - 'vendor' and 'renderer' string fields.
  */
+let lastGLContext = null;
+let lastDebugInfo = null;
 export function glGetDebugInfo(gl) {
-  const info = gl.getExtension('WEBGL_debug_renderer_info');
-  // We can't determine if 'WEBGL_debug_renderer_info' is supported by
-  // checking whether info is null here. Firefox doesn't follow the
-  // specs by returning null for unsupported extension. Instead,
-  // it returns an object without GL_UNMASKED_VENDOR_WEBGL and GL_UNMASKED_RENDERER_WEBGL.
-  return {
-    vendor: (info && info.UNMASKED_VENDOR_WEBGL) ?
-      gl.getParameter(info.UNMASKED_VENDOR_WEBGL) : 'unknown',
-    renderer: (info && info.UNMASKED_RENDERER_WEBGL) ?
-      gl.getParameter(info.UNMASKED_RENDERER_WEBGL) : 'unknown'
-  };
+  if (gl !== lastGLContext || lastDebugInfo === null) {
+    const info = gl.getExtension('WEBGL_debug_renderer_info');
+    // We can't determine if 'WEBGL_debug_renderer_info' is supported by
+    // checking whether info is null here. Firefox doesn't follow the
+    // specs by returning null for unsupported extension. Instead,
+    // it returns an object without GL_UNMASKED_VENDOR_WEBGL and GL_UNMASKED_RENDERER_WEBGL.
+    lastDebugInfo = {
+      vendor: (info && info.UNMASKED_VENDOR_WEBGL) ?
+        gl.getParameter(info.UNMASKED_VENDOR_WEBGL) : 'unknown',
+      renderer: (info && info.UNMASKED_RENDERER_WEBGL) ?
+        gl.getParameter(info.UNMASKED_RENDERER_WEBGL) : 'unknown'
+    };
+    lastGLContext = gl;
+  }
+  return lastDebugInfo;
 }
 
 function logInfo(gl) {

--- a/src/webgl/draw.js
+++ b/src/webgl/draw.js
@@ -23,12 +23,12 @@ export function draw(gl, {
 
   drawMode = glGet(drawMode);
   indexType = glGet(indexType);
-
-  assertDrawMode(drawMode, 'in draw');
-  if (isIndexed) {
-    assertIndexType(indexType, 'in draw');
+  if (gl.debug) {
+    assertDrawMode(drawMode, 'in draw');
+    if (isIndexed) {
+      assertIndexType(indexType, 'in draw');
+    }
   }
-
   // TODO - Use polyfilled WebGL2RenderingContext instead of ANGLE extension
   if (isInstanced) {
     const webgl2 = isWebGL2Context(gl);
@@ -37,7 +37,7 @@ export function draw(gl, {
     const suffix = webgl2 ? '' : 'ANGLE';
     const drawElements = 'drawElementsInstanced' + suffix;
     const drawArrays = 'drawArraysInstanced' + suffix;
-    
+
     if (isIndexed) {
       context[drawElements](
         drawMode, vertexCount, indexType, offset, instanceCount


### PR DESCRIPTION
Cache glGetDebugInfo queries results

ATTN: this diff is targeting the 3.0-release branch