### PR TITLE
Fix framebuffer creation error introduced in #172

### DIFF
--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -65,7 +65,7 @@ export default class Framebuffer extends Resource {
       }
     } else {
       // Create any requested default attachments
-      attachments = this._createDefaultAttachments({color, depth, stencil});
+      attachments = this._createDefaultAttachments({color, depth, stencil, width, height});
     }
 
     // Any current attachments need to be removed, create a map with null values

--- a/src/webgl/texture-cube.js
+++ b/src/webgl/texture-cube.js
@@ -23,7 +23,7 @@ export default class TextureCube extends Texture {
   initialize(opts = {}) {
     const {
       format = GL.RGBA,
-      mipmaps = true
+      mipmaps = false
     } = opts;
 
     let {

--- a/src/webgl/texture.js
+++ b/src/webgl/texture.js
@@ -122,7 +122,7 @@ export default class Texture extends Resource {
       format = GL.RGBA,
       type = GL.UNSIGNED_BYTE,
       border = 0,
-      mipmaps = true,
+      mipmaps = false,
       recreate = false,
       parameters = {},
       pixelStore = {}


### PR DESCRIPTION
Fix the framebuffer creation issue introduced by #172 
Also turn off default mipmap generation because WebGL has strict requirements on texture type / format / wrapping mode parameter combination for mipmap generation.

This is the root cause of https://github.com/uber/deck.gl/issues/653

@ibgreen @ericsoco 