### PR TITLE
Fix the framebuffer creation issue by manually turning mipmap off

### DIFF
--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -319,7 +319,8 @@ export default class Framebuffer extends Resource {
         parameters: {
           [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
           [GL.TEXTURE_MAG_FILTER]: GL.NEAREST
-        }
+        },
+        mipmaps: false
       });
     }
 

--- a/src/webgl/texture-cube.js
+++ b/src/webgl/texture-cube.js
@@ -23,7 +23,7 @@ export default class TextureCube extends Texture {
   initialize(opts = {}) {
     const {
       format = GL.RGBA,
-      mipmaps = false
+      mipmaps = true
     } = opts;
 
     let {

--- a/src/webgl/texture.js
+++ b/src/webgl/texture.js
@@ -122,7 +122,7 @@ export default class Texture extends Resource {
       format = GL.RGBA,
       type = GL.UNSIGNED_BYTE,
       border = 0,
-      mipmaps = false,
+      mipmaps = true,
       recreate = false,
       parameters = {},
       pixelStore = {}


### PR DESCRIPTION
Partially revert #177 by turning mipmap on by default
Framebuffer texture needs to have mipmap off due to its non-power-of-2 sizes