### PR TITLE
Fix blending in lessons

### DIFF
--- a/examples/lessons/04/app.js
+++ b/examples/lessons/04/app.js
@@ -36,6 +36,7 @@ const animationLoop = new AnimationLoop({
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
+    gl.disable(gl.BLEND);
 
     const program = new Program(gl, {vs: VERTEX_SHADER, fs: FRAGMENT_SHADER});
 

--- a/examples/lessons/05/app.js
+++ b/examples/lessons/05/app.js
@@ -38,6 +38,7 @@ const animationLoop = new AnimationLoop({
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
+    gl.disable(gl.BLEND);
     gl.pixelStorei(GL.UNPACK_FLIP_Y_WEBGL, true);
 
     return loadTextures(gl, {

--- a/examples/lessons/06/app.js
+++ b/examples/lessons/06/app.js
@@ -59,6 +59,7 @@ const animationLoop = new AnimationLoop({
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
+    gl.disable(gl.BLEND);
 
     const cube = new Cube({gl, vs: VERTEX_SHADER, fs: FRAGMENT_SHADER});
 

--- a/examples/lessons/07/app.js
+++ b/examples/lessons/07/app.js
@@ -71,6 +71,7 @@ const animationLoop = new AnimationLoop({
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
+    gl.disable(gl.BLEND);
 
     return loadTextures(gl, {
       urls: ['crate.gif']

--- a/examples/lessons/08/app.js
+++ b/examples/lessons/08/app.js
@@ -71,8 +71,6 @@ const animationLoop = new AnimationLoop({
 
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
-    gl.enable(GL.DEPTH_TEST);
-    gl.depthFunc(GL.LEQUAL);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
     gl.enable(gl.BLEND);
     gl.disable(gl.DEPTH_TEST);


### PR DESCRIPTION
All lessons are sharing same canvas hence same GL context. When switching from a lesson that enables blending to another lesson that doesn't causes problem. Disable blending on initialize for all lessons that don't need blending.