### PR TITLE
Context state management fixes.

### DIFF
--- a/docs/api-reference/webgl/context-state.md
+++ b/docs/api-reference/webgl/context-state.md
@@ -37,7 +37,7 @@ withParameters(gl, {
   colorMask: ,
   colorWritemask: ,
 
-  cullFace: false,
+  cullFace: GL.BACK,
   cullFaceMode: ,
 
   depthTest: false,
@@ -122,6 +122,16 @@ withState(gl, {...params}, func)
 ```
 Executes a function with gl states temporarily set
 Exception safe
+
+### resetContext
+
+```js
+resetContext(gl)
+```
+Resets gl state to default values.
+
+* `gl` {WebGLRenderingContext} - context
+Returns no value.
 
 
 ## Parameters
@@ -474,4 +484,3 @@ WebGL State Management can be quite complicated.
   them as they are changed through luma functions.
   The cached values can get out of sync if the context is shared outside
   of luma.gl.
-

--- a/examples/lessons/01/app.js
+++ b/examples/lessons/01/app.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-var, max-statements */
 
-import {AnimationLoop, Program, Buffer, Matrix4} from 'luma.gl';
+import {AnimationLoop, Program, Buffer, Matrix4, resetContext} from 'luma.gl';
 
 const VERTEX_SHADER = `\
 attribute vec3 positions;
@@ -27,6 +27,7 @@ const animationLoop = new AnimationLoop({
   onInitialize({gl, canvas, aspect}) {
     addControls();
 
+    resetContext(gl);
     gl.viewport(0, 0, canvas.width, canvas.height);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);

--- a/examples/lessons/02/app.js
+++ b/examples/lessons/02/app.js
@@ -1,6 +1,6 @@
 /* global window, document, LumaGL */
 /* eslint-disable no-var, max-statements */
-import {AnimationLoop, Program, Buffer, Matrix4} from 'luma.gl';
+import {AnimationLoop, Program, Buffer, Matrix4, resetContext} from 'luma.gl';
 
 const VERTEX_SHADER = `\
 attribute vec3 positions;
@@ -33,6 +33,7 @@ const animationLoop = new AnimationLoop({
   onInitialize({gl, aspect, canvas}) {
     addControls();
 
+    resetContext(gl);
     gl.viewport(0, 0, canvas.width, canvas.height);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);

--- a/examples/lessons/03/app.js
+++ b/examples/lessons/03/app.js
@@ -1,5 +1,5 @@
 /* eslint-disable array-bracket-spacing, no-multi-spaces */
-import {GL, AnimationLoop, Program, Model, Geometry, Matrix4} from 'luma.gl';
+import {GL, AnimationLoop, Program, Model, Geometry, Matrix4, resetContext} from 'luma.gl';
 
 const FRAGMENT_SHADER = `\
 #ifdef GL_ES
@@ -48,6 +48,7 @@ const animationLoop = new AnimationLoop({
   onInitialize({gl}) {
     addControls();
 
+    resetContext(gl);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
     gl.enable(gl.DEPTH_TEST);

--- a/examples/lessons/04/app.js
+++ b/examples/lessons/04/app.js
@@ -1,4 +1,4 @@
-import {GL, AnimationLoop, Model, Geometry, Program, Matrix4} from 'luma.gl';
+import {GL, AnimationLoop, Model, Geometry, Program, Matrix4, resetContext} from 'luma.gl';
 
 const VERTEX_SHADER = `\
 attribute vec3 positions;
@@ -32,11 +32,11 @@ const animationLoop = new AnimationLoop({
   onInitialize({gl}) {
     addControls();
 
+    resetContext(gl);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
-    gl.disable(gl.BLEND);
 
     const program = new Program(gl, {vs: VERTEX_SHADER, fs: FRAGMENT_SHADER});
 

--- a/examples/lessons/05/app.js
+++ b/examples/lessons/05/app.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var, max-statements, indent, no-multi-spaces */
-import {GL, AnimationLoop, loadTextures, Cube, Matrix4} from 'luma.gl';
+import {GL, AnimationLoop, loadTextures, Cube, Matrix4, resetContext} from 'luma.gl';
 
 const VERTEX_SHADER = `\
 attribute vec3 positions;
@@ -34,11 +34,11 @@ const animationLoop = new AnimationLoop({
   onInitialize({gl}) {
     addControls();
 
+    resetContext(gl);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
-    gl.disable(gl.BLEND);
     gl.pixelStorei(GL.UNPACK_FLIP_Y_WEBGL, true);
 
     return loadTextures(gl, {

--- a/examples/lessons/06/app.js
+++ b/examples/lessons/06/app.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-var, max-statements, indent, no-multi-spaces */
-import {GL, AnimationLoop, Cube, Matrix4, Texture2D, addEvents, loadImage} from 'luma.gl';
+import {GL, AnimationLoop, Cube, Matrix4, Texture2D, addEvents, loadImage, resetContext}
+  from 'luma.gl';
 
 /* global window */
 /* eslint-disable max-statements, no-var, no-multi-spaces */
@@ -55,11 +56,11 @@ const animationLoop = new AnimationLoop({
     //   [GL.UNPACK_FLIP_Y_WEBGL]: true
     // });
 
+    resetContext(gl);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
-    gl.disable(gl.BLEND);
 
     const cube = new Cube({gl, vs: VERTEX_SHADER, fs: FRAGMENT_SHADER});
 

--- a/examples/lessons/07/app.js
+++ b/examples/lessons/07/app.js
@@ -3,7 +3,7 @@
 /* global document */
 
 import {GL, AnimationLoop, Cube, Matrix4, Texture2D,
-  addEvents, loadTextures, Model} from 'luma.gl';
+  addEvents, loadTextures, Model, resetContext} from 'luma.gl';
 
 const VERTEX_SHADER = `\
 attribute vec3 positions;
@@ -67,11 +67,11 @@ const animationLoop = new AnimationLoop({
     addControls();
     addKeyboardHandler(canvas);
 
+    resetContext(gl);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
     gl.enable(GL.DEPTH_TEST);
     gl.depthFunc(GL.LEQUAL);
-    gl.disable(gl.BLEND);
 
     return loadTextures(gl, {
       urls: ['crate.gif']

--- a/examples/lessons/08/app.js
+++ b/examples/lessons/08/app.js
@@ -2,7 +2,7 @@
 /* eslint-disable max-statements, array-bracket-spacing, no-multi-spaces */
 /* global window, document */
 import {GL, AnimationLoop, Cube, Matrix4, Texture2D,
-  addEvents, loadTextures, Model} from 'luma.gl';
+  addEvents, loadTextures, Model, resetContext} from 'luma.gl';
 
 // Vertex shader with lighting
 const VERTEX_SHADER = `\
@@ -69,6 +69,7 @@ const animationLoop = new AnimationLoop({
     addControls();
     addKeyboardHandler(canvas);
 
+    resetContext(gl);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE);

--- a/examples/lessons/09/app.js
+++ b/examples/lessons/09/app.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-var, max-statements */
 /* eslint-disable array-bracket-spacing, no-multi-spaces */
 /* global document */
-import {GL, AnimationLoop, loadTextures, addEvents, Matrix4} from 'luma.gl';
+import {GL, AnimationLoop, loadTextures, addEvents, Matrix4, resetContext} from 'luma.gl';
 import {Star} from './star';
 
 var zoom = -15;
@@ -12,11 +12,11 @@ const animationLoop = new AnimationLoop({
     addControls();
     addKeyboardHandler(canvas);
 
+    resetContext(gl);
     gl.clearColor(0, 0, 0, 1);
     gl.clearDepth(1);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
     gl.enable(gl.BLEND);
-//    gl.disable(gl.DEPTH_TEST);
 
     return loadTextures(gl, {
       urls: ['star.gif']

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ export {
 export {
   getParameter,
   setParameter,
-  withState} from './webgl/context-state';
+  withState,
+  resetContext} from './webgl/context-state';
 export {
   getGLContextInfo,
   getContextLimits,

--- a/test/webgl/context-state.spec.js
+++ b/test/webgl/context-state.spec.js
@@ -1,5 +1,6 @@
 import {isWebGL2Context} from 'luma.gl';
-import {getParameter, withState, TEST_EXPORTS} from '../../src/webgl/context-state';
+import {getParameter, setParameter, withState, resetContext, TEST_EXPORTS}
+  from '../../src/webgl/context-state';
 
 import test from 'tape-catch';
 
@@ -65,3 +66,20 @@ test('WebGLState#withState', t => {
   t.end();
 });
 
+test('WebGLState#resetContext', t => {
+  const {gl} = fixture;
+
+  setParameter(gl, 'clearColor', [0, 1, 0, 1]);
+
+  let value = getParameter(gl, 'clearColor');
+  t.deepEqual(value, [0, 1, 0, 1],
+    `got expected value ${stringifyTypedArray(value)}`);
+
+  resetContext(gl);
+
+  value = getParameter(gl, 'clearColor');
+  t.deepEqual(value, [0, 0, 0, 0],
+    `got expected value ${stringifyTypedArray(value)}`);
+
+  t.end();
+});


### PR DESCRIPTION
Context state management changes:
- 	Add 'resetContext' to set all gl states to default values.
- 	Call either glEnable or glDisable based on the value to be set.
- 	Fix default values for several gl states.