### PR TITLE
Misc fixes

### DIFF
--- a/src/core/animation-loop.js
+++ b/src/core/animation-loop.js
@@ -154,7 +154,7 @@ export default class AnimationLoop {
   // Add application's data to the app context object
   _addAppDataToContext(appContext) {
     if (typeof appContext === 'object' && appContext !== null) {
-      this._context = Object.assign({}, appContext, this._context);
+      this._context = Object.assign({}, this._context, appContext);
     }
   }
 

--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -19,7 +19,7 @@ const UNIFORM_BASE_DESCRIPTORS = {
   [GL.BOOL_VEC3]: {function: 'uniform3fv', type: Uint16Array, elements: 3},
   [GL.BOOL_VEC4]: {function: 'uniform4iv', type: Uint16Array, elements: 4},
   [GL.FLOAT_MAT2]: {function: 'uniformMatrix2fv', type: Float32Array, matrix: true, elements: 4},
-  [GL.FLOAT_MAT3]: {mfunction: 'uniformMatrix3fv', type: Float32Array, matrix: true, elements: 9},
+  [GL.FLOAT_MAT3]: {function: 'uniformMatrix3fv', type: Float32Array, matrix: true, elements: 9},
   [GL.FLOAT_MAT4]: {function: 'uniformMatrix4fv', type: Float32Array, matrix: true, elements: 16},
   [GL.SAMPLER_2D]: {function: 'uniform1i', type: Uint16Array, texture: true},
   [GL.SAMPLER_CUBE]: {function: 'uniform1i', type: Uint16Array, texture: true}


### PR DESCRIPTION
Fixes I found while debugging lesson16.

- animation-loop.json: When merging the appContext (returned from initializer), use the correct merging order so existing props in current context are overwritten by whats in appContext.
- uniforms.js: Fix a typo.