### PR TITLE
Add NPOT workaround for texture2d object.

### DIFF
--- a/docs/api-reference/webgl/framebuffer.md
+++ b/docs/api-reference/webgl/framebuffer.md
@@ -16,6 +16,16 @@ const framebuffer = new Framebuffer(gl, {
   depth: true
 });
 ```
+When no attachments are provided during `Framebuffer` object creation, new resources are created and used as default attachments for enabled targets (color and depth).
+For color, new `Texture2D` object is created with no mipmaps and following filtering parameters are set.
+
+| Texture parameter       | Value |
+| ---                     | --- |
+| `GL.TEXTURE_MIN_FILTER` | `GL.LINEAR` |
+| `GL.TEXTURE_WRAP_S`     | `GL.CLAMP_TO_EDGE` |
+| `GL.TEXTURE_WRAP_T`     | `GL.CLAMP_TO_EDGE` |
+For depth, new `Renderbuffer` object is created with `GL.DEPTH_COMPONENT16` format.
+
 
 Attaching textures and renderbuffers
 ```js

--- a/docs/api-reference/webgl/texture.md
+++ b/docs/api-reference/webgl/texture.md
@@ -367,6 +367,19 @@ For more details, see tables in:
 | `GL.LINEAR_*` sampling of floating point textures           | `TEXTURE_FILTER_LINEAR_FLOAT` |
 | `GL.LINEAR_*` sampling of half-floating point textures      | `TEXTURE_FILTER_LINEAR_HALF_FLOAT` |
 
+## NPOT Textures (WebGL1)
+
+* Any texture with a `non power of two` dimension (width or height) is referred as `NPOT` texture, under WebGL1 NPOT textures have following limitations.
+
+| State              | Limitation |
+| ---                | --- |
+| Mipmapping         | Should be disabled |
+| `GL.TEXTURE_MIN_FILTER` | Must be either `GL.LINEAR` or `GL.NEAREST` |
+| `GL.TEXTURE_WRAP_S`     | Must be `GL.CLAMP_TO_EDGE` |
+| `GL.TEXTURE_WRAP_T`     | Must be `GL.CLAMP_TO_EDGE` |
+
+* 'Texture' class will perform above settings when NPOT texture resource is created. When un-supported filtering is set using `Texture.setParameters`, those will be overwritten with above supported values (`GL.TEXTURE_MIN_FILTER` will be set to `GL.LINEAR`). This only happens for NPOT textures when using WebGL1, and a warning log will be printed every time a setting is overwritten.
+
 
 ## Remarks
 

--- a/examples/lessons/03/app.js
+++ b/examples/lessons/03/app.js
@@ -59,8 +59,8 @@ const animationLoop = new AnimationLoop({
     });
 
     const program = new Program(gl, {vs: VERTEX_SHADER, fs: FRAGMENT_SHADER});
-    const triangle = new Model({geometry: triangleGeometry, program});
-    const square = new Model({geometry: squareGeometry, program});
+    const triangle = new Model(gl, {geometry: triangleGeometry, program});
+    const square = new Model(gl, {geometry: squareGeometry, program});
 
     return {triangle, square};
   },

--- a/examples/lessons/04/app.js
+++ b/examples/lessons/04/app.js
@@ -44,8 +44,8 @@ const animationLoop = new AnimationLoop({
     const program = new Program(gl, {vs: VERTEX_SHADER, fs: FRAGMENT_SHADER});
 
     return {
-      pyramid: new Model({program, geometry: getPyramidGeometry()}),
-      cube: new Model({program, geometry: getCubeGeometry()})
+      pyramid: new Model(gl, {program, geometry: getPyramidGeometry()}),
+      cube: new Model(gl, {program, geometry: getCubeGeometry()})
     };
   },
   onRender({gl, tick, aspect, pyramid, cube}) {

--- a/examples/lessons/09/star.js
+++ b/examples/lessons/09/star.js
@@ -39,6 +39,7 @@ export class Star extends Model {
     });
 
     super({
+      gl: opts.gl,
       program,
       geometry: new Geometry({
         positions: new Float32Array([

--- a/examples/lessons/16/app.js
+++ b/examples/lessons/16/app.js
@@ -230,7 +230,7 @@ const animationLoop = new AnimationLoop({
 
       // TODO: Square program/model for debugging only, remove once all rendering issues resolved
       const programSQ = new Program(gl, {vs: VERTEX_SHADER_SQ, fs: FRAGMENT_SHADER_SQ});
-      const tSquare = new Model({geometry: squareGeometry, program: programSQ});
+      const tSquare = new Model(gl, {geometry: squareGeometry, program: programSQ});
 
       return {moon, macbook, cube, laptopScreenModel, tCrate, tSquare};
     });

--- a/src/io/load-files.js
+++ b/src/io/load-files.js
@@ -103,7 +103,7 @@ export function parseModel(gl, opts = {}) {
     }
   }
 
-  return new Model(Object.assign(
+  return new Model(gl, Object.assign(
     {program, geometry: new Geometry({attributes})},
     modelOptions,
     opts

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 /**
  * Wraps the argument in an array if it is not one.
  * @param {object} a - The object to wrap.
@@ -75,4 +77,14 @@ function detach(elem) {
   }
 
   return ans;
+}
+
+/**
+ * Verifies if a given number is power of two or not.
+ * @param {object} n - The number to check.
+ * @return {Array} Returns true if the given number is power of 2, false otherwise.
+ **/
+export function isPowerOfTwo(n) {
+  assert((typeof n === 'number'), 'Input must be a number');
+  return n && ((n & (n - 1)) === 0);
 }

--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -433,7 +433,19 @@ export default class Framebuffer extends Resource {
         format: GL.RGBA,
         type: GL.UNSIGNED_BYTE,
         width,
-        height
+        height,
+        // Note: Mipmapping can be disabled by texture resource when we resize the texture
+        // to a non-power-of-two dimenstion (NPOT texture) under WebGL1. To have consistant
+        // behavior we always disable mipmaps.
+        mipmaps: false,
+        // Set MIN and MAG filtering parameters so mipmaps are not used in sampling.
+        // Set WRAP modes that support NPOT textures too.
+        parameters: {
+          [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
+          [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
+          [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
+          [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE
+        }
       });
     }
 

--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -151,8 +151,7 @@ export default class Framebuffer extends Resource {
 
   // Attach from a map of attachments
   attach(attachments, {
-    clearAttachments = false,
-    setFilteringParameters = true
+    clearAttachments = false
   } = {}) {
     const newAttachments = {};
 
@@ -185,15 +184,6 @@ export default class Framebuffer extends Resource {
         this._attachTexture({attachment, texture, layer, level});
       } else {
         this._attachTexture({attachment, texture: object, layer: 0, level: 0});
-      }
-
-      if (setFilteringParameters && object instanceof Texture2D) {
-        object.setParameters({
-          [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
-          [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
-          [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
-          [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE
-        });
       }
 
       // Resize objects
@@ -443,16 +433,7 @@ export default class Framebuffer extends Resource {
         format: GL.RGBA,
         type: GL.UNSIGNED_BYTE,
         width,
-        height,
-        // Only power of two sized textures can have mipmaps in WebGL1
-        mipmaps: false,
-        // Use poor filtering, and clamp
-        parameters: {
-          [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
-          [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
-          [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
-          [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE
-        }
+        height
       });
     }
 

--- a/src/webgl/texture.js
+++ b/src/webgl/texture.js
@@ -226,7 +226,7 @@ export default class Texture extends Resource {
 
     if (this._isNPOT()) {
 
-      log.warn(0, `texture: ${this.handle} is Non-Power-Of-Two, disabling mipmaping`);
+      log.warn(0, `texture: ${this} is Non-Power-Of-Two, disabling mipmaping`);
       mipmaps = false;
 
       this._updateForNPOT(parameters);
@@ -711,15 +711,15 @@ export default class Texture extends Resource {
   // Update default settings which are not supported by NPOT textures.
   _updateForNPOT(parameters) {
     if (parameters[this.gl.TEXTURE_MIN_FILTER] === undefined) {
-      log.warn(0, `texture: ${this.handle} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
+      log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
       parameters[this.gl.TEXTURE_MIN_FILTER] = this.gl.LINEAR;
     }
     if (parameters[this.gl.TEXTURE_WRAP_S] === undefined) {
-      log.warn(0, `texture: ${this.handle} is Non-Power-Of-Two, forcing TEXTURE_WRAP_S to CLAMP_TO_EDGE`);
+      log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_WRAP_S to CLAMP_TO_EDGE`);
       parameters[this.gl.TEXTURE_WRAP_S] = this.gl.CLAMP_TO_EDGE;
     }
     if (parameters[this.gl.TEXTURE_WRAP_T] === undefined) {
-      log.warn(0, `texture: ${this.handle} is Non-Power-Of-Two, forcing TEXTURE_WRAP_T to CLAMP_TO_EDGE`);
+      log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_WRAP_T to CLAMP_TO_EDGE`);
       parameters[this.gl.TEXTURE_WRAP_T] = this.gl.CLAMP_TO_EDGE;
     }
   }
@@ -729,14 +729,14 @@ export default class Texture extends Resource {
       switch (pname) {
       case GL.TEXTURE_MIN_FILTER:
         if (NPOT_MIN_FILTERS.indexOf(param) === -1) {
-          log.warn(0, `texture: ${this.handle} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
+          log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
           param = GL.LINEAR;
         }
         break;
       case GL.TEXTURE_WRAP_S:
       case GL.TEXTURE_WRAP_T:
         if (param !== GL.CLAMP_TO_EDGE) {
-          log.warn(0, `texture: ${this.handle} is Non-Power-Of-Two, ${glKey(pname)} to CLAMP_TO_EDGE`);
+          log.warn(0, `texture: ${this} is Non-Power-Of-Two, ${glKey(pname)} to CLAMP_TO_EDGE`);
           param = GL.CLAMP_TO_EDGE;
         }
         break;

--- a/test/node.js
+++ b/test/node.js
@@ -14,6 +14,6 @@ moduleAlias.addAlias('luma.gl', path.resolve('./src'));
 require('luma.gl/headless');
 
 // Run the tests
-// require('./index-webgl-independent-tests');
+require('./index-webgl-independent-tests');
 require('./index-webgl-dependent-tests');
 require('./debug/seer-integration');

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -14,7 +14,7 @@ export function createTestContext(opts = {}) {
 }
 
 export const fixture = {
-  gl: createTestContext(),
+  gl: createTestContext({webgl2: false, webgl1: true}),
   gl2: createTestContext({webgl2: true, webgl1: false})
 };
 

--- a/test/utils/utils.spec.js
+++ b/test/utils/utils.spec.js
@@ -1,4 +1,4 @@
-import {merge, splat, noop, uid} from '../../src/utils';
+import {merge, splat, noop, uid, isPowerOfTwo} from '../../src/utils';
 import test from 'tape-catch';
 
 test('Utils#merge', t => {
@@ -28,5 +28,15 @@ test('Utils#uid', t => {
   t.ok(typeof uid() === 'string', 'Type of uid() is correct');
   t.equal(uid('prefix').indexOf('prefix'), 0,
     'uid("prefix") starts with prefix');
+  t.end();
+});
+
+test('Utils#isPowerOfTwo', t => {
+  t.ok(JSON.stringify(isPowerOfTwo(1)) === JSON.stringify(true));
+  t.ok(JSON.stringify(isPowerOfTwo(2)) === JSON.stringify(true));
+  t.ok(JSON.stringify(isPowerOfTwo(3)) === JSON.stringify(false));
+  t.ok(JSON.stringify(isPowerOfTwo(500)) === JSON.stringify(false));
+  t.ok(JSON.stringify(isPowerOfTwo(512)) === JSON.stringify(true));
+  t.ok(JSON.stringify(isPowerOfTwo(514)) === JSON.stringify(false));
   t.end();
 });

--- a/test/webgl/texture.spec.js
+++ b/test/webgl/texture.spec.js
@@ -222,6 +222,7 @@ test('WebGL#Texture2D NPOT Workaround: texture creation', t => {
   let texture = new Texture2D(gl, {data: null, width: 500, height: 512});
   t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
 
+  // Default parameters should be changed to supported NPOT parameters.
   let minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
   t.equals(minFilter, GL.LINEAR, 'NPOT textuer min filter is set to LINEAR');
   let wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
@@ -244,6 +245,7 @@ test('WebGL#Texture2D NPOT Workaround: texture creation', t => {
   });
   t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
 
+  // Above parameters should be changed to supported NPOT parameters.
   minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
   t.equals(minFilter, GL.NEAREST, 'NPOT textuer min filter is set to NEAREST');
   wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
@@ -268,12 +270,89 @@ test('WebGL#Texture2D NPOT Workaround: setParameters', t => {
   };
   texture.setParameters(invalidNPOTParameters);
 
+  // Above parameters should be changed to supported NPOT parameters.
   const minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
   t.equals(minFilter, GL.LINEAR, 'NPOT textuer min filter is set to LINEAR');
   const wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
   t.equals(wrapS, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_s is set to CLAMP_TO_EDGE');
   const wrapT = texture.getParameter(GL.TEXTURE_WRAP_T);
   t.equals(wrapT, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_t is set to CLAMP_TO_EDGE');
+
+  t.end();
+});
+
+test('WebGL2#Texture2D NPOT Workaround: texture creation', t => {
+  // WebGL2 supports NPOT texture hence, texture parameters should not be changed.
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  // Create NPOT texture with no parameters
+  let texture = new Texture2D(gl2, {data: null, width: 500, height: 512});
+  t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
+
+  // Default values are un-changed.
+  let minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
+  t.equals(minFilter, GL.NEAREST_MIPMAP_LINEAR, 'NPOT textuer min filter is set to NEAREST_MIPMAP_LINEAR');
+  let wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
+  t.equals(wrapS, GL.REPEAT, 'NPOT textuer wrap_s is set to REPEAT');
+  let wrapT = texture.getParameter(GL.TEXTURE_WRAP_T);
+  t.equals(wrapT, GL.REPEAT, 'NPOT textuer wrap_t is set to REPEAT');
+
+  const parameters = {
+    [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
+    [GL.TEXTURE_WRAP_S]: GL.REPEAT,
+    [GL.TEXTURE_WRAP_T]: GL.MIRRORED_REPEAT
+  };
+
+  // Create NPOT texture with parameters
+  texture = new Texture2D(gl2, {
+    data: null,
+    width: 512,
+    height: 600,
+    parameters
+  });
+  t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
+
+  minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
+  t.equals(minFilter, GL.NEAREST, 'NPOT textuer min filter is set to NEAREST');
+  wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
+  t.equals(wrapS, GL.REPEAT, 'NPOT textuer wrap_s is set to REPEAT');
+  wrapT = texture.getParameter(GL.TEXTURE_WRAP_T);
+  t.equals(wrapT, GL.MIRRORED_REPEAT, 'NPOT textuer wrap_t is set to MIRRORED_REPEAT');
+
+  t.end();
+});
+
+test('WebGL2#Texture2D NPOT Workaround: setParameters', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  // Create NPOT texture
+  const texture = new Texture2D(gl2, {data: null, width: 100, height: 100});
+  t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
+
+  const invalidNPOTParameters = {
+    [GL.TEXTURE_MIN_FILTER]: GL.LINEAR_MIPMAP_NEAREST,
+    [GL.TEXTURE_WRAP_S]: GL.MIRRORED_REPEAT,
+    [GL.TEXTURE_WRAP_T]: GL.REPEAT
+  };
+  texture.setParameters(invalidNPOTParameters);
+
+  // Above parameters are not changed for NPOT texture when using WebGL2 context.
+  const minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
+  t.equals(minFilter, GL.LINEAR_MIPMAP_NEAREST, 'NPOT textuer min filter is set to LINEAR_MIPMAP_NEAREST');
+  const wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
+  t.equals(wrapS, GL.MIRRORED_REPEAT, 'NPOT textuer wrap_s is set to MIRRORED_REPEAT');
+  const wrapT = texture.getParameter(GL.TEXTURE_WRAP_T);
+  t.equals(wrapT, GL.REPEAT, 'NPOT textuer wrap_t is set to REPEAT');
 
   t.end();
 });

--- a/test/webgl/texture.spec.js
+++ b/test/webgl/texture.spec.js
@@ -214,3 +214,66 @@ test('WebGL2#Texture2D setParameters', t => {
 
   t.end();
 });
+
+test('WebGL#Texture2D NPOT Workaround: texture creation', t => {
+  const {gl} = fixture;
+
+  // Create NPOT texture with no parameters
+  let texture = new Texture2D(gl, {data: null, width: 500, height: 512});
+  t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
+
+  let minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
+  t.equals(minFilter, GL.LINEAR, 'NPOT textuer min filter is set to LINEAR');
+  let wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
+  t.equals(wrapS, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_s is set to CLAMP_TO_EDGE');
+  let wrapT = texture.getParameter(GL.TEXTURE_WRAP_T);
+  t.equals(wrapT, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_t is set to CLAMP_TO_EDGE');
+
+  const parameters = {
+    [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
+    [GL.TEXTURE_WRAP_S]: GL.REPEAT,
+    [GL.TEXTURE_WRAP_T]: GL.MIRRORED_REPEAT
+  };
+
+  // Create NPOT texture with parameters
+  texture = new Texture2D(gl, {
+    data: null,
+    width: 512,
+    height: 600,
+    parameters
+  });
+  t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
+
+  minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
+  t.equals(minFilter, GL.NEAREST, 'NPOT textuer min filter is set to NEAREST');
+  wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
+  t.equals(wrapS, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_s is set to CLAMP_TO_EDGE');
+  wrapT = texture.getParameter(GL.TEXTURE_WRAP_T);
+  t.equals(wrapT, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_t is set to CLAMP_TO_EDGE');
+
+  t.end();
+});
+
+test('WebGL#Texture2D NPOT Workaround: setParameters', t => {
+  const {gl} = fixture;
+
+  // Create NPOT texture
+  const texture = new Texture2D(gl, {data: null, width: 100, height: 100});
+  t.ok(texture instanceof Texture2D, 'Texture2D construction successful');
+
+  const invalidNPOTParameters = {
+    [GL.TEXTURE_MIN_FILTER]: GL.LINEAR_MIPMAP_NEAREST,
+    [GL.TEXTURE_WRAP_S]: GL.MIRRORED_REPEAT,
+    [GL.TEXTURE_WRAP_T]: GL.REPEAT
+  };
+  texture.setParameters(invalidNPOTParameters);
+
+  const minFilter = texture.getParameter(GL.TEXTURE_MIN_FILTER);
+  t.equals(minFilter, GL.LINEAR, 'NPOT textuer min filter is set to LINEAR');
+  const wrapS = texture.getParameter(GL.TEXTURE_WRAP_S);
+  t.equals(wrapS, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_s is set to CLAMP_TO_EDGE');
+  const wrapT = texture.getParameter(GL.TEXTURE_WRAP_T);
+  t.equals(wrapT, GL.CLAMP_TO_EDGE, 'NPOT textuer wrap_t is set to CLAMP_TO_EDGE');
+
+  t.end();
+});


### PR DESCRIPTION
- Remove NPOT (non power of two) texture workaround from framebuffer object and add it to texure2d object. Make it applicable for only webgl1 context and when texture is NPOT.
- Fix assert failures in few lessons.
- Note: Merge is pending until deck.gl picking is verified.