### PR TITLE
Enable Query object for model draw timing and add unit tests

### DIFF
--- a/docs/api-reference/webgl/query.md
+++ b/docs/api-reference/webgl/query.md
@@ -1,6 +1,6 @@
 # Query
 
-A `Query` object provides a way to measure the duration of a set of GL commands, without stalling the rendering pipeline. Exposes a `promise` member that tracks the state of the query when `poll` is used to update queries.
+A `Query` object provides single unified API for using WebGL asynchronus queries, which include query objects ('Occlusion' and 'Transform Feedback') and timer queries (WebGL1: 'EXT_disjoint_timer_query', WebGL2: 'EXT_disjoint_timer_query_webgl2'). Exposes a `promise` member that tracks the state of the query and `poll` is used to update queries.
 
 
 ## Usage
@@ -42,8 +42,10 @@ Can also check whether timestamp queries are available.
 
 * gl {WebGLRenderingContext} - gl context
 * opts= {Object}  - options
-* opts.requireTimestamps=false {Object}  - If true, checks if timestamps are supported
-return {Boolean} - TimerQueries are supported with specified configuration
+* opts.queries=false {Object}  - If true, checks if Query objects (occlusion/transform feedback) are supported
+* opts.timers=false {Object}  - If true, checks if 'TIME_ELAPSED_EXT' queries are supported
+* opts.timestamps=false {Object}  - If true, checks if 'TIMESTAMP_EXT' queries are supported
+return {Boolean} - Query API is supported with specified configuration
 
 Options
 * queries = false,

--- a/test/webgl/index.js
+++ b/test/webgl/index.js
@@ -24,4 +24,4 @@ import './sampler.spec';
 import './uniform-buffer-layout.spec';
 
 // Extensions / webgl2
-// import './query.spec';
+import './query.spec';

--- a/test/webgl/query.spec.js
+++ b/test/webgl/query.spec.js
@@ -4,10 +4,9 @@ import test from 'tape-catch';
 import {pollContext, Query} from 'luma.gl';
 import util from 'util';
 import {fixture} from '../setup';
+import GL from '../../src/webgl-utils/constants';
 
-test('WebGL#Query construct/delete', t => {
-  const {gl} = fixture;
-
+function testQueryConstructDelete(gl, t) {
   const ext = gl.getExtension('EXT_disjoint_timer_query');
   t.comment(`EXT_disjoint_timer_query is ${Boolean(ext)} ${ext}`, ext);
   util.inspect(ext, {showHidden: true});
@@ -38,11 +37,25 @@ test('WebGL#Query construct/delete', t => {
   t.ok(timerQuery instanceof Query, 'Query repeated delete successful');
 
   t.end();
-});
+}
 
-test('WebGL#Query begin/cancel', t => {
+test('WebGL#Query construct/delete', t => {
   const {gl} = fixture;
 
+  testQueryConstructDelete(gl, t);
+});
+
+test('WebGL2#Query construct/delete', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  testQueryConstructDelete(gl2, t);
+});
+
+function testQueryBeginCancel(gl, t) {
   // Cancelled query
 
   const timerQuery = new Query(gl, {
@@ -67,11 +80,24 @@ test('WebGL#Query begin/cancel', t => {
     t.pass(`Query promise reset by cancel or not implemented ${error}`);
     t.end();
   });
+}
+
+test('WebGL#Query begin/cancel', t => {
+  const {gl} = fixture;
+  testQueryBeginCancel(gl, t);
 });
 
-test('WebGL#Query completed/failed queries', t => {
-  const {gl} = fixture;
+test('WebGL2#Query begin/cancel', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  testQueryBeginCancel(gl2, t);
+});
 
+function testQueryCompleteFail(gl, t) {
   // Completed query
   const timerQuery = Query.isSupported(gl) ?
     new Query(gl, {
@@ -87,8 +113,142 @@ test('WebGL#Query completed/failed queries', t => {
 
   function finalizer() {
     clearInterval(interval);
-    t.end();
   }
 
   return timerQuery.promise.then(finalizer, finalizer);
+}
+
+test('WebGL#Query completed/failed queries', t => {
+  const {gl} = fixture;
+  testQueryCompleteFail(gl, t);
+  t.end();
+});
+
+test('WebGL2#Query completed/failed queries', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  testQueryCompleteFail(gl2, t);
+  t.end();
+});
+
+function testQuery(gl, opts, target, t) {
+  if (!Query.isSupported(gl, opts)) {
+    t.comment('Query API not supported, skipping tests');
+    return null;
+  }
+  const query = new Query(gl, {
+    onComplete: result => t.pass(`Timer query: ${result}ms`),
+    onError: error => t.fail(`Timer query: ${error}`)
+  });
+
+  query.begin(target).end();
+  t.ok(query.promise instanceof Promise, 'Query begin/end successful');
+
+  const interval = setInterval(() => pollContext(gl), 20);
+  function finalizer() {
+    clearInterval(interval);
+  }
+
+  return query.promise.then(finalizer, finalizer);
+}
+
+test('WebGL#TimeElapsedQuery', t => {
+  const {gl} = fixture;
+  const opts = {timer: true};
+  testQuery(gl, opts, GL.TIME_ELAPSED_EXT, t);
+  t.end();
+});
+
+test('WebGL2#TimeElapsedQuery', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  const opts = {timer: true};
+  testQuery(gl2, opts, GL.TIME_ELAPSED_EXT, t);
+  t.end();
+});
+
+test('WebGL#OcclusionQuery', t => {
+  const {gl} = fixture;
+  const opts = {queries: true};
+  testQuery(gl, opts, GL.ANY_SAMPLES_PASSED_CONSERVATIVE, t);
+  t.end();
+});
+
+test('WebGL2#OcclusionQuery', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  const opts = {queries: true};
+  testQuery(gl2, opts, GL.ANY_SAMPLES_PASSED_CONSERVATIVE, t);
+  t.end();
+});
+
+test('WebGL#TransformFeedbackQuery', t => {
+  const {gl} = fixture;
+  const opts = {queries: true};
+  testQuery(gl, opts, GL.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, t);
+  t.end();
+});
+
+test('WebGL2#TransformFeedbackQuery', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  const opts = {queries: true};
+  testQuery(gl2, opts, GL.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, t);
+  t.end();
+});
+
+function testGetTimestamp(gl, t) {
+  if (!Query.isSupported(gl, {timestamps: true})) {
+    t.comment('TIMESTAMP_EXT Query not supported, skipping tests');
+    return null;
+  }
+  const query = new Query(gl, {
+    onComplete: result => t.pass(`timestamp: ${result}`),
+    onError: error => t.fail(`timestamp: ${error}`)
+  });
+
+  query.getTimestamp().end();
+  t.ok(query.promise instanceof Promise, 'Query getTimestamp/end successful');
+
+  const interval = setInterval(() => pollContext(gl), 20);
+  function finalizer() {
+    clearInterval(interval);
+  }
+
+  return query.promise.then(finalizer, finalizer);
+}
+
+test('WebGL#getTimestamp', t => {
+  const {gl} = fixture;
+
+  testGetTimestamp(gl, t);
+  t.end();
+});
+
+test('WebGL2#getTimestamp', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  testGetTimestamp(gl2, t);
+  t.end();
 });


### PR DESCRIPTION
- Replace raw gl timer queries with Query object.
- Add more unit tests for Query class.