### PR TITLE
Fix the WebGL context creation issue on Safari

### DIFF
--- a/src/webgl-utils/create-context.js
+++ b/src/webgl-utils/create-context.js
@@ -29,7 +29,7 @@ export function createContext({
     gl = gl || canvas.getContext('experimental-webgl', opts);
   }
 
-  canvas.removeEventListener(onContextCreationError, false);
+  canvas.removeEventListener('webglcontextcreationerror', onContextCreationError, false);
 
   if (!gl) {
     return onError(`Failed to create ${webgl2 && !webgl1 ? 'WebGL2' : 'WebGL'} context`);


### PR DESCRIPTION
This seems to be the issue why our deck.gl example doesn't run on Safari. WebGL context creation is all good but the deregistration of event handler seems to contain a typo. @Pessimistress 