### PR TITLE
Picking shader module: Handle invalid/null picking color

### DIFF
--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -50,7 +50,12 @@ const animationLoop = new AnimationLoop({
       uModel: new Matrix4().rotateX(tick * 0.01).rotateY(tick * 0.013)
     });
 
-    const pickInfo = pickModels(gl, {models: [cube], position: pickPosition, framebuffer});
+    const pickInfo = pickPosition && pickModels(gl, {
+      models: [cube],
+      position: pickPosition,
+      framebuffer
+    });
+
     cube.updateModuleSettings({
       pickingSelectedColor: pickInfo && pickInfo.color,
       pickingValid: pickInfo !== null

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -8,6 +8,9 @@ let pickPosition = [0, 0];
 function mousemove(e) {
   pickPosition = [e.offsetX, e.offsetY];
 }
+function mouseleave(e) {
+  pickPosition = null;
+}
 
 const animationLoop = new AnimationLoop({
   onInitialize({gl}) {
@@ -19,6 +22,7 @@ const animationLoop = new AnimationLoop({
     });
 
     gl.canvas.addEventListener('mousemove', mousemove);
+    gl.canvas.addEventListener('mouseleave', mouseleave);
 
     return {
       cube: makeInstancedCube(gl)
@@ -47,21 +51,13 @@ const animationLoop = new AnimationLoop({
     });
 
     const pickInfo = pickModels(gl, {models: [cube], position: pickPosition, framebuffer});
-    // console.log(pickInfo ? pickInfo.color : 'picked background');
     cube.updateModuleSettings({
-      pickingSelectedColor: pickInfo && pickInfo.color
+      pickingSelectedColor: pickInfo && pickInfo.color,
+      pickingValid: pickInfo !== null
     });
 
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
     cube.render();
-  },
-  onMouseMove({gl, tick, cube, framebuffer}) {
-    // TODO - activate this path
-    const pickInfo = pickModels(gl, {models: [cube], position: pickPosition, framebuffer});
-    console.log(pickInfo ? pickInfo.color : 'picked background');
-    cube.setUniforms(picking.getUniforms({
-      pickingSelectedColor: pickInfo && pickInfo.color
-    }));
   }
 });
 

--- a/examples/core/picking/app.js
+++ b/examples/core/picking/app.js
@@ -31,6 +31,10 @@ const animationLoop = new AnimationLoop({
       pickPosition = [e.offsetX, e.offsetY];
     });
 
+    canvas.addEventListener('mouseleave', function mouseleave(e) {
+      pickPosition = null;
+    });
+
     return loadTextures(gl, {
       urls: PLANETS.map(planet => planet.textureUrl),
       mipmaps: true,

--- a/examples/core/picking/app.js
+++ b/examples/core/picking/app.js
@@ -87,7 +87,7 @@ const animationLoop = new AnimationLoop({
       planet.render();
     }
 
-    const pickedModel = pickModels(gl, {
+    const pickedModel = pickPosition && pickModels(gl, {
       models: planets,
       position: pickPosition,
       framebuffer

--- a/src/core/pick-models.js
+++ b/src/core/pick-models.js
@@ -11,7 +11,7 @@ function getDevicePixelRatio() {
 
 export default function pickModels(gl, {
   models,
-  position,
+  position = null,
   uniforms = {}, // eslint-disable-line
   parameters = {},
   settings,
@@ -20,6 +20,10 @@ export default function pickModels(gl, {
 }) {
   assert(isWebGL(gl), ILLEGAL_ARG);
   assert(framebuffer, ILLEGAL_ARG);
+
+  if (position === null) {
+    return null;
+  }
 
   const [x, y] = position;
 

--- a/src/core/pick-models.js
+++ b/src/core/pick-models.js
@@ -11,7 +11,7 @@ function getDevicePixelRatio() {
 
 export default function pickModels(gl, {
   models,
-  position = null,
+  position,
   uniforms = {}, // eslint-disable-line
   parameters = {},
   settings,
@@ -20,10 +20,7 @@ export default function pickModels(gl, {
 }) {
   assert(isWebGL(gl), ILLEGAL_ARG);
   assert(framebuffer, ILLEGAL_ARG);
-
-  if (position === null) {
-    return null;
-  }
+  assert(position, ILLEGAL_ARG);
 
   const [x, y] = position;
 

--- a/src/shadertools/modules/picking/picking.js
+++ b/src/shadertools/modules/picking/picking.js
@@ -3,18 +3,18 @@ const DEFAULT_HIGHLIGHT_COLOR = new Uint8Array([0, 64, 128, 64]);
 const DEFAULT_MODULE_OPTIONS = {
   pickingSelectedColor: null, //  Set to a picking color to visually highlight that item
   pickingHighlightColor: DEFAULT_HIGHLIGHT_COLOR, // Color of visual highlight of "selected" item
-  pickingNullColor: [-1, 0, 0],
   pickingThreshold: 1.0,
-  pickingActive: false // Set to true when rendering to off-screen "picking" buffer
+  pickingActive: false, // Set to true when rendering to off-screen "picking" buffer
+  pickingValid: false
 };
 
 /* eslint-disable camelcase */
 function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
   const uniforms = {};
+  uniforms.picking_uValid = opts.pickingValid ? 1 : 0;
   if (opts.pickingSelectedColor !== undefined) {
-    let selectedColor = opts.pickingNullColor || DEFAULT_MODULE_OPTIONS.pickingNullColor;
     if (opts.pickingSelectedColor) {
-      selectedColor = [
+      const selectedColor = [
         opts.pickingSelectedColor[0],
         opts.pickingSelectedColor[1],
         opts.pickingSelectedColor[2]
@@ -39,22 +39,24 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
 const vs = `\
 uniform vec3 picking_uSelectedPickingColor;
 uniform float picking_uThreshold;
+uniform bool picking_uValid;
 
 varying vec4 picking_vRGBcolor_Aselected;
 
 const float COLOR_SCALE = 1. / 256.;
 
-bool equalColors(vec3 color1, vec3 color2) {
+bool isVertexPicked(vec3 vertexColor, vec3 pickedColor, bool pickingValid) {
   return
-    abs(color1.r - color2.r) < picking_uThreshold &&
-    abs(color1.g - color2.g) < picking_uThreshold &&
-    abs(color1.b - color2.b) < picking_uThreshold;
+    pickingValid &&
+    abs(vertexColor.r - pickedColor.r) < picking_uThreshold &&
+    abs(vertexColor.g - pickedColor.g) < picking_uThreshold &&
+    abs(vertexColor.b - pickedColor.b) < picking_uThreshold;
 }
 
 void picking_setPickingColor(vec3 pickingColor) {
   // Do the comparison with selected item color in vertex shader as it should mean fewer compares
   picking_vRGBcolor_Aselected.a =
-    float(equalColors(pickingColor, picking_uSelectedPickingColor));
+    float(isVertexPicked(pickingColor, picking_uSelectedPickingColor, picking_uValid));
 
   // Stores the picking color so that the fragment shader can render it during picking
   picking_vRGBcolor_Aselected.rgb = pickingColor * COLOR_SCALE;


### PR DESCRIPTION
- Instead of overloading `pickingSelectedColor` with a unique null color value (`pickingNullColor`), use a boolean enum, `pickingValid`. This way it is more clear and within the shader we only do boolean check instead of vec3 compare.
- Do not highlight models when `pickingValid` is false.
- Update picking/instancing apps to listen to `mouseleave` events and set pickPosition to null.
- Tested with picking/instancing core examples.
@shaojingli we need this to be ported to release branch.