### PR TITLE
Use shaderCache to avoid re-compilaiton of same shader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 ## 4.1.0-alpha.1
 - Add SphericalCoordinates and export Euler (#295)
 
+## 4.0.1
+
+- Wire up ShaderCache in Model class to avoid re-compilaiton of same shader (#301)
+
 ## 4.0.0-beta.6
 - Call assembleShaders always (#270)
 - Remove invalid assert on GL.POINTS (#268)

--- a/docs/api-reference/core/model.md
+++ b/docs/api-reference/core/model.md
@@ -74,6 +74,7 @@ The constructor for the Model class. Use this to create a new Model.
   * `modules` - shader modules to be applied.
   * `moduleSettings` - any uniforms needed by shader modules.
   * `program` - pre created program to use, when provided, vs, ps and modules are not used.
+  * `shaderCache` - (ShaderCache) - Compiled shader (Vertex and Fragment) are cached in this object very first time they got compiled and then retrieved when same shader is used. When using multiple Model objects with duplicate shaders, use the same shaderCache object for better performance.
   * `isInstanced` - default value is false.
   * `instanceCount` - default value is 0.
   * `vertexCount` - when not provided will be deduced from `geometry` object.

--- a/examples/core/cubemap/webpack.config.js
+++ b/examples/core/cubemap/webpack.config.js
@@ -10,4 +10,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/core/fragment/webpack.config.js
+++ b/examples/core/fragment/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/core/instancing/webpack.config.js
+++ b/examples/core/instancing/webpack.config.js
@@ -7,4 +7,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/core/mandelbrot/webpack.config.js
+++ b/examples/core/mandelbrot/webpack.config.js
@@ -7,4 +7,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/core/picking/app.js
+++ b/examples/core/picking/app.js
@@ -1,6 +1,6 @@
 import {
   GL, AnimationLoop, setParameters, loadTextures, Buffer, Matrix4, radians,
-  Sphere, project, diffuse, picking, pickModels
+  Sphere, project, diffuse, picking, pickModels, ShaderCache
 } from 'luma.gl';
 
 const PLANETS = [
@@ -19,6 +19,8 @@ const animationLoop = new AnimationLoop({
   onInitialize: ({gl, canvas}) => {
     // Use non zero pickingColor to identify if the model has been picked or not.
     const pickingColorsData = new Float32Array(10000).fill(1.0);
+
+    const shaderCache = new ShaderCache({gl});
 
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
@@ -58,7 +60,8 @@ const animationLoop = new AnimationLoop({
         moduleSettings: {
           diffuseTexture: textures[i],
           pickingThreshold: 0
-        }
+        },
+        shaderCache
       })
       .setPosition([
         Math.cos(i / PLANETS.length * Math.PI * 2) * 3,

--- a/examples/core/picking/webpack.config.js
+++ b/examples/core/picking/webpack.config.js
@@ -7,4 +7,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/core/shadowmap/webpack.config.js
+++ b/examples/core/shadowmap/webpack.config.js
@@ -7,4 +7,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/core/transform-feedback/webpack.config.js
+++ b/examples/core/transform-feedback/webpack.config.js
@@ -8,4 +8,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/01/webpack.config.js
+++ b/examples/lessons/01/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/02/webpack.config.js
+++ b/examples/lessons/02/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/03/webpack.config.js
+++ b/examples/lessons/03/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/04/webpack.config.js
+++ b/examples/lessons/04/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/05/webpack.config.js
+++ b/examples/lessons/05/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/06/webpack.config.js
+++ b/examples/lessons/06/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/07/webpack.config.js
+++ b/examples/lessons/07/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/08/webpack.config.js
+++ b/examples/lessons/08/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/09/webpack.config.js
+++ b/examples/lessons/09/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;

--- a/examples/lessons/16/webpack.config.js
+++ b/examples/lessons/16/webpack.config.js
@@ -9,4 +9,4 @@ const CONFIG = {
 };
 
 // This line enables bundling against src in this repo rather than installed module
-module.exports = env => env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG;
+module.exports = env => env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG;


### PR DESCRIPTION
Verified using examples, lessons and test-browser.
Update picking example to verify cache hit.
Update webpack.config files of examples, so `npm run start-local` works.
Fixes #299 