### PR TITLE
Keep version directive at the beginning of the shader during assembly.

### DIFF
--- a/docs/api-reference/shadertools/README.md
+++ b/docs/api-reference/shadertools/README.md
@@ -102,6 +102,7 @@ Remarks:
 * Will inject platform prologue, with defines identifying GPU driver to enable bug workarounds
 * Will inject a GLSL feature detection prologue, simplifying writing code that works with GLSL extensions and across GLSL versions (WebGL1 and WebGL2)
 * Will follow module dependencies and inject dependency tree in correct order
+* Version directive (like `#version 300 es`) must be the very first line in `vs` and `fs` shader if it exists, `assembleShaders` will make sure it is still the very first line in resolved shader.
 
 
 ### `registerShaderModules`

--- a/src/shadertools/lib/assemble-shaders.js
+++ b/src/shadertools/lib/assemble-shaders.js
@@ -116,7 +116,18 @@ ${type === FRAGMENT_SHADER ? FRAGMENT_SHADER_PROLOGUE : ''}
   }
 
   // Add the actual source of this shader
-  assembledSource += source;
+  if (source.indexOf('#version ') === 0) {
+    // Keep any version directive at the begining of the shader
+    // TODO : keep all pre-processor statements at the begining of the shader.
+    const lines = source.split('\n');
+    const assembledLines = [
+      lines[0],
+      assembledSource
+    ].concat(lines.slice(1));
+    assembledSource = assembledLines.join('\n');
+  } else {
+    assembledSource += source;
+  }
 
   // Finally, if requested, insert an automatic module injector chunk
   if (inject) {

--- a/src/shadertools/lib/assemble-shaders.js
+++ b/src/shadertools/lib/assemble-shaders.js
@@ -91,6 +91,16 @@ function assembleShader(gl, {
 }) {
   assert(typeof source === 'string', 'shader source must be a string');
 
+  const sourceLines = source.split('\n');
+  let versionLine = '';
+  let coreSource = source;
+  // Extract any version directive string from source.
+  // TODO : keep all pre-processor statements at the begining of the shader.
+  if (sourceLines[0].indexOf('#version ') === 0) {
+    versionLine = sourceLines[0];
+    coreSource = sourceLines.slice(1).join('\n');
+  }
+
   // Add platform defines (use these to work around platform-specific bugs and limitations)
   // Add common defines (GLSL version compatibility, feature detection)
   // Add precision declaration for fragment shaders
@@ -115,19 +125,8 @@ ${type === FRAGMENT_SHADER ? FRAGMENT_SHADER_PROLOGUE : ''}
     }
   }
 
-  // Add the actual source of this shader
-  if (source.indexOf('#version ') === 0) {
-    // Keep any version directive at the begining of the shader
-    // TODO : keep all pre-processor statements at the begining of the shader.
-    const lines = source.split('\n');
-    const assembledLines = [
-      lines[0],
-      assembledSource
-    ].concat(lines.slice(1));
-    assembledSource = assembledLines.join('\n');
-  } else {
-    assembledSource += source;
-  }
+  // Add the version directive and actual source of this shader
+  assembledSource = versionLine + assembledSource + coreSource;
 
   // Finally, if requested, insert an automatic module injector chunk
   if (inject) {

--- a/test/shadertools/lib/assemble-shaders.spec.js
+++ b/test/shadertools/lib/assemble-shaders.spec.js
@@ -1,0 +1,46 @@
+import 'luma.gl/headless';
+import {createGLContext, assembleShaders, picking} from 'luma.gl';
+import test from 'tape-catch';
+
+const fixture = {
+  gl: createGLContext()
+};
+const VS_GLSL_300 = `\
+#version 300 es
+
+in vec4 positions;
+
+void main(void) {
+  gl_Position = positions;
+}
+`;
+const FS_GLSL_300 = `\
+#version 300 es
+
+#ifdef GL_ES
+precision highp float;
+#endif
+
+out vec4 fragmentColor;
+
+void main(void) {
+  fragmentColor = vec4(1.0, 1.0, 1.0, 1.0);
+}
+`;
+
+test('assembleShaders#import', t => {
+  t.ok(assembleShaders !== undefined, 'assembleShaders import successful');
+  t.end();
+});
+
+test('assembleShaders#version_directive', t => {
+  const assembleResult = assembleShaders(fixture.gl, {
+    vs: VS_GLSL_300,
+    fs: FS_GLSL_300,
+    modules: [picking]
+  });
+  // Verify version directive remains as first line.
+  t.equal(assembleResult.vs.indexOf('#version 300 es'), 0, 'version directive should be first statement');
+  t.equal(assembleResult.fs.indexOf('#version 300 es'), 0, 'version directive should be first statement');
+  t.end();
+});

--- a/test/shadertools/lib/index.js
+++ b/test/shadertools/lib/index.js
@@ -1,2 +1,3 @@
+import './assemble-shaders.spec.js';
 import './shader-cache.spec';
 import './shader-modules.spec';


### PR DESCRIPTION
Fixes #304
Tested with test-browser and lesson04 update to use GLSL 3.0 shaders.