### PR TITLE
Add "math.gl" dependency for website

### DIFF
--- a/examples/lessons/10/app.js
+++ b/examples/lessons/10/app.js
@@ -3,9 +3,7 @@ import {
   resetParameters, setParameters
 } from 'luma.gl';
 
-import {
-  Matrix4
-} from 'math.gl';
+import { Matrix4 } from 'math.gl';
 
 import {loadWorldGeometry, World} from './world';
 

--- a/examples/lessons/10/app.js
+++ b/examples/lessons/10/app.js
@@ -5,7 +5,7 @@ import {
 
 import {
   Matrix4
-} from 'math.gl'
+} from 'math.gl';
 
 import {loadWorldGeometry, World} from './world';
 

--- a/examples/lessons/11/app.js
+++ b/examples/lessons/11/app.js
@@ -2,9 +2,7 @@ import {
   GL, AnimationLoop, loadTextures, addEvents, Vector3, setParameters, Sphere
 } from 'luma.gl';
 
-import {
-  Matrix4
-} from 'math.gl';
+import { Matrix4 } from 'math.gl';
 
 const VERTEX_SHADER = `\
 attribute vec3 positions;

--- a/examples/lessons/11/app.js
+++ b/examples/lessons/11/app.js
@@ -4,7 +4,7 @@ import {
 
 import {
   Matrix4
-} from 'math.gl'
+} from 'math.gl';
 
 const VERTEX_SHADER = `\
 attribute vec3 positions;

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "immutable": "^3.7.5",
     "luma.gl": ">=4.0.0-beta.6",
     "marked": "^0.3.6",
+    "math.gl": ">=1.0.0-alpha.7",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-map-gl": ">=3.0.0-beta.1",

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -47,6 +47,7 @@ const COMMON_CONFIG = {
   resolve: {
     alias: {
       'luma.gl': libSources,
+      // TODO: need better way to expose math.gl to examples instead of this line
       'math.gl': join(__dirname, 'node_modules/math.gl')
     }
   },

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -46,7 +46,8 @@ const COMMON_CONFIG = {
 
   resolve: {
     alias: {
-      'luma.gl': libSources
+      'luma.gl': libSources,
+      'math.gl': join(__dirname, 'node_modules/math.gl')
     }
   },
 


### PR DESCRIPTION
After cleaning up all the dependencies under examples/lessons/10/node-modules, found the website testing failed for lesson10 because of missing "math.gl", figured out we need add "math.gl" dependency for website project.