### PR TITLE
Fix buffer.getData default parameters and target setting.

### DIFF
--- a/docs/api-reference/webgl/buffer.md
+++ b/docs/api-reference/webgl/buffer.md
@@ -14,7 +14,7 @@ For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wik
 | `delete` | Destroys buffer |
 | `subData` | Updates a subset of a buffer object's data store. |
 | `copyData` (WebGL2) | Copies part of the data of another buffer into this buffer |
-| `getData` (WebGL2) | Reads data from buffer (GPU) into an ArrayBuffer or SharedArrayBuffer. When no destination ArrayBufferView is provided, it optimally allocates enough memory to copy all eligible data.|
+| `getData` (WebGL2) | Reads data from buffer (GPU) into an `ArrayBufferView` or `SharedArrayBuffer`.|
 
 
 ## Usage
@@ -57,14 +57,38 @@ buffer.subData({})
 
 Copying data between buffers (WebGL2)
 ```js
-const buffer = new Buffer(gl, {bytes: 200})
-buffer.subData({offset: 20, data: new Float32Array([1, 2, 3])});
+const sourceBuffer = ...
+const destinationBuffer = ...
+
+// To copy 32 bytes from sourceBuffer to destinationBuffer
+destinationBuffer.copyData({sourceBuffer, size: 32});
+
+// To copy 32 bytes from sourceBuffer at 8 byte offset into
+// destinationBuffer at 16 byte offset.
+destinationBuffer.copyData({sourceBuffer,
+  readOffset: 8,
+  writeOffset: 16,
+  size: 32});
 ```
 
 Getting data from a buffer (WebGL2)
 ```js
 const buffer = ...;
-const data = buffer.getData({srcByteOffset: 32, length: 5});
+
+// To get all the data from buffer
+const data = buffer.getData();
+
+// To get all the data from buffer starting from byteOffset 8
+// into existing ArrayBufferView.
+const existingArray = ...
+const data = buffer.getData({dstData: existingArray, srcByteOffset: 8});
+// Maximum possible elements will be copied based buffer and dstData size.
+
+// To get 5 elements from source buffer starting from byteOffset 8
+// into existing ArrayBufferView starting from 3rd element position.
+const existingArray = ...
+const data = buffer.getData({dstData: existingArray, srcByteOffset: 8, dstOffset: 3, length: 5});
+
 ```
 
 Binding and unbinding a buffer
@@ -180,14 +204,14 @@ Note:
 
 ### getData (WEBGL2)
 
-Reads data from buffer into an `ArrayBuffer` or `SharedArrayBuffer`.
+Reads data from buffer into an `ArrayBufferView` or `SharedArrayBuffer`.
 
 `Buffer.getData({dstData, srcByteOffset, srcOffset, length})`
 
-* `dstData`=`null` (`ArrayBufferView` | `ArrayBuffer` | `SharedArrayBuffer` | `null`)  - memory to which to write the buffer data.
+* `dstData`=`null` (`ArrayBufferView` | `SharedArrayBuffer` | `null`)  - memory to which to write the buffer data. New ArrayBufferView allocated with correct type if not provided.
 * `srcByteOffset`=`0` (GLintptr) - byte offset from which to start reading from the buffer.
 * `srcOffset`=`0` (GLuint) - element index offset where to start reading the buffer.
-* `length`=`0` (GLuint)  Optional, defaulting to 0.
+* `length`=`0` (GLuint)  Optional, Element count to be copied, optimal value calculated when not provided.
 
 Returns a typed array containing the data from the buffer (if `dstData` was supplied it will be returned, otherwise this will be a freshly allocated array).
 

--- a/docs/api-reference/webgl/buffer.md
+++ b/docs/api-reference/webgl/buffer.md
@@ -13,8 +13,8 @@ For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wik
 | `initialize` | Allocates and optionally initializes the buffer object's data store on GPU. |
 | `delete` | Destroys buffer |
 | `subData` | Updates a subset of a buffer object's data store. |
-| `copySubData` (WebGL2) | Copies part of the data of another buffer into this buffer |
-| `getSubData` (WebGL2) | Reads data from buffer (GPU) into an ArrayBuffer or SharedArrayBuffer. |
+| `copyData` (WebGL2) | Copies part of the data of another buffer into this buffer |
+| `getData` (WebGL2) | Reads data from buffer (GPU) into an ArrayBuffer or SharedArrayBuffer. When no destination ArrayBufferView is provided, it optimally allocates enough memory to copy all eligible data.|
 
 
 ## Usage
@@ -64,7 +64,7 @@ buffer.subData({offset: 20, data: new Float32Array([1, 2, 3])});
 Getting data from a buffer (WebGL2)
 ```js
 const buffer = ...;
-const data = buffer.getSubData({offset: 20, size: 10});
+const data = buffer.getData({srcByteOffset: 32, length: 5});
 ```
 
 Binding and unbinding a buffer

--- a/test/webgl/buffer.spec.js
+++ b/test/webgl/buffer.spec.js
@@ -98,6 +98,39 @@ test('WebGL#Buffer setData/subData', t => {
   t.end();
 });
 
+test('WebGL#Buffer copyData', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  const sourceData = new Float32Array([1, 2, 3]);
+  const sourceBuffer = new Buffer(gl2, {data: sourceData});
+  const destinationData = new Float32Array([4, 5, 6]);
+  const destinationBuffer = new Buffer(gl2, {data: destinationData});
+
+  let receivedData = destinationBuffer.getData();
+  let expectedData = new Float32Array([4, 5, 6]);
+  t.deepEqual(receivedData, expectedData, 'Buffer.getData: default parameters successful');
+
+  destinationBuffer.copyData({sourceBuffer, size: 2 * Float32Array.BYTES_PER_ELEMENT});
+  receivedData = destinationBuffer.getData();
+  expectedData = new Float32Array([1, 2, 6]);
+  t.deepEqual(receivedData, expectedData, 'Buffer.copyData: with size successful');
+
+  destinationBuffer.copyData({sourceBuffer,
+    readOffset: Float32Array.BYTES_PER_ELEMENT,
+    writeOffset: 2 * Float32Array.BYTES_PER_ELEMENT,
+    size: Float32Array.BYTES_PER_ELEMENT});
+  receivedData = destinationBuffer.getData();
+  expectedData = new Float32Array([1, 2, 2]);
+  t.deepEqual(receivedData, expectedData, 'Buffer.copyData: with size and offsets successful');
+
+  t.end();
+});
+
 test('WebGL#Buffer getData', t => {
   const {gl2} = fixture;
   if (!gl2) {
@@ -109,7 +142,7 @@ test('WebGL#Buffer getData', t => {
   let data = new Float32Array([1, 2, 3]);
   let buffer = new Buffer(gl2, {data});
 
-  let receivedData = buffer.getData({});
+  let receivedData = buffer.getData();
   let expectedData = new Float32Array([1, 2, 3]);
   t.deepEqual(data, receivedData, 'Buffer.getData: default parameters successful');
 
@@ -140,7 +173,8 @@ test('WebGL#Buffer getData', t => {
   data = new Uint8Array([128, 255, 1]);
   buffer = new Buffer(gl2, {data});
 
-  receivedData = buffer.getData({});
+  receivedData = buffer.getData();
   t.deepEqual(data, data, 'Buffer.getData: Uint8Array + default parameters successful');
 
+  t.end();
 });

--- a/test/webgl/buffer.spec.js
+++ b/test/webgl/buffer.spec.js
@@ -97,3 +97,50 @@ test('WebGL#Buffer setData/subData', t => {
 
   t.end();
 });
+
+test('WebGL#Buffer getData', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  let data = new Float32Array([1, 2, 3]);
+  let buffer = new Buffer(gl2, {data});
+
+  let receivedData = buffer.getData({});
+  let expectedData = new Float32Array([1, 2, 3]);
+  t.deepEqual(data, receivedData, 'Buffer.getData: default parameters successful');
+
+  receivedData = buffer.getData({
+    dstData: new Float32Array(2),
+    srcByteOffset: Float32Array.BYTES_PER_ELEMENT
+  });
+  expectedData = new Float32Array([2, 3]);
+  t.deepEqual(expectedData, receivedData, 'Buffer.getData: with \'dstData\' parameter successful');
+
+  receivedData = buffer.getData({
+    srcByteOffset: Float32Array.BYTES_PER_ELEMENT,
+    dstOffset: 2
+  });
+  expectedData = new Float32Array([0, 0, 2, 3]);
+  t.deepEqual(expectedData, receivedData, 'Buffer.getData: with src/dst offsets successful');
+
+  // NOTE: when source and dst offsets are specified, 'length' needs to be set so that
+  // source buffer access is not outof bounds, otherwise 'getBufferSubData' will throw exception.
+  receivedData = buffer.getData({
+    srcByteOffset: Float32Array.BYTES_PER_ELEMENT * 2,
+    dstOffset: 1,
+    length: 1
+  });
+  expectedData = new Float32Array([0, 3]);
+  t.deepEqual(expectedData, receivedData, 'Buffer.getData: with src/dst offsets and length successful');
+
+  data = new Uint8Array([128, 255, 1]);
+  buffer = new Buffer(gl2, {data});
+
+  receivedData = buffer.getData({});
+  t.deepEqual(data, data, 'Buffer.getData: Uint8Array + default parameters successful');
+
+});


### PR DESCRIPTION
Fix for #314
- Optimize ArrayBufferView allocation when it is not provided.
- Add additional asserts to fire on invalid combination of parameters to `getBufferSubData` (WebGL documentation is very confusing, this should help our users.)
- Update docs for `copyData` and `getData` with simple use cases.
- Add unit tests.