### PR TITLE
Framebuffer fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,8 @@ export {
   getParameters,
   setParameter,
   setParameters,
-  withParameters} from './webgl/context-state';
+  withParameters,
+  getModifiedParameters} from './webgl/context-state';
 export {
   getContextInfo,
   getGLContextInfo,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,4 +2,5 @@ export * from './is-browser';
 export * from './promise-utils';
 export * from './utils';
 export * from './log';
+export * from './typed-array-utils';
 export {default as log} from './log';

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
-/* global console */
+/* global console, window, Image */
+
+console.image = require('console-image');
+
 const cache = {};
 
 const log = {
@@ -34,8 +37,30 @@ const log = {
   error(priority, arg, ...args) {
     console.error(`luma.gl: ${arg}`, ...args);
   },
+  image({priority, image, message = '', scale = 1}) {
+    if (priority > log.priority) {
+      return;
+    }
+    if (typeof window === 'undefined') { // Let's not try this under node
+      return;
+    }
+    if (typeof image === 'string') {
+      const img = new Image();
+      img.onload = logImage.bind(null, img, message, scale);
+      img.src = image;
+    }
+    const element = image.nodeName || '';
+    if (element.toLowerCase() === 'img') {
+      logImage(image, message, scale);
+    }
+    if (element.toLowerCase() === 'canvas') {
+      const img = new Image();
+      img.onload = logImage.bind(null, img, message, scale);
+      img.src = image.toDataURL();
+    }
+  },
   deprecated(oldUsage, newUsage) {
-    log.warn(0, `luma.gl: \`${oldUsage}\` is deprecated and will be removed \
+    log.warn(`luma.gl: \`${oldUsage}\` is deprecated and will be removed \
 in a later version. Use \`${newUsage}\` instead`);
   },
   group(priority, arg, {collapsed = false} = {}) {
@@ -53,6 +78,22 @@ in a later version. Use \`${newUsage}\` instead`);
     }
   }
 };
+
+// Inspired by https://github.com/hughsk/console-image (MIT license)
+function logImage(image, message, scale) {
+  const width = image.width * scale;
+  const height = image.height * scale;
+  const imageUrl = image.src.replace(/\(/g, '%28').replace(/\)/g, '%29');
+
+  console.log(`${message} %c+`, [
+    'font-size:1px;',
+    `padding:${Math.floor(height / 2)}px ${Math.floor(width / 2)}px;`,
+    `line-height:${height}px;`,
+    `background:url(${imageUrl});`,
+    `background-size:${width}px ${height}px;`,
+    'color:transparent;'
+  ].join(''));
+}
 
 function formatArrayValue(v, opts) {
   const {maxElts = 16, size = 1} = opts;

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,8 +1,6 @@
 /* eslint-disable no-console */
 /* global console, window, Image */
 
-console.image = require('console-image');
-
 const cache = {};
 
 const log = {

--- a/src/utils/typed-array-utils.js
+++ b/src/utils/typed-array-utils.js
@@ -60,3 +60,37 @@ export function getTypedArrayFromGLType(glType, {clamped = true} = {}) {
   }
 }
 /* eslint-enable complexity */
+
+// Flip rows (can be used on arrays returned from `Framebuffer.readPixels`)
+// https://stackoverflow.com/questions/41969562/
+// how-can-i-flip-the-result-of-webglrenderingcontext-readpixels
+export function flipRows({data, width, height, bytesPerPixel = 4, temp}) {
+  const bytesPerRow = width * bytesPerPixel;
+
+  // make a temp buffer to hold one row
+  temp = temp || new Uint8Array(bytesPerRow);
+  for (let y = 0; y < height / 2; ++y) {
+    const topOffset = y * bytesPerRow;
+    const bottomOffset = (height - y - 1) * bytesPerRow;
+    // make copy of a row on the top half
+    temp.set(data.subarray(topOffset, topOffset + bytesPerRow));
+    // copy a row from the bottom half to the top
+    data.copyWithin(topOffset, bottomOffset, bottomOffset + bytesPerRow);
+    // copy the copy of the top half row to the bottom half
+    data.set(temp, bottomOffset);
+  }
+}
+
+export function scalePixels({data, width, height}) {
+  const newWidth = Math.round(width / 2);
+  const newHeight = Math.round(height / 2);
+  const newData = new Uint8Array(newWidth * newHeight * 4);
+  for (let y = 0; y < newHeight; y++) {
+    for (let x = 0; x < newWidth; x++) {
+      for (let c = 0; c < 4; c++) {
+        newData[(y * newWidth + x) * 4 + c] = data[(y * 2 * width + x * 2) * 4 + c];
+      }
+    }
+  }
+  return {data: newData, width: newWidth, height: newHeight};
+}

--- a/src/webgl-utils/polyfill-context.js
+++ b/src/webgl-utils/polyfill-context.js
@@ -93,6 +93,14 @@ const WEBGL_CONTEXT_POLYFILLS = {
     queryCounter: null
   },
   OVERRIDES: {
+    // Ensure readBuffer is a no-op
+    readBuffer: (gl, originalFunc, attachment) => {
+      if (isWebGL2(gl)) {
+        originalFunc(attachment);
+      } else {
+        // assert(attachment !== GL_COLOR_ATTACHMENT0 && attachment !== GL_FRONT);
+      }
+    },
     // Override for getVertexAttrib that returns sane values for non-WebGL1 constants
     getVertexAttrib: (gl, originalFunc, location, pname) => {
       // const gl = this; // eslint-disable-line

--- a/src/webgl-utils/polyfill-get-parameter.js
+++ b/src/webgl-utils/polyfill-get-parameter.js
@@ -20,6 +20,8 @@ const getWebGL2ValueOrZero = gl => !isWebGL2(gl) ? 0 : undefined;
 // if a function returns undefined in this table,
 // the original getParameter will be called, defeating the override
 const WEBGL_PARAMETERS = {
+  [GL.READ_BUFFER]: gl => !isWebGL2(gl) ? GL.COLOR_ATTACHMENT0 : undefined,
+
   // WebGL2 context parameters
   [GL_FRAGMENT_SHADER_DERIVATIVE_HINT]:
     gl => !isWebGL2(gl) ? GL_DONT_CARE : undefined,

--- a/src/webgl-utils/track-context-state.js
+++ b/src/webgl-utils/track-context-state.js
@@ -25,123 +25,134 @@ export const deepEqual = (x, y) => {
 };
 
 // interceptors for WEBGL FUNCTIONS that set WebGLRenderingContext state
+// These "setters" map functions to gl parameters
 
 export const GL_STATE_SETTERS = {
 
   // GENERIC SETTERS
 
-  enable: (setter, cap) => setter({
+  enable: (update, cap) => update({
     [cap]: true
   }),
-  disable: (setter, cap) => setter({
+  disable: (update, cap) => update({
     [cap]: false}
   ),
-  pixelStorei: (setter, pname, param) => setter({
+  pixelStorei: (update, pname, param) => update({
     [pname]: param
   }),
-  hint: (setter, pname, hint) => setter({
+  hint: (update, pname, hint) => update({
     [pname]: hint
   }),
 
   // SPECIFIC SETTERS
 
-  bindFramebuffer: (setter, target, fb) => setter({
-    [target === GL.READ_FRAMEBUFFER ?
-      GL.READ_FRAMEBUFFER_BINDING : GL.DRAW_FRAMEBUFFER_BINDING]: fb
-  }),
-
-  blendColor: (setter, r, g, b, a) => setter({
+  bindFramebuffer: (update, target, fb) => {
+    switch (target) {
+    case GL.FRAMEBUFFER:
+      return update({
+        [GL.DRAW_FRAMEBUFFER_BINDING]: fb,
+        [GL.READ_FRAMEBUFFER_BINDING]: fb
+      });
+    case GL.DRAW_FRAMEBUFFER:
+      return update({[GL.DRAW_FRAMEBUFFER_BINDING]: fb});
+    case GL.READ_FRAMEBUFFER:
+      return update({[GL.READ_FRAMEBUFFER_BINDING]: fb});
+    default:
+      return null;
+    }
+  },
+  blendColor: (update, r, g, b, a) => update({
     [GL.BLEND_COLOR]: new Float32Array([r, g, b, a])}
   ),
 
-  blendEquation: (setter, mode) => setter({
+  blendEquation: (update, mode) => update({
     [GL.BLEND_EQUATION_RGB]: mode,
     [GL.BLEND_EQUATION_ALPHA]: mode
   }),
 
-  blendEquationSeparate: (setter, modeRGB, modeAlpha) => setter({
+  blendEquationSeparate: (update, modeRGB, modeAlpha) => update({
     [GL.BLEND_EQUATION_RGB]: modeRGB,
     [GL.BLEND_EQUATION_ALPHA]: modeAlpha
   }),
 
-  blendFunc: (setter, src, dst) => setter({
+  blendFunc: (update, src, dst) => update({
     [GL.BLEND_SRC_RGB]: src,
     [GL.BLEND_DST_RGB]: dst,
     [GL.BLEND_SRC_ALPHA]: src,
     [GL.BLEND_DST_ALPHA]: dst
   }),
 
-  blendFuncSeparate: (setter, srcRGB, dstRGB, srcAlpha, dstAlpha) => setter({
+  blendFuncSeparate: (update, srcRGB, dstRGB, srcAlpha, dstAlpha) => update({
     [GL.BLEND_SRC_RGB]: srcRGB,
     [GL.BLEND_DST_RGB]: dstRGB,
     [GL.BLEND_SRC_ALPHA]: srcAlpha,
     [GL.BLEND_DST_ALPHA]: dstAlpha
   }),
 
-  clearColor: (setter, r, g, b, a) => setter({
+  clearColor: (update, r, g, b, a) => update({
     [GL.COLOR_CLEAR_VALUE]: new Float32Array([r, g, b, a])
   }),
 
-  clearDepth: (setter, depth) => setter({
+  clearDepth: (update, depth) => update({
     [GL.DEPTH_CLEAR_VALUE]: depth
   }),
 
-  clearStencil: (setter, s) => setter({
+  clearStencil: (update, s) => update({
     [GL.STENCIL_CLEAR_VALUE]: s
   }),
 
-  colorMask: (setter, r, g, b, a) => setter({
+  colorMask: (update, r, g, b, a) => update({
     [GL.COLOR_WRITEMASK]: [r, g, b, a]
   }),
 
-  cullFace: (setter, mode) => setter({
+  cullFace: (update, mode) => update({
     [GL.CULL_FACE_MODE]: mode
   }),
 
-  depthFunc: (setter, func) => setter({
+  depthFunc: (update, func) => update({
     [GL.DEPTH_FUNC]: func
   }),
 
-  depthRange: (setter, zNear, zFar) => setter({
+  depthRange: (update, zNear, zFar) => update({
     [GL.DEPTH_RANGE]: new Float32Array([zNear, zFar])
   }),
 
-  depthMask: (setter, mask) => setter({
+  depthMask: (update, mask) => update({
     [GL.DEPTH_WRITEMASK]: mask
   }),
 
-  frontFace: (setter, face) => setter({
+  frontFace: (update, face) => update({
     [GL.FRONT_FACE]: face
   }),
 
-  lineWidth: (setter, width) => setter({
+  lineWidth: (update, width) => update({
     [GL.LINE_WIDTH]: width
   }),
 
-  polygonOffset: (setter, factor, units) => setter({
+  polygonOffset: (update, factor, units) => update({
     [GL.POLYGON_OFFSET_FACTOR]: factor,
     [GL.POLYGON_OFFSET_UNITS]: units
   }),
 
-  sampleCoverage: (setter, value, invert) => setter({
+  sampleCoverage: (update, value, invert) => update({
     [GL.SAMPLE_COVERAGE_VALUE]: value,
     [GL.SAMPLE_COVERAGE_INVERT]: invert
   }),
 
-  scissor: (setter, x, y, width, height) => setter({
+  scissor: (update, x, y, width, height) => update({
     [GL.SCISSOR_BOX]: new Int32Array([x, y, width, height])
   }),
 
-  stencilMask: (setter, mask) => setter({
+  stencilMask: (update, mask) => update({
     [GL.STENCIL_WRITEMASK]: mask,
     [GL.STENCIL_BACK_WRITEMASK]: mask
   }),
 
-  stencilMaskSeparate: (setter, face, mask) => setter({
+  stencilMaskSeparate: (update, face, mask) => update({
     [face === GL.FRONT ? GL.STENCIL_WRITEMASK : GL.STENCIL_BACK_WRITEMASK]: mask
   }),
 
-  stencilFunc: (setter, func, ref, mask) => setter({
+  stencilFunc: (update, func, ref, mask) => update({
     [GL.STENCIL_FUNC]: func,
     [GL.STENCIL_REF]: ref,
     [GL.STENCIL_VALUE_MASK]: mask,
@@ -150,13 +161,13 @@ export const GL_STATE_SETTERS = {
     [GL.STENCIL_BACK_VALUE_MASK]: mask
   }),
 
-  stencilFuncSeparate: (setter, face, func, ref, mask) => setter({
+  stencilFuncSeparate: (update, face, func, ref, mask) => update({
     [face === GL.FRONT ? GL.STENCIL_FUNC : GL.STENCIL_BACK_FUNC]: func,
     [face === GL.FRONT ? GL.STENCIL_REF : GL.STENCIL_BACK_REF]: ref,
     [face === GL.FRONT ? GL.STENCIL_VALUE_MASK : GL.STENCIL_BACK_VALUE_MASK]: mask
   }),
 
-  stencilOp: (setter, fail, zfail, zpass) => setter({
+  stencilOp: (update, fail, zfail, zpass) => update({
     [GL.STENCIL_FAIL]: fail,
     [GL.STENCIL_PASS_DEPTH_FAIL]: zfail,
     [GL.STENCIL_PASS_DEPTH_PASS]: zpass,
@@ -165,13 +176,13 @@ export const GL_STATE_SETTERS = {
     [GL.STENCIL_BACK_PASS_DEPTH_PASS]: zpass
   }),
 
-  stencilOpSeparate: (setter, face, fail, zfail, zpass) => setter({
+  stencilOpSeparate: (update, face, fail, zfail, zpass) => update({
     [face === GL.FRONT ? GL.STENCIL_FAIL : GL.STENCIL_BACK_FAIL]: fail,
     [face === GL.FRONT ? GL.STENCIL_PASS_DEPTH_FAIL : GL.STENCIL_BACK_PASS_DEPTH_FAIL]: zfail,
     [face === GL.FRONT ? GL.STENCIL_PASS_DEPTH_PASS : GL.STENCIL_BACK_PASS_DEPTH_PASS]: zpass
   }),
 
-  viewport: (setter, x, y, width, height) => setter({
+  viewport: (update, x, y, width, height) => update({
     [GL.VIEWPORT]: new Int32Array([x, y, width, height])
   })
 };
@@ -210,7 +221,7 @@ function installGetterOverride(gl, functionName) {
 // Overrides a WebGLRenderingContext state "setter" function
 // to call a setter spy before the actual setter. Allows us to keep a cache
 // updated with a copy of the WebGL context state.
-function installSetterSpy(gl, functionName, setter, updateCache) {
+function installSetterSpy(gl, functionName, setter) {
   // Get the original function from the WebGLRenderingContext
   const originalSetterFunc = gl[functionName].bind(gl);
 
@@ -218,17 +229,20 @@ function installSetterSpy(gl, functionName, setter, updateCache) {
   gl[functionName] = function(...params) {
     // Update the value
     // Call the setter with the state cache and the params so that it can store the parameters
-    const valueChanged = setter(updateCache, ...params);
+    const {valueChanged, oldValue} = setter(gl.state._updateCache, ...params);
 
     // Call the original WebGLRenderingContext func to make sure the context actually gets updated
     if (valueChanged) {
       gl.state.log(`gl.${functionName}`, ...params); // eslint-disable-line
       originalSetterFunc(...params);
     }
+
     // Note: if the original function fails to set the value, our state cache will be bad
     // No solution for this at the moment, but assuming that this is unlikely to be a real problem
     // We could call the setter after the originalSetterFunc. Concern is that this would
     // cause different behavior in debug mode, where originalSetterFunc can throw exceptions
+
+    return oldValue;
   };
 
   // Set the name of this anonymous function to help in debugging and profiling
@@ -271,6 +285,7 @@ class GLState {
   // values (Object) - the key values for this setter
   _updateCache(values) {
     let valueChanged = false;
+    let oldValue; // = undefined
 
     const oldValues = this.stateStack.length > 0 && this.stateStack[this.stateStack.length - 1];
 
@@ -279,6 +294,7 @@ class GLState {
       // Check that value hasn't already been shadowed
       if (!deepEqual(values[key], this.cache[key])) {
         valueChanged = true;
+        oldValue = this.cache[key];
 
         // First, save current value being shadowed
         // If a state stack frame is active, save the current parameter values for pop
@@ -292,7 +308,7 @@ class GLState {
       }
     }
 
-    return valueChanged;
+    return {valueChanged, oldValue};
   }
 }
 
@@ -317,7 +333,7 @@ export default function trackContextState(gl, {enable = true, copyState} = {}) {
     // intercept all setter functions in the table
     for (const key in GL_STATE_SETTERS) {
       const setter = GL_STATE_SETTERS[key];
-      installSetterSpy(gl, key, setter, gl.state._updateCache);
+      installSetterSpy(gl, key, setter);
     }
 
     // intercept all getter functions in the table

--- a/src/webgl/clear.js
+++ b/src/webgl/clear.js
@@ -22,10 +22,12 @@ export function clear(gl, {
   depth = null,
   stencil = null
 } = {}) {
-  const parameters = {
-    nocatch: false,
-    framebuffer
-  };
+  const parameters = {};
+
+  if (framebuffer) {
+    parameters.framebuffer = framebuffer;
+  }
+
   let clearFlags = 0;
 
   if (color) {

--- a/src/webgl/context-state.js
+++ b/src/webgl/context-state.js
@@ -2,8 +2,15 @@
 import GL from '../webgl-utils/constants';
 import {pushContextState, popContextState} from '../webgl-utils/track-context-state';
 import {log} from '../utils';
-import {isWebGL2} from './context';
-import assert from 'assert';
+
+import {
+  getParameter,
+  getParameters,
+  setParameter,
+  setParameters as glSetParameters,
+  resetParameters,
+  getModifiedParameters
+} from '../webgl-utils/set-parameters';
 
 // map of parameter setter function names, parameter constants, default values and types
 // - Uses gl function names, except when setter function exist that are named differently
@@ -12,23 +19,9 @@ import assert from 'assert';
 //   separate arguments. Thus, a `getParameter` call will always return all the separate values
 //   in an array, in a form that can be accepted by the setter.
 export const LUMA_SETTERS = {
-  bindFramebuffer: (gl, args) => {
-    assert(args.length === 2, 'bindFramebuffer needs two arguments, target and handle');
-    const [target, handle] = args;
-    if (target === GL.FRAMEBUFFER) {
-      if (isWebGL2(gl)) {
-        // NOTE: https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_framebuffer_blit.txt
-        // As per above spec, under WebGL2, FRAMEBUFFER binding updates both READ_FRAMEBUFFER and DRAW_FRAMEBUFFER
-        // This generates two bindFramebuffer calls so that our cache is correct
-        gl.bindFramebuffer(GL.DRAW_FRAMEBUFFER, handle);
-        gl.bindFramebuffer(GL.READ_FRAMEBUFFER, handle);
-      } else {
-        gl.bindFramebuffer(GL.FRAMEBUFFER, handle);
-      }
-    } else {
-      // handle GL.DRAW_FRAMEBUFFER and GL.READ_FRAMEBUFFER
-      gl.bindFramebuffer(target, handle);
-    }
+  framebuffer: (gl, framebuffer) => {
+    const handle = framebuffer && framebuffer.handle ? framebuffer.handle : framebuffer;
+    return gl.bindFramebuffer(GL.FRAMEBUFFER, handle);
   },
   blend: (gl, value) => value ? gl.enable(GL.BLEND) : gl.disable(GL.BLEND),
   blendColor: (gl, value) => gl.blendColor(...value),
@@ -109,16 +102,21 @@ function isArray(array) {
 // GETTERS AND SETTERS
 
 // Get the parameter value(s) from the context
-export {getParameter} from '../webgl-utils/set-parameters';
+export {getParameter}; // from '../webgl-utils/set-parameters'
 
 // Get the parameters from the context
-export {getParameters} from '../webgl-utils/set-parameters';
+export {getParameters}; // from '../webgl-utils/set-parameters'
 
 // Resets gl state to default values.
-export {resetParameters} from '../webgl-utils/set-parameters';
+export {setParameter}; // from '../webgl-utils/set-parameters'
 
-// Get the parameter value(s) from the context
-import {setParameters as glSetParameters} from '../webgl-utils/set-parameters';
+// Resets gl state to default values.
+export {resetParameters}; // from '../webgl-utils/set-parameters'
+
+// Get a map of modified parameters
+export {getModifiedParameters};
+
+// Note: "setParameters" is given extra treatment below
 
 // Set the parameter value(s) by key to the context
 // Sets value with key to context.
@@ -141,40 +139,30 @@ export function withParameters(gl, parameters, func) {
   // assertWebGLContext(gl);
 
   const {frameBuffer, nocatch = true} = parameters;
-  let {framebuffer} = parameters;
   if (frameBuffer) {
     log.deprecated('withParameters({frameBuffer})', 'withParameters({framebuffer})');
-    framebuffer = frameBuffer;
-  }
-
-  // Define a helper function that will reset state after the function call
-  function resetStateAfterCall() {
-    popContextState(gl);
+    parameters.framebuffer = parameters.framebuffer || frameBuffer;
   }
 
   pushContextState(gl);
-
   setParameters(gl, parameters);
-
-  if (framebuffer) {
-    framebuffer.bind();
-  }
 
   // Setup is done, call the function
   let value;
 
   if (nocatch) {
-    // Avoid try catch to minimize debugging impact for safe execution paths
+    // Avoid try catch to minimize stack size impact for safe execution paths
     value = func(gl);
-    resetStateAfterCall();
+    popContextState(gl);
   } else {
     // Wrap in a try-catch to ensure that parameters are restored on exceptions
     try {
       value = func(gl);
     } finally {
-      resetStateAfterCall();
+      popContextState(gl);
     }
   }
+
   return value;
 }
 

--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -1,12 +1,12 @@
 import GL from './api';
 import {isWebGL2, ERR_WEBGL2} from './context';
-import {clear, clearBuffer} from './clear';
 import {getFeatures} from './context-features';
+import {clear, clearBuffer} from './clear';
 import Resource from './resource';
 import Texture2D from './texture-2d';
 import Renderbuffer from './renderbuffer';
 import {getTypedArrayFromGLType, getGLTypeFromTypedArray} from '../utils/typed-array-utils';
-import {log} from '../utils';
+import {log, flipRows, scalePixels} from '../utils';
 import assert from 'assert';
 
 // Local constants - will collapse during minification
@@ -46,6 +46,24 @@ export default class Framebuffer extends Resource {
     supported = colorBufferHalfFloat &&
       gl.getExtension(isWebGL2(gl) ? 'EXT_color_buffer_float' : 'EXT_color_buffer_half_float');
     return supported;
+  }
+
+  // Create a Framebuffer wrapper for the default framebuffer (target === null)
+  static getDefaultFramebuffer(gl) {
+    gl.luma = gl.luma || {};
+    if (!gl.luma.defaultFramebuffer) {
+      gl.luma.defaultFramebuffer = new Framebuffer(gl, {handle: null, attachments: {}});
+    }
+    // TODO - can we query for and get a handle to the GL.FRONT renderbuffer?
+    return gl.luma.defaultFramebuffer;
+  }
+
+  get MAX_COLOR_ATTACHMENTS() {
+    return this.gl.getParameter(this.gl.MAX_COLOR_ATTACHMENTS);
+  }
+
+  get MAX_DRAW_BUFFERS() {
+    return this.gl.getParameter(this.gl.MAX_DRAW_BUFFERS);
   }
 
   constructor(gl, opts = {}) {
@@ -126,26 +144,42 @@ export default class Framebuffer extends Resource {
 
     const {gl} = this;
     // Multiple render target support, set read buffer and draw buffers
-    gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
     if (readBuffer) {
       this._setReadBuffer(readBuffer);
     }
     if (drawBuffers) {
       this._setDrawBuffers(drawBuffers);
     }
-    gl.bindFramebuffer(GL_FRAMEBUFFER, null);
+    gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle);
 
     return this;
   }
 
   // Attachment resize is expected to be a noop if size is same
   resize({width, height}) {
-    log.log(2, `Resizing framebuffer ${this.id} to ${width}x${height}`);
+    if (this.handle === null) {
+      return this.updateSize();
+    }
+
+    if (width !== this.width && height !== this.height) {
+      log.log(2, `Resizing framebuffer ${this.id} to ${width}x${height}`);
+    }
     for (const attachmentPoint in this.attachments) {
       this.attachments[attachmentPoint].resize({width, height});
     }
     this.width = width;
     this.height = height;
+    return this;
+  }
+
+  updateSize() {
+    // If default framebuffer
+    if (this.handle === null) {
+      // Default
+      this.width = this.gl.drawingBufferWidth;
+      this.height = this.gl.drawingBufferHeight;
+    }
     return this;
   }
 
@@ -165,7 +199,7 @@ export default class Framebuffer extends Resource {
     // Overlay the new attachments
     Object.assign(newAttachments, attachments);
 
-    this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
 
     // Walk the attachments
     for (const attachment in newAttachments) {
@@ -192,7 +226,7 @@ export default class Framebuffer extends Resource {
       }
     }
 
-    this.gl.bindFramebuffer(GL_FRAMEBUFFER, null);
+    this.gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle);
 
     // Assign to attachments and remove any nulls to get a clean attachment map
     Object.assign(this.attachments, attachments);
@@ -203,9 +237,9 @@ export default class Framebuffer extends Resource {
 
   checkStatus() {
     const {gl} = this;
-    gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
     const status = gl.checkFramebufferStatus(GL_FRAMEBUFFER);
-    gl.bindFramebuffer(GL_FRAMEBUFFER, null);
+    gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle);
     if (status !== gl.FRAMEBUFFER_COMPLETE) {
       throw new Error(_getFrameBufferStatus(status));
     }
@@ -219,7 +253,7 @@ export default class Framebuffer extends Resource {
     drawBuffers = []
   } = {}) {
     // Bind framebuffer and delegate to global clear functions
-    this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
 
     if (color || depth || stencil) {
       clear(this.gl, {color, depth, stencil});
@@ -229,7 +263,7 @@ export default class Framebuffer extends Resource {
       clearBuffer({drawBuffer, value});
     });
 
-    this.gl.bindFramebuffer(GL_FRAMEBUFFER, null);
+    this.gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle);
 
     return this;
   }
@@ -241,13 +275,19 @@ export default class Framebuffer extends Resource {
   readPixels({
     x = 0,
     y = 0,
-    width,
-    height,
+    width = this.width,
+    height = this.height,
     format = GL.RGBA,
-    type,
-    pixelArray = null
+    type, // Auto deduced from pixelArray or gl.UNSIGNED_BYTE
+    pixelArray = null,
+    attachment = GL_COLOR_ATTACHMENT0 // TODO - support gl.readBuffer
   }) {
     const {gl} = this;
+
+    // TODO - Set and unset gl.readBuffer
+    if (attachment === GL.COLOR_ATTACHMENT0 && this.handle === null) {
+      attachment = GL.FRONT;
+    }
 
     // Deduce type and allocated pixelArray if needed
     if (!pixelArray) {
@@ -262,64 +302,125 @@ export default class Framebuffer extends Resource {
     // Pixel array available, if necessary, deduce type from it.
     type = type || getGLTypeFromTypedArray(pixelArray);
 
-    this.bind();
+    const prevHandle = this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
     this.gl.readPixels(x, y, width, height, format, type, pixelArray);
-    this.unbind();
+    this.gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle);
 
     return pixelArray;
   }
 
-  /**
-   * Copy from framebuffer into a texture
-   */
+  // Reads pixels as a dataUrl
+  copyToDataUrl({
+    attachment = GL_COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
+    maxHeight = Number.MAX_SAFE_INTEGER
+  } = {}) {
+    let data = this.readPixels({attachment});
+
+    // Scale down
+    let {width, height} = this;
+    while (height > maxHeight) {
+      ({data, width, height} = scalePixels({data, width, height}));
+    }
+
+    // Flip to top down coordinate system
+    flipRows({data, width, height});
+
+    /* global document */
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+
+    // Copy the pixels to a 2D canvas
+    const imageData = context.createImageData(width, height);
+    imageData.data.set(data);
+    context.putImageData(imageData, 0, 0);
+
+    return canvas.toDataURL();
+  }
+
+  // Reads pixels into an HTML Image
+  copyToImage({
+    image = null,
+    attachment = GL_COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
+    maxHeight = Number.MAX_SAFE_INTEGER
+  } = {}) {
+    /* global Image */
+    const dataUrl = this.readDataUrl({attachment});
+    image = image || new Image();
+    image.src = dataUrl;
+    return image;
+  }
+
+  // copyToFramebuffer({width, height}) {
+  //   const scaleX = width / this.width;
+  //   const scaleY = height / this.height;
+  //   const scale = Math.min(scaleX, scaleY);
+  //   width = width * scale;
+  //   height = height * scale;
+  //   const scaledFramebuffer = new Framebuffer(this.gl, {width, height});
+  //   this.blit();
+  // }
+
+  // Copy a rectangle from a framebuffer attachment into a texture (at an offset)
   copyToTexture({
-    srcFramebuffer,
-    x,
-    y,
-    width,
-    height,
+    // Target
     texture,
+    target, // for cubemaps
     xoffset = 0,
     yoffset = 0,
     zoffset = 0,
     mipmapLevel = 0,
-    internalFormat = GL.RGBA,
-    // offset = 0,
-    // type = GL.UNSIGNED_BYTE,
-    border = 0
+
+    // Source
+    attachment = GL_COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
+    x = 0,
+    y = 0,
+    width, // defaults to texture width
+    height // defaults to texture height
   }) {
     const {gl} = this;
-    gl.bindFramebuffer(GL_FRAMEBUFFER, srcFramebuffer.handle);
+    const prevHandle = gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevBuffer = gl.readBuffer(attachment);
+
+    width = Number.isFinite(width) ? width : texture.width;
+    height = Number.isFinite(height) ? height : texture.height;
 
     // target
     switch (texture.target) {
     case GL_TEXTURE_2D:
     case GL_TEXTURE_CUBE_MAP:
       gl.copyTexSubImage2D(
-        texture.target,
+        target || texture.target,
         mipmapLevel,
-        internalFormat,
-        x, y,
-        texture.width,
-        texture.height
+        xoffset,
+        yoffset,
+        x,
+        y,
+        width,
+        height
       );
       break;
     case GL_TEXTURE_2D_ARRAY:
     case GL_TEXTURE_3D:
       gl.copyTexSubImage3D(
-        texture.target,
+        target || texture.target,
         mipmapLevel,
-        internalFormat,
-        x, y,
-        texture.width,
-        texture.height
+        xoffset,
+        yoffset,
+        zoffset,
+        x,
+        y,
+        width,
+        height
       );
       break;
     default:
     }
 
-    gl.bindFramebuffer(GL_FRAMEBUFFER, null);
-    return this;
+    gl.readBuffer(prevBuffer);
+    gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle);
+    return texture;
   }
 
   // WEBGL2 INTERFACE
@@ -327,16 +428,21 @@ export default class Framebuffer extends Resource {
   // Copies a rectangle of pixels between framebuffers
   blit({
     srcFramebuffer,
-    srcX0, srcY0, srcX1, srcY1,
-    dstX0, dstY0, dstX1, dstY1,
-    color,
-    depth,
-    stencil,
+    attachment = GL_COLOR_ATTACHMENT0,
+    srcX0 = 0, srcY0 = 0, srcX1, srcY1,
+    dstX0 = 0, dstY0 = 0, dstX1, dstY1,
+    color = true,
+    depth = false,
+    stencil = false,
     mask = 0,
     filter = GL.NEAREST
   }) {
     const {gl} = this;
     assert(isWebGL2(gl), ERR_WEBGL2);
+
+    if (!srcFramebuffer.handle && attachment === GL_COLOR_ATTACHMENT0) {
+      attachment = GL.FRONT;
+    }
 
     if (color) {
       mask |= GL_COLOR_BUFFER_BIT;
@@ -347,17 +453,21 @@ export default class Framebuffer extends Resource {
     if (stencil) {
       mask |= GL_STENCIL_BUFFER_BIT;
     }
+    assert(mask);
 
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, srcFramebuffer.handle);
-    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, this.handle);
-    gl.blitFramebuffer(
-      srcX0, srcY0, srcX1, srcY1,
-      dstX0, dstY0, dstX1, dstY1,
-      mask,
-      filter
-    );
-    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, null);
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, null);
+    srcX1 = srcX1 === undefined ? srcFramebuffer.width : srcX1;
+    srcY1 = srcY1 === undefined ? srcFramebuffer.height : srcY1;
+    dstX1 = dstX1 === undefined ? this.width : dstX1;
+    dstY1 = dstY1 === undefined ? this.height : dstY1;
+
+    const prevDrawHandle = gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, this.handle);
+    const prevReadHandle = gl.bindFramebuffer(GL_READ_FRAMEBUFFER, srcFramebuffer.handle);
+    const prevReadBuffer = gl.readBuffer(attachment);
+    gl.blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    gl.readBuffer(prevReadBuffer);
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, prevReadHandle);
+    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, prevDrawHandle);
+
     return this;
   }
 
@@ -372,30 +482,30 @@ export default class Framebuffer extends Resource {
   }) {
     const {gl} = this;
     assert(isWebGL2(gl, ERR_WEBGL2));
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, this.handle);
+    const prevHandle = gl.bindFramebuffer(GL_READ_FRAMEBUFFER, this.handle);
     const invalidateAll = x === 0 && y === 0 && width === undefined && height === undefined;
     if (invalidateAll) {
       gl.invalidateFramebuffer(GL_READ_FRAMEBUFFER, attachments);
     } else {
       gl.invalidateFramebuffer(GL_READ_FRAMEBUFFER, attachments, x, y, width, height);
     }
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, null);
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, prevHandle);
     return this;
   }
 
-  // Return the value for the passed pname given the target and attachment.
-  // The type returned is the natural type for the requested pname:
-  // pname returned type
-  // If an OpenGL error is generated, returns null.
+  // Return the value for `pname` of the specified attachment.
+  // The type returned is the type of the requested pname
   getAttachmentParameter({
-    target = this.target,
     attachment = GL_COLOR_ATTACHMENT0,
     pname
   } = {}) {
-    const fallback = this._getAttachmentParameterFallback(pname);
-    return fallback !== null ?
-      fallback :
-      this.gl.getFramebufferAttachmentParameter(target, attachment, pname);
+    let value = this._getAttachmentParameterFallback(pname);
+    if (value === null) {
+      this.gl.bindTexture(GL_FRAMEBUFFER, this.handle);
+      value = this.gl.getFramebufferAttachmentParameter(GL_FRAMEBUFFER, attachment, pname);
+      this.gl.bindTexture(GL_FRAMEBUFFER, null);
+    }
+    return value;
   }
 
   getAttachmentParameters(
@@ -404,7 +514,26 @@ export default class Framebuffer extends Resource {
   ) {
     const values = {};
     for (const pname in parameters) {
-      values[pname] = this.getParameter(pname);
+      values[pname] = this.getAttachmentParameter(pname);
+    }
+    return this;
+  }
+
+  // DEBUG
+
+  // Note: Will only work when called in an event handler
+  show() {
+    /* global window */
+    if (typeof window !== 'undefined') {
+      window.open(this.copyToDataUrl(), 'luma-debug-texture');
+    }
+    return this;
+  }
+
+  log({priority = 0, message = ''} = {}) {
+    message = message || `Framebuffer ${this.id}`;
+    if (typeof window !== 'undefined') { // Let's not try this under node
+      log.image({priority, message, image: this.copyToDataUrl({maxHeight: 100})}, message);
     }
     return this;
   }
@@ -452,11 +581,8 @@ export default class Framebuffer extends Resource {
     // Add a depth buffer if requested and not supplied
     if (depth) {
       defaultAttachments = defaultAttachments || {};
-      defaultAttachments[GL_DEPTH_ATTACHMENT] = new Renderbuffer(this.gl, {
-        format: GL.DEPTH_COMPONENT16,
-        width,
-        height
-      });
+      defaultAttachments[GL_DEPTH_ATTACHMENT] =
+        new Renderbuffer(this.gl, {format: GL.DEPTH_COMPONENT16, width, height});
     }
 
     // TODO - handle stencil and combined depth and stencil

--- a/src/webgl/program.js
+++ b/src/webgl/program.js
@@ -4,6 +4,7 @@ import {assertWebGL2Context, isWebGL2} from './context';
 import VertexArray from './vertex-array';
 import Resource from './resource';
 import Texture from './texture';
+import Framebuffer from './framebuffer';
 import {getTransformFeedbackMode} from './transform-feedback';
 import {parseUniformName, getUniformSetter} from './uniforms';
 import {VertexShader, FragmentShader} from './shader';
@@ -242,11 +243,14 @@ export default class Program extends Resource {
   /* eslint-disable max-depth */
   setUniforms(uniforms, samplers = {}) {
     for (const uniformName in uniforms) {
-      const uniform = uniforms[uniformName];
+      let uniform = uniforms[uniformName];
       const uniformSetter = this._uniformSetters[uniformName];
       const sampler = samplers[uniformName];
 
       if (uniformSetter) {
+        if (uniform instanceof Framebuffer) {
+          uniform = uniform.texture;
+        }
         if (uniform instanceof Texture) {
           if (uniformSetter.textureIndex === undefined) {
             uniformSetter.textureIndex = this._textureIndexCounter++;
@@ -385,7 +389,7 @@ export default class Program extends Resource {
         const location = this._attributeLocations[attributeName];
         // throw new Error(`Program ${this.id}: ` +
         //   `Attribute ${location}:${attributeName} not supplied`);
-        log.warn(0, `Program ${this.id}: Attribute ${location}:${attributeName} not supplied`);
+        log.warn(`Program ${this.id}: Attribute ${location}:${attributeName} not supplied`);
         this._warn[attributeName] = true;
       }
     }
@@ -405,7 +409,7 @@ export default class Program extends Resource {
         } else if (buffer.target === GL.ELEMENT_ARRAY_BUFFER) {
           elements = bufferName;
         } else if (!this._warn[bufferName]) {
-          log.warn(2, `${this._print(bufferName)} not used`);
+          log.log(2, `${this._print(bufferName)} not used`);
           this._warn[bufferName] = true;
         }
       } else {

--- a/src/webgl/resource.js
+++ b/src/webgl/resource.js
@@ -77,8 +77,6 @@ export default class Resource {
   /**
    * Query a Resource parameter
    *
-   * @todo - cache parameters to avoid issuing WebGL calls?
-   *
    * @param {GLenum} pname
    * @return {GLint|GLfloat|GLenum} param
    */

--- a/src/webgl/shader.js
+++ b/src/webgl/shader.js
@@ -84,9 +84,9 @@ export class Shader extends Resource {
       const infoLog = this.gl.getShaderInfoLog(this.handle);
       const {shaderName, errors, warnings} =
         parseGLSLCompilerError(infoLog, this.source, this.shaderType);
-      log.error(0, `GLSL compilation errors in ${shaderName}\n${errors}`);
-      log.warn(0, `GLSL compilation warnings in ${shaderName}\n${warnings}`);
-      throw new Error(`GLSL compilation errors in ${shaderName}\n${errors}`);
+      log.error(`GLSL compilation errors in ${shaderName}\n${errors}`);
+      log.warn(`GLSL compilation warnings in ${shaderName}\n${warnings}`);
+      throw new Error(`GLSL compilation errors in ${shaderName}`);
     }
   }
 

--- a/src/webgl/texture.js
+++ b/src/webgl/texture.js
@@ -233,7 +233,7 @@ export default class Texture extends Resource {
 
     if (this._isNPOT()) {
 
-      log.warn(0, `texture: ${this} is Non-Power-Of-Two, disabling mipmaping`);
+      log.warn(`texture: ${this} is Non-Power-Of-Two, disabling mipmaping`);
       mipmaps = false;
 
       this._updateForNPOT(parameters);
@@ -785,15 +785,15 @@ export default class Texture extends Resource {
   // Update default settings which are not supported by NPOT textures.
   _updateForNPOT(parameters) {
     if (parameters[this.gl.TEXTURE_MIN_FILTER] === undefined) {
-      log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
+      log.warn(`texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
       parameters[this.gl.TEXTURE_MIN_FILTER] = this.gl.LINEAR;
     }
     if (parameters[this.gl.TEXTURE_WRAP_S] === undefined) {
-      log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_WRAP_S to CLAMP_TO_EDGE`);
+      log.warn(`texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_WRAP_S to CLAMP_TO_EDGE`);
       parameters[this.gl.TEXTURE_WRAP_S] = this.gl.CLAMP_TO_EDGE;
     }
     if (parameters[this.gl.TEXTURE_WRAP_T] === undefined) {
-      log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_WRAP_T to CLAMP_TO_EDGE`);
+      log.warn(`texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_WRAP_T to CLAMP_TO_EDGE`);
       parameters[this.gl.TEXTURE_WRAP_T] = this.gl.CLAMP_TO_EDGE;
     }
   }
@@ -803,14 +803,14 @@ export default class Texture extends Resource {
       switch (pname) {
       case GL.TEXTURE_MIN_FILTER:
         if (NPOT_MIN_FILTERS.indexOf(param) === -1) {
-          log.warn(0, `texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
+          log.warn(`texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`);
           param = GL.LINEAR;
         }
         break;
       case GL.TEXTURE_WRAP_S:
       case GL.TEXTURE_WRAP_T:
         if (param !== GL.CLAMP_TO_EDGE) {
-          log.warn(0, `texture: ${this} is Non-Power-Of-Two, ${glKey(pname)} to CLAMP_TO_EDGE`);
+          log.warn(`texture: ${this} is Non-Power-Of-Two, ${glKey(pname)} to CLAMP_TO_EDGE`);
           param = GL.CLAMP_TO_EDGE;
         }
         break;

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -21,7 +21,7 @@ export default class TranformFeedback extends Resource {
    * @param {WebGL2RenderingContext} gl - context
    * @param {Object} opts - options
    */
-  constructor(gl, opts) {
+  constructor(gl, opts = {}) {
     assertWebGL2Context(gl);
     super(gl, opts);
     this.buffers = {};

--- a/test/webgl/context-state.spec.js
+++ b/test/webgl/context-state.spec.js
@@ -306,7 +306,7 @@ test('WebGLState#bindFramebuffer (WebGL1)', t => {
   t.equal(fbHandle, null, 'Initial draw frambuffer binding should be null');
 
   setParameters(gl, {
-    bindFramebuffer: [gl.FRAMEBUFFER, framebuffer.handle]
+    framebuffer
   });
 
   fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
@@ -326,7 +326,7 @@ test('WebGLState#bindFramebuffer (WebGL2)', t => {
     resetParameters(gl2);
 
     setParameters(gl2, {
-      bindFramebuffer: [gl2.FRAMEBUFFER, framebuffer.handle]
+      framebuffer: framebuffer.handle
     });
 
     fbHandle = getParameter(gl2, gl2.DRAW_FRAMEBUFFER_BINDING);
@@ -335,17 +335,13 @@ test('WebGLState#bindFramebuffer (WebGL2)', t => {
     fbHandle = getParameter(gl2, gl2.READ_FRAMEBUFFER_BINDING);
     t.equal(fbHandle, framebuffer.handle, 'FRAMEBUFFER binding should also set READ_FRAMEBUFFER_BINDING');
 
-    setParameters(gl2, {
-      bindFramebuffer: [gl2.DRAW_FRAMEBUFFER, framebufferTwo.handle]
-    });
+    gl2.bindFramebuffer(gl2.DRAW_FRAMEBUFFER, framebufferTwo.handle);
     fbHandle = getParameter(gl2, gl2.DRAW_FRAMEBUFFER_BINDING);
     t.equal(fbHandle, framebufferTwo.handle, 'DRAW_FRAMEBUFFER binding should set DRAW_FRAMEBUFFER_BINDING');
     fbHandle = getParameter(gl2, gl2.READ_FRAMEBUFFER_BINDING);
     t.equal(fbHandle, framebuffer.handle, 'DRAW_FRAMEBUFFER binding should NOT set READ_FRAMEBUFFER_BINDING');
 
-    setParameters(gl2, {
-      bindFramebuffer: [gl2.READ_FRAMEBUFFER, framebufferThree.handle]
-    });
+    gl2.bindFramebuffer(gl2.READ_FRAMEBUFFER, framebufferThree.handle);
     fbHandle = getParameter(gl2, gl2.DRAW_FRAMEBUFFER_BINDING);
     t.equal(fbHandle, framebufferTwo.handle, 'READ_FRAMEBUFFER binding should NOT set DRAW_FRAMEBUFFER_BINDING');
     fbHandle = getParameter(gl2, gl2.READ_FRAMEBUFFER_BINDING);

--- a/test/webgl/framebuffer.spec.js
+++ b/test/webgl/framebuffer.spec.js
@@ -93,6 +93,19 @@ test('WebGL#Framebuffer construct/delete', t => {
   t.end();
 });
 
+test('Framebuffer#getDefaultFramebuffer', t => {
+  const {gl} = fixture;
+
+  const framebuffer = Framebuffer.getDefaultFramebuffer(gl);
+  t.ok(framebuffer instanceof Framebuffer,
+    'getDefaultFramebuffer successful');
+
+  framebuffer.resize({width: 1000, height: 1000});
+  framebuffer.checkStatus();
+
+  t.end();
+});
+
 function testFramebuffer(t, gl) {
   for (const tc of TEST_CASES) {
     let opts;


### PR DESCRIPTION
* Prevent `AnimationLoop` from creating unused framebuffer
* Add `defaultFramebuffer` object, allowing the default framebuffer to be manipulated using the `Framebuffer` class methods.
* Add `readDataUrl` and `readImage` methods, read out texture to HTML Image
* Fixes to `blit` and `getAttachmentParameter`