### PR TITLE
Fix `TransformFeedback.isSupported` bug

### DIFF
--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -9,7 +9,7 @@ const GL_TRANSFORM_FEEDBACK = 0x8E22;
 export default class TranformFeedback extends Resource {
 
   static isSupported(gl) {
-    return isWebGL2(gl) || gl.getExtension('OES_vertex_array_object');
+    return isWebGL2(gl) && gl.getExtension('OES_vertex_array_object');
   }
 
   static isHandle(handle) {

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -9,7 +9,7 @@ const GL_TRANSFORM_FEEDBACK = 0x8E22;
 export default class TranformFeedback extends Resource {
 
   static isSupported(gl) {
-    return isWebGL2(gl) && gl.getExtension('OES_vertex_array_object');
+    return isWebGL2(gl);
   }
 
   static isHandle(handle) {

--- a/test/webgl/index.js
+++ b/test/webgl/index.js
@@ -25,3 +25,4 @@ import './uniform-buffer-layout.spec';
 
 // Extensions / webgl2
 import './query.spec';
+import './transform-feedback.spec';

--- a/test/webgl/transform-feedback.spec.js
+++ b/test/webgl/transform-feedback.spec.js
@@ -1,0 +1,38 @@
+import {TransformFeedback} from 'luma.gl';
+import 'luma.gl/headless';
+import test from 'tape-catch';
+
+import {fixture} from '../setup';
+
+test('WebGL#TransformFeedback isSupported', t => {
+  const {gl, gl2} = fixture;
+  t.notok(TransformFeedback.isSupported(gl), 'isSupported returns correct result');
+  t.is(TransformFeedback.isSupported(gl2), Boolean(gl2), 'isSupported returns correct result');
+  t.end();
+});
+
+test('WebGL#TransformFeedback constructor/delete', t => {
+  const {gl2} = fixture;
+
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  t.throws(
+    () => new TransformFeedback(),
+    /.*WebGLRenderingContext.*/,
+    'Buffer throws on missing gl context');
+
+  const tf = new TransformFeedback(gl2);
+  t.ok(tf instanceof TransformFeedback, 'TransformFeedback construction successful');
+
+  tf.delete();
+  t.ok(tf instanceof TransformFeedback, 'TransformFeedback delete successful');
+
+  tf.delete();
+  t.ok(tf instanceof TransformFeedback, 'TransformFeedback repeated delete successful');
+
+  t.end();
+});


### PR DESCRIPTION
The returned value (WebGL extension) is consistent with the behavior of other classes' `isSupported` methods, though we really should convert it to `Boolean` for a cleaner interface.