### PR TITLE
Picking module from deck.gl

### DIFF
--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -59,7 +59,7 @@ const animationLoop = new AnimationLoop({
 
     cube.updateModuleSettings({
       pickingSelectedColor: pickInfo && pickInfo.color,
-      pickingValid: pickInfo !== null
+      pickingSelectedColorValid: pickInfo !== null
     });
 
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -22,6 +22,10 @@ const ERR_MODEL_PARAMS = 'Model needs drawMode and vertexCount';
 
 const LOG_DRAW_PRIORITY = 2;
 
+// These old picking uniforms should be avoided and we should use picking module
+// and set uniforms using Model class 'updateModuleSettings()'
+const DEPRECATED_PICKING_UNIFORMS = ['renderPickingBuffer', 'pickingEnabled'];
+
 // Model abstract O3D Class
 export default class Model extends Object3D {
   constructor(gl, opts = {}) {
@@ -287,6 +291,7 @@ in a future version. Use shader modules instead.`);
 
   // TODO - should actually set the uniforms
   setUniforms(uniforms = {}) {
+    this._checkForDeprecatedUniforms(uniforms);
     checkUniformValues(uniforms, this.id);
     Object.assign(this.uniforms, uniforms);
     this.setNeedsRedraw();
@@ -403,6 +408,17 @@ in a future version. Use shader modules instead.`);
     // is unbound
     this.program.unsetBuffers();
     return this;
+  }
+
+  // HELPER METHODS
+
+  _checkForDeprecatedUniforms(uniforms) {
+    // deprecated picking uniforms
+    DEPRECATED_PICKING_UNIFORMS.forEach((uniform) => {
+      if (uniform in uniforms) {
+        log.deprecated(uniform, 'use picking shader module and Model class updateModuleSettings()');
+      }
+    });
   }
 
   _timerQueryStart() {

--- a/src/shadertools/modules/picking/README.md
+++ b/src/shadertools/modules/picking/README.md
@@ -1,29 +1,29 @@
 # Shader Module: Picking
 
-Provides support for color based picking. In particular, supports picking a specific instance in an instanced draw call.
+Provides support for color-coding-based picking and highlighting. In particular, supports picking a specific instance in an instanced draw call and highlighting an instance based on its picking color, and correspondingly, supports picking and highlighting groups of primitives with the same picking color in non-instanced draw-calls
 
-Color based picking lets the application draw a primitive with a fixed color, and by reading the color from a pixel in the resulting Framebuffer it can determine which primitive was drawn topmost at that point without asking the CPU to refer to geometry or raycasting etc.
+Color based picking lets the application draw a primitive with a color that can later be used to index this specific primitive.
+
+Highlighting allows application to specify a picking color corresponding to an object that need to be highlighted and the highlight color to be used.
 
 ## Usage
 
 In your vertex shader, your inform the picking module what object we are currently rendering by supplying a picking color, perhaps from an attribute.
 ```
 attribute vec3 aPickingColor;
-
 main() {
   picking_setColor(aPickingColor);
   ...
 }
 ```
 
-In your fragment shader, you simply apply (call) the `picking_filterPickingColor` filter function at the very end of the shader.This will return the normal color or the picking color, as appropriate.
+In your fragment shader, you simply apply (call) the `picking_filterPickingColor` filter function at the very end of the shader. This will return the normal color, or the highlight color, or the picking color, as appropriate.
 ```
 main() {
   gl_FragColor = ...
   gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 ```
-
 If you would like to apply the highlight color to the currently selected element call `picking_filterHighlightColor` before calling `picking_filterPickingColor`. You can also apply other filters on the non-picking color (vertex or highlight color) by placing those instruction between these two function calls.
 
  ```
@@ -32,22 +32,23 @@ main() {
     ... apply any filters on gl_FragColor ...
   gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
+
 ```
 
 ## JavaScript Functions
 
 ### getUniforms
 
-`getUniforms` returns an object with key/value pairs representing the uniforms that the `picking` module shaders need.
+`getUniforms` takes an object takes a set of key/value pairs, returns an object with key/value pairs representing the uniforms that the `picking` module shaders need.
 
-`getUniforms({enabled, })`
+`getUniforms(opts)`
+opts can contain following keys:
+* `pickingSelectedColorValid` (*boolean*) - When true current instance picking color is ignored, hence no instance is highlighted.
+* `pickingSelectedColor` (*array*) - Picking color of the currently selected instance.
+* `pickingHighlightColor` (*array*)- Color used to highlight the currently selected instance.
+* `pickingActive`=`false` (*boolean*) - When true, renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking. Default value is `false`.
 
-* `enabled`=`true` (*boolean*) - Activates picking
-* `selectedIndex`=-1 (*number*) - The index of the selected item, or -1 if no selection.
-* `highlightColor`= (*array*)- Color used to highlight the currently selected
-* `active`=`false` (*boolean*) - Renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking.
-
-Note that the selected item will be rendered using `highlightColor`.
+Note that the selected item will be rendered using `pickingHighlightColor`, if blending is enabled for the draw, alpha channel can be used to control the blending result.
 
 
 ## Vertex Shader Functions
@@ -59,21 +60,18 @@ Sets the color that will be returned by the fragment shader if color based picki
 
 ## Fragment Shader Functions
 
-### picking_filterFinal
+### picking_filterPickingColor
 
- If is picking enabled and active, returns the current vertex's picking color set by `picking_setPickingColor`. Otherwise returns its argument, unmodified.
+If picking active, returns the current vertex's picking color set by `picking_setPickingColor`, otherwise returns its argument unmodified.
 
-`vec4 picking_filterFinal(vec4 color)`
+`vec4 picking_filterPickingColor(vec4 color)`
 
+### picking_filterHighlightColor
 
+Returns picking highlight color if the pixel belongs to currently selected model, otherwise returns its argument unmodified.
 
-### picking_filterHighlight
-
-Returns the picking color set by `picking_setPickingColor`, if is picking enabled and active. Otherwise returns its argument, unmodified.
-
-`vec4 picking_filterHighlight(vec4 color)`
-
+`vec4 picking_filterHighlightColor(vec4 color)`
 
 ## Remarks
 
-* It is strongly recommended that `picking_filterColor` is called last in a fragment shader, as the picking color (returned when picking is enabled) must not be modified in any way (and alpha must remain 1) or picking results will not be correct.
+* It is strongly recommended that `picking_filterPickingColor` is called last in a fragment shader, as the picking color (returned when picking is enabled) must not be modified in any way (and alpha must remain 1) or picking results will not be correct.

--- a/src/shadertools/modules/picking/picking.js
+++ b/src/shadertools/modules/picking/picking.js
@@ -1,17 +1,25 @@
-const DEFAULT_HIGHLIGHT_COLOR = new Uint8Array([0, 64, 128, 64]);
+import {log} from '../../../utils';
+
+const DEFAULT_HIGHLIGHT_COLOR = new Uint8Array([0, 255, 255, 255]);
 
 const DEFAULT_MODULE_OPTIONS = {
   pickingSelectedColor: null, //  Set to a picking color to visually highlight that item
   pickingHighlightColor: DEFAULT_HIGHLIGHT_COLOR, // Color of visual highlight of "selected" item
   pickingThreshold: 1.0,
   pickingActive: false, // Set to true when rendering to off-screen "picking" buffer
-  pickingValid: false
+  pickingSelectedColorValid: false
 };
 
 /* eslint-disable camelcase */
 function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
   const uniforms = {};
-  uniforms.picking_uValid = opts.pickingValid ? 1 : 0;
+  if (opts.pickingSelectedColorValid !== undefined) {
+    uniforms.picking_uSelectedPickingColorValid = opts.pickingSelectedColorValid ? 1 : 0;
+  }
+  if (opts.pickingValid !== undefined) {
+    uniforms.picking_uSelectedPickingColorValid = opts.pickingValid ? 1 : 0;
+    log.deprecated('pickingValid', 'pickingSelectedColorValid');
+  }
   if (opts.pickingSelectedColor !== undefined) {
     if (opts.pickingSelectedColor) {
       const selectedColor = [
@@ -39,24 +47,24 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
 const vs = `\
 uniform vec3 picking_uSelectedPickingColor;
 uniform float picking_uThreshold;
-uniform bool picking_uValid;
+uniform bool picking_uSelectedPickingColorValid;
 
 varying vec4 picking_vRGBcolor_Aselected;
 
-const float COLOR_SCALE = 1. / 256.;
+const float COLOR_SCALE = 1. / 255.;
 
-bool isVertexPicked(vec3 vertexColor, vec3 pickedColor, bool pickingValid) {
+bool isVertexPicked(vec3 vertexColor) {
   return
-    pickingValid &&
-    abs(vertexColor.r - pickedColor.r) < picking_uThreshold &&
-    abs(vertexColor.g - pickedColor.g) < picking_uThreshold &&
-    abs(vertexColor.b - pickedColor.b) < picking_uThreshold;
+    picking_uSelectedPickingColorValid &&
+    abs(vertexColor.r - picking_uSelectedPickingColor.r) < picking_uThreshold &&
+    abs(vertexColor.g - picking_uSelectedPickingColor.g) < picking_uThreshold &&
+    abs(vertexColor.b - picking_uSelectedPickingColor.b) < picking_uThreshold;
 }
 
 void picking_setPickingColor(vec3 pickingColor) {
   // Do the comparison with selected item color in vertex shader as it should mean fewer compares
   picking_vRGBcolor_Aselected.a =
-    float(isVertexPicked(pickingColor, picking_uSelectedPickingColor, picking_uValid));
+    float(isVertexPicked(pickingColor));
 
   // Stores the picking color so that the fragment shader can render it during picking
   picking_vRGBcolor_Aselected.rgb = pickingColor * COLOR_SCALE;
@@ -70,14 +78,14 @@ uniform vec4 picking_uHighlightColor;
 
 varying vec4 picking_vRGBcolor_Aselected;
 
-const float COLOR_SCALE = 1. / 256.;
+const float COLOR_SCALE = 1. / 255.;
 
 /*
  * Returns highlight color if this item is selected.
  */
 vec4 picking_filterHighlightColor(vec4 color) {
   bool selected = bool(picking_vRGBcolor_Aselected.a);
-  return selected ? picking_uHighlightColor : color;
+  return selected ? (picking_uHighlightColor * COLOR_SCALE) : color;
 }
 
 /*


### PR DESCRIPTION
- Copy enhanced picking module from deck.gl to luma.gl
- Fix documentation.

Fix for #890.
Next step:  Remove picking module from deck.gl. (Once this change is published in an alpha release)

Verified with, `test-browser`, `examples`.