### PR TITLE
Fix performance in picking path

### DIFF
--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -532,10 +532,12 @@ export default class Framebuffer extends Resource {
   }
 
   log({priority = 0, message = ''} = {}) {
-    message = message || `Framebuffer ${this.id}`;
-    if (typeof window !== 'undefined') { // Let's not try this under node
-      log.image({priority, message, image: this.copyToDataUrl({maxHeight: 100})}, message);
+    if (priority > log.priority || typeof window === 'undefined') {
+      return this;
     }
+    message = message || `Framebuffer ${this.id}`;
+    const image = this.copyToDataUrl({maxHeight: 100});
+    log.image({priority, message, image}, message);
     return this;
   }
 


### PR DESCRIPTION
- Avoid framebuffer logging when priority is not set.

Verified with `test-browser`, `examples`, framebuffer logging using shadowMap example.