### PR TITLE
Do not issue duplicate warnings

### DIFF
--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -23,14 +23,14 @@ const log = {
   once(priority, arg, ...args) {
     if (!cache[arg]) {
       log.log(priority, arg, ...args);
+      cache[arg] = true;
     }
-    cache[arg] = true;
   },
   warn(arg, ...args) {
     if (!cache[arg]) {
       console.warn(`luma.gl: ${arg}`, ...args);
+      cache[arg] = true;
     }
-    cache[arg] = true;
   },
   error(arg, ...args) {
     console.error(`luma.gl: ${arg}`, ...args);

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -27,7 +27,9 @@ const log = {
     cache[arg] = true;
   },
   warn(arg, ...args) {
-    console.warn(`luma.gl: ${arg}`, ...args);
+    if (!cache[arg]) {
+      console.warn(`luma.gl: ${arg}`, ...args);
+    }
     cache[arg] = true;
   },
   error(arg, ...args) {


### PR DESCRIPTION
Warning messages were cached, but `log.warn` did not check cache before printing to console.

Fixes https://github.com/uber/luma.gl/issues/340.