### PR TITLE
Disable picking uniform warnings

### DIFF
--- a/src/core/model.js
+++ b/src/core/model.js
@@ -291,7 +291,9 @@ in a future version. Use shader modules instead.`);
 
   // TODO - should actually set the uniforms
   setUniforms(uniforms = {}) {
-    this._checkForDeprecatedUniforms(uniforms);
+    // TODO: we are still setting these uniforms in deck.gl so we don't break any external
+    // application using them, these will be removed in 5.0 release, enable warnings then.
+    // this._checkForDeprecatedUniforms(uniforms);
     checkUniformValues(uniforms, this.id);
     Object.assign(this.uniforms, uniforms);
     this.setNeedsRedraw();


### PR DESCRIPTION
In deck.gl#1045 PR, all examples are upgraded to use luma.gl `picking` module, but external apps might still be using old custom picking uniforms (which are always set), to avoid un-necessary warning disabling these deprecated warning for now, will re-enable in next major release.