### PR TITLE
Fix the platform define

### DIFF
--- a/src/shadertools/lib/platform-defines.js
+++ b/src/shadertools/lib/platform-defines.js
@@ -31,13 +31,11 @@ export function getPlatformShaderDefines(gl) {
     platformDefines += `\
 #define NVIDIA_GPU
 #define NVIDIA_FP64_WORKAROUND 1
-#define NVIDIA_EQUATION_WORKAROUND 1
 `;
   } else if (checkRendererVendor(debugInfo, 'intel')) {
     platformDefines += `\
 #define INTEL_GPU
 #define INTEL_FP64_WORKAROUND 1
-#define NVIDIA_EQUATION_WORKAROUND 1\n \
 #define INTEL_TAN_WORKAROUND 1
 `;
   } else if (checkRendererVendor(debugInfo, 'amd')) {

--- a/src/shadertools/lib/platform-defines.js
+++ b/src/shadertools/lib/platform-defines.js
@@ -30,21 +30,27 @@ export function getPlatformShaderDefines(gl) {
   if (checkRendererVendor(debugInfo, 'nvidia')) {
     platformDefines += `\
 #define NVIDIA_GPU
-#define NVIDIA_FP64_WORKAROUND 1
+// Nvidia optimizes away the calculation necessary for emulated fp64
+#define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
 `;
   } else if (checkRendererVendor(debugInfo, 'intel')) {
     platformDefines += `\
 #define INTEL_GPU
-#define INTEL_FP64_WORKAROUND 1
-#define INTEL_TAN_WORKAROUND 1
+// Intel optimizes away the calculation necessary for emulated fp64
+#define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
+// Intel's built-in 'tan' function doesn't have acceptable precision
+#define LUMA_FP32_TAN_PRECISION_WORKAROUND 1
 `;
   } else if (checkRendererVendor(debugInfo, 'amd')) {
+    // AMD Does not eliminate fp64 code
     platformDefines += `\
 #define AMD_GPU
 `;
   } else {
     platformDefines += `\
 #define DEFAULT_GPU
+// Prevent driver from optimizing away the calculation necessary for emulated fp64
+#define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
 `;
   }
 

--- a/src/shadertools/modules/fp32/fp32.js
+++ b/src/shadertools/modules/fp32/fp32.js
@@ -1,5 +1,5 @@
 const fp32shader = `\
-#ifdef INTEL_TAN_WORKAROUND
+#ifdef LUMA_FP32_TAN_PRECISION_WORKAROUND
 
 // All these functions are for substituting tan() function from Intel GPU only
 const float TWO_PI = 6.2831854820251465;
@@ -143,7 +143,7 @@ float tan_taylor_fp32(float a) {
 #endif
 
 float tan_fp32(float a) {
-#ifdef INTEL_TAN_WORKAROUND
+#ifdef LUMA_FP32_TAN_PRECISION_WORKAROUND
   return tan_taylor_fp32(a);
 #else
   return tan(a);

--- a/src/shadertools/modules/fp64/fp64-arithmetic.glsl.js
+++ b/src/shadertools/modules/fp64/fp64-arithmetic.glsl.js
@@ -39,7 +39,7 @@ vec2 split(float a) {
 }
 #endif
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 vec2 quickTwoSum(float a, float b) {
   float sum = (a + b) * ONE;
   float err = b - (sum - a) * ONE;
@@ -53,7 +53,7 @@ vec2 quickTwoSum(float a, float b) {
 }
 #endif
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 
 /* The purpose of this workaround is to prevent shader compilers from
 optimizing away necessary arithmetic operations by swapping their sequences
@@ -82,7 +82,7 @@ vec2 twoSum(float a, float b) {
 }
 #endif
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 /* Same thing as in twoSum() */
 vec2 twoSub(float a, float b) {
   float s = (a - b);
@@ -99,7 +99,7 @@ vec2 twoSub(float a, float b) {
 }
 #endif
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 vec2 twoSqr(float a) {
   float prod = a * a;
   vec2 a_fp64 = split(a);

--- a/src/shadertools/modules/fp64/fp64-functions.glsl.js
+++ b/src/shadertools/modules/fp64/fp64-functions.glsl.js
@@ -271,7 +271,7 @@ vec2 sin_fp64(vec2 a) {
     vec2 u = vec2(0.0, 0.0);
     vec2 v = vec2(0.0, 0.0);
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
     if (abs(float(abs_k) - 1.0) < 0.5) {
         u = COS_TABLE_0_FP64;
         v = SIN_TABLE_0_FP64;
@@ -381,7 +381,7 @@ vec2 cos_fp64(vec2 a) {
     vec2 u = vec2(0.0, 0.0);
     vec2 v = vec2(0.0, 0.0);
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
     if (abs(float(abs_k) - 1.0) < 0.5) {
         u = COS_TABLE_0_FP64;
         v = SIN_TABLE_0_FP64;
@@ -491,7 +491,7 @@ vec2 tan_fp64(vec2 a) {
         s = sin_t;
         c = cos_t;
     } else {
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
         if (abs(float(abs_k) - 1.0) < 0.5) {
             u = COS_TABLE_0_FP64;
             v = SIN_TABLE_0_FP64;

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
 /* global console, window, Image */
 
+console.debug = console.debug || console.log;
+
 const cache = {};
 
 const log = {

--- a/src/webgl-utils/format-glsl-error.js
+++ b/src/webgl-utils/format-glsl-error.js
@@ -62,7 +62,7 @@ function formatErrors(errors, lines) {
       const segments = error.split(':', 3);
       const type = segments[0];
       const column = parseInt(segments[1], 10) || 0;
-      const err = error.substr(segments.join(':').length + 1).trim();
+      const err = error.substring(segments.join(':').length + 1).trim();
       message += padLeft(`^^^ ${type}: ${err}\n\n`, column);
     }
   }

--- a/src/webgl/context.js
+++ b/src/webgl/context.js
@@ -139,8 +139,8 @@ export function createGLContext(opts = {}) {
     // Debug forces log level to at least 1
     log.priority = Math.max(log.priority, 1);
     // Log some debug info about the context
-    logInfo(gl);
   }
+  logInfo(gl);
 
   // Add to seer integration
 
@@ -162,7 +162,7 @@ function logInfo(gl) {
   const info = glGetDebugInfo(gl);
   const driver = info ? `(${info.vendor} ${info.renderer})` : '';
   const debug = gl.debug ? 'debug' : '';
-  log.log(0, `luma.gl: Created ${webGL} ${debug} context ${driver}`, gl);
+  log.once(0, `luma.gl: Created ${webGL} ${debug} context ${driver}`, gl);
 }
 
 // Create headless gl context (for running under Node.js)

--- a/test/webgl-utils/format-glsl-error.spec.js
+++ b/test/webgl-utils/format-glsl-error.spec.js
@@ -1038,23 +1038,23 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 
  965:     radiusMinPixels, radiusMaxPixels
  966:   );
- 967:
+ 967: 
 ^^^ ERROR: 'project_scale' : no matching overloaded function found
 
  992:   vertex_pos_modelspace[3] = vec2(1.0, 0.0);
- 993:
+ 993: 
  994:   gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
 ^^^ ERROR: 'project_scale' : no matching overloaded function found
 
 
- 262:
+ 262: 
  263:   float x = 1.0 / sqrt(a.x);
  264:   float yn = a.x * x;
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  292:   if (a.x == 0.0 && a.y == 0.0) return vec2(1.0, 0.0);
  293:   if (a.x == 1.0 && a.y == 0.0) return E_FP64;
- 294:
+ 294: 
 ^^^ WARNING: '/' : Divide by zero during constant folding
 
  342:   vec2 x = vec2(log(a.x), 0.0);
@@ -1063,7 +1063,7 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  445:     }
- 446:
+ 446: 
  447:     t = sub_fp64(r, mul_fp64(PI_2_FP64, vec2(q, 0.0)));
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
@@ -1073,7 +1073,7 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  555:     }
- 556:
+ 556: 
  557:     t = sub_fp64(r, mul_fp64(PI_2_FP64, vec2(q, 0.0)));
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
@@ -1083,7 +1083,7 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  667:     }
- 668:
+ 668: 
  669:     t = sub_fp64(r, mul_fp64(PI_2_FP64, vec2(q, 0.0)));
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 

--- a/test/webgl-utils/format-glsl-error.spec.js
+++ b/test/webgl-utils/format-glsl-error.spec.js
@@ -114,7 +114,7 @@ vec2 split(float a) {
 }
 #endif
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 vec2 quickTwoSum(float a, float b) {
   float sum = (a + b) * ONE;
   float err = b - (sum - a) * ONE;
@@ -145,7 +145,7 @@ vec2 nint_fp64(vec2 a) {
     return tmp;
 }
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 
 /* The purpose of this workaround is to prevent compilers from
 optimizing away necessary arithmetic operations by swapping their sequences
@@ -174,7 +174,7 @@ vec2 twoSum(float a, float b) {
 }
 #endif
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 /* Same thing as in twoSum() */
 vec2 twoSub(float a, float b) {
   float s = (a - b);
@@ -200,7 +200,7 @@ vec2 twoProd(float a, float b) {
   return vec2(prod, err);
 }
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
 vec2 twoSqr(float a) {
   float prod = a * a;
   vec2 a_fp64 = split(a);
@@ -475,7 +475,7 @@ vec2 sin_fp64(vec2 a) {
     vec2 u = vec2(0.0, 0.0);
     vec2 v = vec2(0.0, 0.0);
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
     if (abs(float(abs_k) - 1.0) < 0.5) {
         u = COS_TABLE_0_FP64;
         v = SIN_TABLE_0_FP64;
@@ -585,7 +585,7 @@ vec2 cos_fp64(vec2 a) {
     vec2 u = vec2(0.0, 0.0);
     vec2 v = vec2(0.0, 0.0);
 
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
     if (abs(float(abs_k) - 1.0) < 0.5) {
         u = COS_TABLE_0_FP64;
         v = SIN_TABLE_0_FP64;
@@ -695,7 +695,7 @@ vec2 tan_fp64(vec2 a) {
         s = sin_t;
         c = cos_t;
     } else {
-#if defined(NVIDIA_EQUATION_WORKAROUND) || defined(INTEL_EQUATION_WORKAROUND)
+#if defined(NVIDIA_FP64_WORKAROUND) || defined(INTEL_FP64_WORKAROUND)
         if (abs(float(abs_k) - 1.0) < 0.5) {
             u = COS_TABLE_0_FP64;
             v = SIN_TABLE_0_FP64;
@@ -1038,23 +1038,23 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 
  965:     radiusMinPixels, radiusMaxPixels
  966:   );
- 967: 
+ 967:
 ^^^ ERROR: 'project_scale' : no matching overloaded function found
 
  992:   vertex_pos_modelspace[3] = vec2(1.0, 0.0);
- 993: 
+ 993:
  994:   gl_Position = project_to_clipspace_fp64(vertex_pos_modelspace);
 ^^^ ERROR: 'project_scale' : no matching overloaded function found
 
 
- 262: 
+ 262:
  263:   float x = 1.0 / sqrt(a.x);
  264:   float yn = a.x * x;
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  292:   if (a.x == 0.0 && a.y == 0.0) return vec2(1.0, 0.0);
  293:   if (a.x == 1.0 && a.y == 0.0) return E_FP64;
- 294: 
+ 294:
 ^^^ WARNING: '/' : Divide by zero during constant folding
 
  342:   vec2 x = vec2(log(a.x), 0.0);
@@ -1063,7 +1063,7 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  445:     }
- 446: 
+ 446:
  447:     t = sub_fp64(r, mul_fp64(PI_2_FP64, vec2(q, 0.0)));
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
@@ -1073,7 +1073,7 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  555:     }
- 556: 
+ 556:
  557:     t = sub_fp64(r, mul_fp64(PI_2_FP64, vec2(q, 0.0)));
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
@@ -1083,7 +1083,7 @@ GLSL compilation error in vertex shader scatterplot-layer-vertex-shader-64
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 
  667:     }
- 668: 
+ 668:
  669:     t = sub_fp64(r, mul_fp64(PI_2_FP64, vec2(q, 0.0)));
 ^^^ WARNING: '/' : Zero divided by zero during constant folding generated NaN
 

--- a/test/webgl-utils/index.js
+++ b/test/webgl-utils/index.js
@@ -1,7 +1,7 @@
 // import './constants.spec';
 // import './get-error.spec';
 import './get-shader-name.spec';
-import './format-glsl-error.spec';
+// import './format-glsl-error.spec';
 import './polyfill-context.spec';
 import './track-context-state.spec';
 import './set-parameters.spec';

--- a/test/webgl-utils/index.js
+++ b/test/webgl-utils/index.js
@@ -1,7 +1,7 @@
 // import './constants.spec';
 // import './get-error.spec';
 import './get-shader-name.spec';
-// import './format-glsl-error.spec';
+import './format-glsl-error.spec';
 import './polyfill-context.spec';
 import './track-context-state.spec';
 import './set-parameters.spec';


### PR DESCRIPTION
Clean up the platform specific macro definitions.

Currently, there are two defs in our 64 bit shader files that always defined together 
#define NVIDIA_FP64_WORKAROUND 1
#define NVIDIA_EQUATION_WORKAROUND 1

this might stem from different versions of 64-bit shaders, so I consolidated them. 

Moreover, the defs on the Intel platform is not effective as "NVIDIA_EQUATION_WORKAROUND" is used there, obviously a careless copy-paste mistake. I fixed it.

I will try to test this change on all platforms available to me tomorrow, before land it.

This fix might be related to https://github.com/uber/deck.gl/issues/1071 and should be cherry-picked to the release branch as well.