### PR TITLE
Remove errant character in examples

### DIFF
--- a/examples/lessons/01/index.html
+++ b/examples/lessons/01/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/02/index.html
+++ b/examples/lessons/02/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/03/index.html
+++ b/examples/lessons/03/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/04/index.html
+++ b/examples/lessons/04/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/05/index.html
+++ b/examples/lessons/05/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/06/index.html
+++ b/examples/lessons/06/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/07/index.html
+++ b/examples/lessons/07/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/08/index.html
+++ b/examples/lessons/08/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/09/index.html
+++ b/examples/lessons/09/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>

--- a/examples/lessons/16/index.html
+++ b/examples/lessons/16/index.html
@@ -15,7 +15,7 @@
     </style>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
-  </head>a
+  </head>
 
   <body>
     <canvas id="lumagl-canvas"></canvas>


### PR DESCRIPTION
There was an errant character in many examples causing an annoying page scroll. Fixed with:

`grep -r -l "</head>a" ./ | xargs sed -i 's/head>a/head>/g'`

