### PR TITLE
ShaderCache: Add support for Program objects

### DIFF
--- a/docs/api-reference/shadertools/shader-cache.md
+++ b/docs/api-reference/shadertools/shader-cache.md
@@ -9,21 +9,24 @@ A cache of compiled shaders, keyed by shader source strings. Compilation of long
 
 Creates a new `ShaderCache` object.
 
+`new ShaderCache(gl)`
+
+Note that only objects from a single context can be cached, any attempts to use this cache with other gl contexts will result in exceptions.
+
 
 ### delete
 
 `ShaderCache.delete()`
 
 Hint to delete any unused cached shaders (currently a no-op).
-Returns itself to enable chaining.
 
 
 ### getVertexShader
 
+Returns a compiled `VertexShader` object corresponding to the supplied GLSL source code string, if possible from cache.
+
 `ShaderCache.getVertexShader(gl, source)`
 
-Returns a compiled `VertexShader` object corresponding to the supplied
-GLSL source code string, if possible from cache.
 
 * `gl` {WebGLRenderingContext} - gl context
 * `source` {String} - Source code for shader
@@ -32,8 +35,7 @@ returns {VertexShader} - a compiled vertex shader
 
 ### getFragmentShader
 
-Returns a compiled `FragmentShader` object corresponding to the supplied
-GLSL source code string, if possible from cache.
+Returns a compiled `FragmentShader` object corresponding to the supplied GLSL source code string, if possible from cache.
 
 `ShaderCache.getFragmentShader(gl, source)`
 

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -192,16 +192,14 @@ in a future version. Use shader modules instead.`);
       const assembleResult = assembleShaders(this.gl, {vs, fs, modules, defines});
       ({vs, fs} = assembleResult);
 
-      // Retrive compiled shaders from cache if exist, otherwise add to the cache.
       if (shaderCache) {
-        vs = shaderCache.getVertexShader(this.gl, vs);
-        fs = shaderCache.getFragmentShader(this.gl, fs);
+        program = shaderCache.getProgram(this.gl, {vs, fs, id: this.id});
+      } else {
+        program = new Program(this.gl, {vs, fs});
       }
 
       const {getUniforms} = assembleResult;
       this.getModuleUniforms = getUniforms || (x => {});
-
-      program = new Program(this.gl, {vs, fs});
     }
 
     this.program = program;

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -76,6 +76,26 @@ in a later version. Use \`${newUsage}\` instead`);
     if (priority <= log.priority) {
       console.groupEnd(`luma.gl: ${arg}`);
     }
+  },
+  time(priority, label) {
+    if (priority <= log.priority) {
+      // In case the platform doesn't have console.time
+      if (console.time) {
+        console.time(label);
+      } else {
+        console.info(label);
+      }
+    }
+  },
+  timeEnd(priority, label) {
+    if (priority <= log.priority) {
+      // In case the platform doesn't have console.timeEnd
+      if (console.timeEnd) {
+        console.timeEnd(label);
+      } else {
+        console.info(label);
+      }
+    }
   }
 };
 

--- a/src/webgl/context-debug.js
+++ b/src/webgl/context-debug.js
@@ -64,6 +64,7 @@ export function getDebugContext(gl) {
   // Store the debug context
   data.debugContext = debugContext;
   debugContext.debug = true;
+  debugContext.gl = gl;
 
   // Return it
   return debugContext;

--- a/test/shadertools/lib/shader-cache.spec.js
+++ b/test/shadertools/lib/shader-cache.spec.js
@@ -1,11 +1,9 @@
 import 'luma.gl/headless';
-import {createGLContext, VertexShader, FragmentShader, Program, ShaderCache} from 'luma.gl';
+import {VertexShader, FragmentShader, Program, ShaderCache} from 'luma.gl';
 
 import test from 'tape-catch';
 
-const fixture = {
-  gl: createGLContext()
-};
+import {fixture} from '../../setup';
 
 const VS1 = `
 attribute vec3 positions;
@@ -63,7 +61,8 @@ test('Experimental#ShaderCache import', t => {
 });
 
 test('Experimental#ShaderCache construct/delete', t => {
-  let shaderCache = new ShaderCache();
+  const {gl} = fixture;
+  let shaderCache = new ShaderCache({gl});
   t.ok(shaderCache instanceof ShaderCache, 'ShaderCache construction successful');
   shaderCache = shaderCache.delete();
   t.ok(shaderCache instanceof ShaderCache, 'ShaderCache delete successful');
@@ -73,7 +72,7 @@ test('Experimental#ShaderCache construct/delete', t => {
 test('Experimental#ShaderCache get cached vertex shaders', t => {
   const {gl} = fixture;
 
-  const shaderCache = new ShaderCache(gl);
+  const shaderCache = new ShaderCache({gl});
 
   const vs1 = shaderCache.getVertexShader(gl, VS1);
   const vs2 = shaderCache.getVertexShader(gl, VS2);
@@ -94,7 +93,7 @@ test('Experimental#ShaderCache get cached vertex shaders', t => {
 test('Experimental#ShaderCache get cached fragment shaders', t => {
   const {gl} = fixture;
 
-  const shaderCache = new ShaderCache(gl);
+  const shaderCache = new ShaderCache({gl});
 
   const fs1 = shaderCache.getFragmentShader(gl, FS1);
   const fs2 = shaderCache.getFragmentShader(gl, FS2);
@@ -115,7 +114,7 @@ test('Experimental#ShaderCache get cached fragment shaders', t => {
 test('Experimental#ShaderCache - construct Program from cached shaders', t => {
   const {gl} = fixture;
 
-  const shaderCache = new ShaderCache();
+  const shaderCache = new ShaderCache({gl});
   shaderCache.getVertexShader(gl, VS1);
   shaderCache.getFragmentShader(gl, FS1);
 
@@ -135,6 +134,110 @@ test('Experimental#ShaderCache - construct Program from cached shaders', t => {
   });
   t.ok(program2 instanceof Program,
     'Program constructed from cached shaders successful after delete of first program');
+
+  t.end();
+});
+
+test('Experimental#ShaderCache - check default Program caching', t => {
+  const {gl} = fixture;
+
+  // without _cachePrograms set to true, Program caching should be disabled.
+  const shaderCache = new ShaderCache({gl});
+
+  const program = shaderCache.getProgram(gl, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-1'
+  });
+  t.ok(program instanceof Program, 'Program construction successful ');
+
+  const newProgram = shaderCache.getProgram(gl, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-1'
+  });
+  t.ok(newProgram instanceof Program, 'Program construction successful ');
+
+  t.notEqual(program, newProgram, 'Should receive new program');
+
+  t.end();
+});
+
+test('Experimental#ShaderCache - check Program caching with same id', t => {
+  const {gl} = fixture;
+
+  const shaderCache = new ShaderCache({gl, _cachePrograms: true});
+
+  const program = shaderCache.getProgram(gl, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-1'
+  });
+  t.ok(program instanceof Program, 'Program construction successful ');
+
+  const cachedProgram = shaderCache.getProgram(gl, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-1'
+  });
+  t.ok(cachedProgram instanceof Program, 'Program construction successful ');
+
+  t.equal(program, cachedProgram, 'Should receive cached program');
+
+  t.end();
+});
+
+test('Experimental#ShaderCache - check Program caching with different id', t => {
+  const {gl} = fixture;
+
+  const shaderCache = new ShaderCache({gl, _cachePrograms: true});
+
+  const program = shaderCache.getProgram(gl, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-1'
+  });
+  t.ok(program instanceof Program, 'Program construction successful ');
+
+  const newProgram = shaderCache.getProgram(gl, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-2'
+  });
+  t.ok(newProgram instanceof Program, 'Program construction successful ');
+
+  t.notEqual(program, newProgram, 'Should receive new Program instance');
+
+  t.end();
+});
+
+test('Experimental#ShaderCache - check Program caching with varyings', t => {
+  const {gl2} = fixture;
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  const shaderCache = new ShaderCache({gl: gl2, _cachePrograms: true});
+
+  const program = shaderCache.getProgram(gl2, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-1',
+    varyings: ['gl_Position']
+  });
+  t.ok(program instanceof Program, 'Program construction successful ');
+
+  const newProgram = shaderCache.getProgram(gl2, {
+    vs: VS1,
+    fs: FS1,
+    id: 'id-1',
+    varyings: ['gl_Position']
+  });
+  t.ok(newProgram instanceof Program, 'Program construction successful ');
+
+  t.notEqual(program, newProgram, 'Should receive new Program instance');
 
   t.end();
 });


### PR DESCRIPTION
Fix for deck.gl issue : https://github.com/uber/deck.gl/issues/1126

Turns out creating and linking Program object for 64 bit shaders take a long time, add caching support for Program object hence, program linking is done only once per a given combination of vertex and fragment shaders.

Verified with `layer-browser`, `examples(website)` and  deck.gl `PolygonLayer` rendering when enabling `fp64` prop.

**Without this fix :**

- toggle to fp64 first time : **659.33** ms
![nochangetofp64_1](https://user-images.githubusercontent.com/9502731/32576444-d59c4906-c48b-11e7-9aac-0d7b5f9048b8.png)

- toggle to fp64 second time : **556.93** ms
![nochangetofp64_2](https://user-images.githubusercontent.com/9502731/32576494-f9bff378-c48b-11e7-9336-05e551336b8e.png)


**With this fix :**

- toggle to fp64 first time : **590.11** ms
![withchangefp64_1](https://user-images.githubusercontent.com/9502731/32576562-288dfe84-c48c-11e7-9f88-1e0d7c401ad0.png)

- toggle to fp64 second time : **84.40** ms
![withchangefp64_2](https://user-images.githubusercontent.com/9502731/32576586-39d2a7e4-c48c-11e7-9184-f93a9e140b4a.png)
