### PR TITLE
Enable Intel Tan shader WA for default GPU

### DIFF
--- a/src/shadertools/lib/platform-defines.js
+++ b/src/shadertools/lib/platform-defines.js
@@ -51,6 +51,8 @@ export function getPlatformShaderDefines(gl) {
 #define DEFAULT_GPU
 // Prevent driver from optimizing away the calculation necessary for emulated fp64
 #define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
+// Intel's built-in 'tan' function doesn't have acceptable precision
+#define LUMA_FP32_TAN_PRECISION_WORKAROUND 1
 `;
   }
 


### PR DESCRIPTION
* When GPU/Render info not avilable, apply Intel Tan shader workaround.
* I would also port this to 4.0-release branch.

Possible fix for https://github.com/uber/deck.gl/issues/1216

Verified with test-browser and examples.