### PR TITLE
Improve perf of uniform setters

### DIFF
--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -92,7 +92,7 @@ const UNIFORM_SETTERS = {
 
   [GL_BOOL]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_BOOL_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value)),
-  [GL_BOOL_VEC3]: (gl, location, value) => gl.uniform3fv(location, toIntArray(value)),
+  [GL_BOOL_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value)),
   [GL_BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value)),
 
   // uniformMatrix(false): don't transpose the matrix

--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -81,24 +81,24 @@ const UNIFORM_SETTERS = {
 
   /* eslint-disable max-len */
   [GL_FLOAT]: (gl, location, value) => gl.uniform1f(location, value),
-  [GL_FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, value),
-  [GL_FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, value),
-  [GL_FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, value),
+  [GL_FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, toFloatArray(value)),
+  [GL_FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, toFloatArray(value)),
+  [GL_FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, toFloatArray(value)),
 
   [GL_INT]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_INT_VEC2]: (gl, location, value) => gl.uniform2iv(location, new Int32Array(value)),
-  [GL_INT_VEC3]: (gl, location, value) => gl.uniform3iv(location, new Int32Array(value)),
-  [GL_INT_VEC4]: (gl, location, value) => gl.uniform4iv(location, new Int32Array(value)),
+  [GL_INT_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value)),
+  [GL_INT_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value)),
+  [GL_INT_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value)),
 
   [GL_BOOL]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_BOOL_VEC2]: (gl, location, value) => gl.uniform2iv(location, new Int32Array(value)),
-  [GL_BOOL_VEC3]: (gl, location, value) => gl.uniform3fv(location, new Int32Array(value)),
-  [GL_BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, new Int32Array(value)),
+  [GL_BOOL_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value)),
+  [GL_BOOL_VEC3]: (gl, location, value) => gl.uniform3fv(location, toIntArray(value)),
+  [GL_BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, value),
-  [GL_FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, value),
-  [GL_FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, value),
+  [GL_FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, toFloatArray(value)),
 
   [GL_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
@@ -106,17 +106,17 @@ const UNIFORM_SETTERS = {
   // WEBGL2 - unsigned integers, irregular matrices, additional texture samplers
 
   [GL_UNSIGNED_INT]: (gl, location, value) => gl.uniform1ui(location, value),
-  [GL_UNSIGNED_INT_VEC2]: (gl, location, value) => gl.uniform2uiv(location, new Uint32Array(value)),
-  [GL_UNSIGNED_INT_VEC3]: (gl, location, value) => gl.uniform3uiv(location, new Uint32Array(value)),
-  [GL_UNSIGNED_INT_VEC4]: (gl, location, value) => gl.uniform4uiv(location, new Uint32Array(value)),
+  [GL_UNSIGNED_INT_VEC2]: (gl, location, value) => gl.uniform2uiv(location, toUIntArray(value)),
+  [GL_UNSIGNED_INT_VEC3]: (gl, location, value) => gl.uniform3uiv(location, toUIntArray(value)),
+  [GL_UNSIGNED_INT_VEC4]: (gl, location, value) => gl.uniform4uiv(location, toUIntArray(value)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, value),
-  [GL_FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, value),
-  [GL_FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, value),
-  [GL_FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, value),
-  [GL_FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, value),
-  [GL_FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, value),
+  [GL_FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, toFloatArray(value)),
 
   [GL_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_SAMPLER_2D_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
@@ -133,6 +133,27 @@ const UNIFORM_SETTERS = {
   [GL_UNSIGNED_INT_SAMPLER_2D_ARRAY]: (gl, location, value) => gl.uniform1i(location, value)
   /* eslint-enable max-len */
 };
+
+function toFloatArray(value) {
+  if (value instanceof Float32Array || Array.isArray(value)) {
+    return value;
+  }
+  return Float32Array.from(value);
+}
+
+function toIntArray(value) {
+  if (value instanceof Int32Array || Array.isArray(value)) {
+    return value;
+  }
+  return Int32Array.from(value);
+}
+
+function toUIntArray(value) {
+  if (value instanceof Uint32Array || Array.isArray(value)) {
+    return value;
+  }
+  return Uint32Array.from(value);
+}
 
 export function parseUniformName(name) {
   // name = name[name.length - 1] === ']' ?

--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -81,24 +81,24 @@ const UNIFORM_SETTERS = {
 
   /* eslint-disable max-len */
   [GL_FLOAT]: (gl, location, value) => gl.uniform1f(location, value),
-  [GL_FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, toFloatArray(value)),
-  [GL_FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, toFloatArray(value)),
-  [GL_FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, toFloatArray(value)),
+  [GL_FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, toFloatArray(value, 2)),
+  [GL_FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, toFloatArray(value, 3)),
+  [GL_FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, toFloatArray(value, 4)),
 
   [GL_INT]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_INT_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value)),
-  [GL_INT_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value)),
-  [GL_INT_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value)),
+  [GL_INT_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value, 2)),
+  [GL_INT_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value, 3)),
+  [GL_INT_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value, 4)),
 
   [GL_BOOL]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_BOOL_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value)),
-  [GL_BOOL_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value)),
-  [GL_BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value)),
+  [GL_BOOL_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value, 2)),
+  [GL_BOOL_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value, 3)),
+  [GL_BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value, 4)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, toFloatArray(value)),
-  [GL_FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, toFloatArray(value)),
-  [GL_FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, toFloatArray(value, 4)),
+  [GL_FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, toFloatArray(value, 9)),
+  [GL_FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, toFloatArray(value, 16)),
 
   [GL_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
@@ -106,17 +106,17 @@ const UNIFORM_SETTERS = {
   // WEBGL2 - unsigned integers, irregular matrices, additional texture samplers
 
   [GL_UNSIGNED_INT]: (gl, location, value) => gl.uniform1ui(location, value),
-  [GL_UNSIGNED_INT_VEC2]: (gl, location, value) => gl.uniform2uiv(location, toUIntArray(value)),
-  [GL_UNSIGNED_INT_VEC3]: (gl, location, value) => gl.uniform3uiv(location, toUIntArray(value)),
-  [GL_UNSIGNED_INT_VEC4]: (gl, location, value) => gl.uniform4uiv(location, toUIntArray(value)),
+  [GL_UNSIGNED_INT_VEC2]: (gl, location, value) => gl.uniform2uiv(location, toUIntArray(value, 2)),
+  [GL_UNSIGNED_INT_VEC3]: (gl, location, value) => gl.uniform3uiv(location, toUIntArray(value, 3)),
+  [GL_UNSIGNED_INT_VEC4]: (gl, location, value) => gl.uniform4uiv(location, toUIntArray(value, 4)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, toFloatArray(value)),
-  [GL_FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, toFloatArray(value)),
-  [GL_FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, toFloatArray(value)),
-  [GL_FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, toFloatArray(value)),
-  [GL_FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, toFloatArray(value)),
-  [GL_FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, toFloatArray(value)),
+  [GL_FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, toFloatArray(value, 6)),
+  [GL_FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, toFloatArray(value, 8)),
+  [GL_FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, toFloatArray(value, 6)),
+  [GL_FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, toFloatArray(value, 12)),
+  [GL_FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, toFloatArray(value, 8)),
+  [GL_FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, toFloatArray(value, 12)),
 
   [GL_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_SAMPLER_2D_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
@@ -134,25 +134,53 @@ const UNIFORM_SETTERS = {
   /* eslint-enable max-len */
 };
 
-function toFloatArray(value) {
-  if (value instanceof Float32Array || Array.isArray(value)) {
+// Pre-located typed arrays for temporary conversion
+const FLOAT_ARRAY = [2, 3, 4, 6, 8, 9, 12, 16].reduce((arrays, length) => {
+  arrays[length] = new Float32Array(length);
+  return arrays;
+}, {});
+const INT_ARRAY = {
+  2: new Int32Array(2),
+  3: new Int32Array(3),
+  4: new Int32Array(4)
+};
+const UINT_ARRAY = {
+  2: new Uint32Array(2),
+  3: new Uint32Array(3),
+  4: new Uint32Array(4)
+};
+
+function toFloatArray(value, length) {
+  if (value instanceof Float32Array) {
     return value;
   }
-  return Float32Array.from(value);
+  const result = FLOAT_ARRAY[length];
+  for (let i = 0; i < length; i++) {
+    result[i] = value[i];
+  }
+  return result;
 }
 
-function toIntArray(value) {
-  if (value instanceof Int32Array || Array.isArray(value)) {
+function toIntArray(value, length) {
+  if (value instanceof Int32Array) {
     return value;
   }
-  return Int32Array.from(value);
+  const result = INT_ARRAY[length];
+  for (let i = 0; i < length; i++) {
+    result[i] = value[i];
+  }
+  return result;
 }
 
-function toUIntArray(value) {
-  if (value instanceof Uint32Array || Array.isArray(value)) {
+function toUIntArray(value, length) {
+  if (value instanceof Uint32Array) {
     return value;
   }
-  return Uint32Array.from(value);
+  const result = UINT_ARRAY[length];
+  for (let i = 0; i < length; i++) {
+    result[i] = value[i];
+  }
+  return result;
 }
 
 export function parseUniformName(name) {

--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -134,7 +134,7 @@ const UNIFORM_SETTERS = {
   /* eslint-enable max-len */
 };
 
-// Pre-located typed arrays for temporary conversion
+// Pre-allocated typed arrays for temporary conversion
 const FLOAT_ARRAY = [2, 3, 4, 6, 8, 9, 12, 16].reduce((arrays, length) => {
   arrays[length] = new Float32Array(length);
   return arrays;
@@ -150,6 +150,7 @@ const UINT_ARRAY = {
   4: new Uint32Array(4)
 };
 
+/* Functions to ensure the type of uniform values */
 function toFloatArray(value, length) {
   if (value instanceof Float32Array) {
     return value;

--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -81,9 +81,9 @@ const UNIFORM_SETTERS = {
 
   /* eslint-disable max-len */
   [GL_FLOAT]: (gl, location, value) => gl.uniform1f(location, value),
-  [GL_FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, new Float32Array(value)),
-  [GL_FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, new Float32Array(value)),
-  [GL_FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, new Float32Array(value)),
+  [GL_FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, value),
+  [GL_FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, value),
+  [GL_FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, value),
 
   [GL_INT]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_INT_VEC2]: (gl, location, value) => gl.uniform2iv(location, new Int32Array(value)),
@@ -96,9 +96,9 @@ const UNIFORM_SETTERS = {
   [GL_BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, new Int32Array(value)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, new Float32Array(value)),
-  [GL_FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, new Float32Array(value)),
-  [GL_FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, new Float32Array(value)),
+  [GL_FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, value),
+  [GL_FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, value),
+  [GL_FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, value),
 
   [GL_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
@@ -111,12 +111,12 @@ const UNIFORM_SETTERS = {
   [GL_UNSIGNED_INT_VEC4]: (gl, location, value) => gl.uniform4uiv(location, new Uint32Array(value)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, new Float32Array(value)),
-  [GL_FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, new Float32Array(value)),
-  [GL_FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, new Float32Array(value)),
-  [GL_FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, new Float32Array(value)),
-  [GL_FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, new Float32Array(value)),
-  [GL_FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, new Float32Array(value)),
+  [GL_FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, value),
+  [GL_FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, value),
+  [GL_FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, value),
+  [GL_FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, value),
+  [GL_FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, value),
+  [GL_FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, value),
 
   [GL_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
   [GL_SAMPLER_2D_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -22,10 +22,12 @@
 import {Bench} from 'probe.gl';
 
 import shadersBench from './shaders.bench';
+import uniformsBench from './uniforms.bench';
 
 const suite = new Bench();
 
 // add tests
+uniformsBench(suite);
 shadersBench(suite);
 
 // Run the suite

--- a/test/bench/uniforms.bench.js
+++ b/test/bench/uniforms.bench.js
@@ -22,7 +22,7 @@ import {createGLContext, Program} from 'luma.gl';
 const gl = createGLContext();
 
 const VS = `
-attribute vec3 positions;
+uniform vec3 positions;
 uniform mat4 uMVMatrix;
 uniform mat4 uPMatrix;
 void main(void) {
@@ -37,13 +37,30 @@ void main(void) {
 `;
 
 const program = new Program(gl, {vs: VS, fs: FS});
+
 const projectionMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 const projectionMatrixTyped = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+const positions = [0, 0, 1];
+const positionsTyped = new Float32Array([0, 0, 1]);
 
 export default function uniformsBench(suite) {
   return suite
 
     .group('SET UNIFORMS')
+
+    .add('Set vec3 uniform from Float32Array', () => {
+      program.setUniforms({positions: positionsTyped});
+    })
+    .add('Set vec3 uniform from cloned Float32Array', () => {
+      program.setUniforms({positions: new Float32Array(positionsTyped)});
+    })
+    .add('Set vec3 uniform from array', () => {
+      program.setUniforms({positions});
+    })
+    .add('Set vec3 uniform from new Float32Array', () => {
+      program.setUniforms({positions: new Float32Array(positions)});
+    })
+
     .add('Set mat4 uniform from Float32Array', () => {
       program.setUniforms({uPMatrix: projectionMatrixTyped});
     })

--- a/test/bench/uniforms.bench.js
+++ b/test/bench/uniforms.bench.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {createGLContext, Program} from 'luma.gl';
-const gl = createGLContext();
+const gl = createGLContext({webgl2: true});
 
 const VS = `
 uniform vec3 positions;
@@ -37,11 +37,12 @@ void main(void) {
 `;
 
 const program = new Program(gl, {vs: VS, fs: FS});
+program.use();
 
 const projectionMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
-const projectionMatrixTyped = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+const projectionMatrixTyped = new Float32Array(projectionMatrix);
 const positions = [0, 0, 1];
-const positionsTyped = new Float32Array([0, 0, 1]);
+const positionsTyped = new Float32Array(positions);
 
 export default function uniformsBench(suite) {
   return suite

--- a/test/bench/uniforms.bench.js
+++ b/test/bench/uniforms.bench.js
@@ -41,8 +41,10 @@ program.use();
 
 const projectionMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 const projectionMatrixTyped = new Float32Array(projectionMatrix);
+const projectionMatrixIntTyped = new Int32Array(projectionMatrix);
 const positions = [0, 0, 1];
 const positionsTyped = new Float32Array(positions);
+const positionsIntTyped = new Int32Array(positions);
 
 export default function uniformsBench(suite) {
   return suite
@@ -52,27 +54,21 @@ export default function uniformsBench(suite) {
     .add('Set vec3 uniform from Float32Array', () => {
       program.setUniforms({positions: positionsTyped});
     })
-    .add('Set vec3 uniform from cloned Float32Array', () => {
-      program.setUniforms({positions: new Float32Array(positionsTyped)});
-    })
-    .add('Set vec3 uniform from array', () => {
+    .add('Set vec3 uniform from plain array', () => {
       program.setUniforms({positions});
     })
-    .add('Set vec3 uniform from new Float32Array', () => {
-      program.setUniforms({positions: new Float32Array(positions)});
+    .add('Set vec3 uniform from Int32Array', () => {
+      program.setUniforms({positions: positionsIntTyped});
     })
 
     .add('Set mat4 uniform from Float32Array', () => {
       program.setUniforms({uPMatrix: projectionMatrixTyped});
     })
-    .add('Set mat4 uniform from cloned Float32Array', () => {
-      program.setUniforms({uPMatrix: new Float32Array(projectionMatrixTyped)});
-    })
-    .add('Set mat4 uniform from array', () => {
+    .add('Set mat4 uniform from plain array', () => {
       program.setUniforms({uPMatrix: projectionMatrix});
     })
-    .add('Set mat4 uniform from new Float32Array', () => {
-      program.setUniforms({uPMatrix: new Float32Array(projectionMatrix)});
+    .add('Set mat4 uniform from Int32Array', () => {
+      program.setUniforms({uPMatrix: projectionMatrixIntTyped});
     })
     ;
 }

--- a/test/bench/uniforms.bench.js
+++ b/test/bench/uniforms.bench.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import {createGLContext, Program} from 'luma.gl';
-const gl = createGLContext({webgl2: true});
+const gl = createGLContext();
 
 const VS = `
 uniform vec3 positions;

--- a/test/bench/uniforms.bench.js
+++ b/test/bench/uniforms.bench.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import {createGLContext, Program} from 'luma.gl';
+const gl = createGLContext();
+
+const VS = `
+attribute vec3 positions;
+uniform mat4 uMVMatrix;
+uniform mat4 uPMatrix;
+void main(void) {
+  gl_Position = uPMatrix * uMVMatrix * vec4(positions, 1.0);
+}
+`;
+
+const FS = `
+void main(void) {
+  gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+}
+`;
+
+const program = new Program(gl, {vs: VS, fs: FS});
+const projectionMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const projectionMatrixTyped = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+export default function uniformsBench(suite) {
+  return suite
+
+    .group('SET UNIFORMS')
+    .add('Set mat4 uniform from Float32Array', () => {
+      program.setUniforms({uPMatrix: projectionMatrixTyped});
+    })
+    .add('Set mat4 uniform from cloned Float32Array', () => {
+      program.setUniforms({uPMatrix: new Float32Array(projectionMatrixTyped)});
+    })
+    .add('Set mat4 uniform from array', () => {
+      program.setUniforms({uPMatrix: projectionMatrix});
+    })
+    .add('Set mat4 uniform from new Float32Array', () => {
+      program.setUniforms({uPMatrix: new Float32Array(projectionMatrix)});
+    })
+    ;
+}

--- a/test/webgl/uniforms.spec.js
+++ b/test/webgl/uniforms.spec.js
@@ -193,18 +193,20 @@ test('WebGL#Uniforms Program uniform locations', t => {
   t.end();
 });
 
-const testSetUniform = gl => t => {
+const testSetUniform = (gl, t) => {
   const program = new Program(gl, {
     vs: VERTEX_SHADER,
     fs: WEBGL1_FRAGMENT_SHADER
   });
   program.use();
 
-  const uniforms = Object.assign({}, WEBGL1_GOOD_UNIFORMS);
+  let uniforms = Object.assign({}, WEBGL1_GOOD_UNIFORMS);
 
+  t.comment('Test setting typed arrays');
   program.setUniforms(uniforms);
-  t.pass('Program set uniforms successful');
+  t.pass('Set typed array uniforms successful');
 
+  uniforms = {};
   for (const uniformName in WEBGL1_GOOD_UNIFORMS) {
     const value = WEBGL1_GOOD_UNIFORMS[uniformName];
     if (value.length) {
@@ -213,9 +215,11 @@ const testSetUniform = gl => t => {
     }
   }
 
+  t.comment('Test setting plain arrays');
   program.setUniforms(uniforms);
-  t.pass('Program set array uniforms successful');
+  t.pass('Set plain array uniforms successful');
 
+  uniforms = {};
   for (const uniformName in WEBGL1_GOOD_UNIFORMS) {
     const value = WEBGL1_GOOD_UNIFORMS[uniformName];
     if (value.length) {
@@ -225,8 +229,9 @@ const testSetUniform = gl => t => {
     }
   }
 
+  t.comment('Test setting malformed typed arrays');
   program.setUniforms(uniforms);
-  t.pass('Program set malformed uniforms successful');
+  t.pass('Set malformed typed array uniforms successful');
 
   t.end();
 };
@@ -234,14 +239,14 @@ const testSetUniform = gl => t => {
 test('WebGL#Uniforms Program setUniforms', t => {
   const {gl} = fixture;
 
-  testSetUniform(gl)(t);
+  testSetUniform(gl, t);
 });
 
 test('WebGL2#Uniforms Program setUniforms', t => {
   const {gl2} = fixture;
 
   if (gl2) {
-    testSetUniform(gl2)(t);
+    testSetUniform(gl2, t);
   } else {
     t.end();
   }


### PR DESCRIPTION
The methods accept either a Float32Array or an array of numbers: [uniformMatrix](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/uniformMatrix), [uniform](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/uniform)

Node / WebGL1:

| Test | Result |
| ----- | ------ |
| Set vec3 uniform from Float32Array | 870k iterations/s (0.12s) |
| Set vec3 uniform from cloned Float32Array | 467k iterations/s (0.21s) |
| Set vec3 uniform from array | 794k iterations/s (0.13s) |
| Set vec3 uniform from new Float32Array | 505k iterations/s (0.20s) |
| Set mat4 uniform from Float32Array | 422k iterations/s (0.24s) |
| Set mat4 uniform from cloned Float32Array | 311k iterations/s (0.32s) |
| Set mat4 uniform from array | 389k iterations/s (0.26s) |
| Set mat4 uniform from new Float32Array | 296k iterations/s (0.34s) |


Browser / WebGL2 (Chrome 62):

| Test | Result |
| ----- | ------ |
| Set vec3 uniform from Float32Array | 2.10M iterations/s (0.48s) |
| Set vec3 uniform from cloned Float32Array | 1.88M iterations/s (0.53s) |
| Set vec3 uniform from array | 1.74M iterations/s (0.58s) |
| Set vec3 uniform from new Float32Array | 521k iterations/s (0.19s) |
| Set mat4 uniform from Float32Array | 1.90M iterations/s (0.53s) |
| Set mat4 uniform from cloned Float32Array | 339k iterations/s (0.29s) |
| Set mat4 uniform from array | 485k iterations/s (0.21s) |
| Set mat4 uniform from new Float32Array | 170k iterations/s (0.59s) |

Tested: node, browser, website