### PR TITLE
Fix generic attribute support

### DIFF
--- a/src/core/model.js
+++ b/src/core/model.js
@@ -460,6 +460,8 @@ count: ${this.stats.profileFrameCount}`
 
       if (attribute instanceof Buffer) {
         this.buffers[attributeName] = attribute;
+      } else if (attribute.isGeneric) {
+        this.buffers[attributeName] = attribute.value;
       } else {
         // Autocreate a buffer
         this.buffers[attributeName] =

--- a/src/webgl/program.js
+++ b/src/webgl/program.js
@@ -163,20 +163,17 @@ export default class Program extends Resource {
       const buffer = buffers[bufferName];
       // DISABLE MISSING ATTRIBUTE
       if (!buffer) {
-        // do not disable attribute at location 0
-        if (location > 0) {
-          this.vertexAttributes.disable(location);
-        }
+        this.vertexAttributes.disable(location);
       } else if (buffer instanceof Buffer) {
         const divisor = buffer.layout.instanced ? 1 : 0;
-        this.vertexAttributes.enable(location);
         this.vertexAttributes.setBuffer({location, buffer});
         this.vertexAttributes.setDivisor(location, divisor);
         drawParams.isInstanced = buffer.layout.instanced > 0;
+        this.vertexAttributes.enable(location);
         this._filledLocations[bufferName] = true;
       } else {
-        this.vertexAttributes.disable(location);
         this.vertexAttributes.setGeneric({location, array: buffer});
+        this.vertexAttributes.disable(location, true);
         this._filledLocations[bufferName] = true;
       }
     }

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -164,10 +164,15 @@ export default class VertexArray extends Resource {
   }
 
   // Disable an attribute
-  disable(location) {
-    this.bind(() => {
-      this.gl.disableVertexAttribArray(location);
-    });
+  // Perf penalty when disabling attribute 0:
+  // https://stackoverflow.com/questions/20305231/webgl-warning-attribute-0-is-disabled-
+  // this-has-significant-performance-penalt
+  disable(location, disableZero = false) {
+    if (location > 0 || disableZero) {
+      this.bind(() => {
+        this.gl.disableVertexAttribArray(location);
+      });
+    }
   }
 
   // Set the frequency divisor used for instanced rendering.

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -36,6 +36,7 @@ const PARAMETERS = [
   GL_VERTEX_ATTRIB_ARRAY_DIVISOR
 ];
 
+const ERR_GENERIC_ATTRBUTE_LENGTH = 'vertex attribute size must be between 1 and 4';
 const ERR_ELEMENTS = 'elements must be GL.ELEMENT_ARRAY_BUFFER';
 
 export default class VertexArray extends Resource {
@@ -165,12 +166,9 @@ export default class VertexArray extends Resource {
 
   // Disable an attribute
   disable(location) {
-    // Don't disable location 0
-    if (location > 0) {
-      this.bind(() => {
-        this.gl.disableVertexAttribArray(location);
-      });
-    }
+    this.bind(() => {
+      this.gl.disableVertexAttribArray(location);
+    });
   }
 
   // Set the frequency divisor used for instanced rendering.
@@ -221,20 +219,48 @@ export default class VertexArray extends Resource {
 
     switch (array.constructor) {
     case Float32Array:
-      gl.vertexAttrib4fv(location, array);
+      this._setGenericFloatArray(location, array);
       break;
     case Int32Array:
       assert(isWebGL2(gl));
-      gl.vertexAttribI4iv(location, array);
+      this._setGenericIntArray(location, array);
       break;
     case Uint32Array:
       assert(isWebGL2(gl));
-      gl.vertexAttribI4uiv(location, array);
+      this._setGenericUintArray(location, array);
       break;
     default:
     }
+  }
 
-    return this;
+  _setGenericFloatArray(location, array) {
+    switch (array.length) {
+    case 1: this.gl.vertexAttrib1fv(location, array); break;
+    case 2: this.gl.vertexAttrib2fv(location, array); break;
+    case 3: this.gl.vertexAttrib3fv(location, array); break;
+    case 4: this.gl.vertexAttrib4fv(location, array); break;
+    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
+    }
+  }
+
+  _setGenericIntArray(location, array) {
+    switch (array.length) {
+    case 1: this.gl.vertexAttribI1iv(location, array); break;
+    case 2: this.gl.vertexAttribI2iv(location, array); break;
+    case 3: this.gl.vertexAttribI3iv(location, array); break;
+    case 4: this.gl.vertexAttribI4iv(location, array); break;
+    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
+    }
+  }
+
+  _setGenericUintArray(location, array) {
+    switch (array.length) {
+    case 1: this.gl.vertexAttribI1uiv(location, array); break;
+    case 2: this.gl.vertexAttribI2uiv(location, array); break;
+    case 3: this.gl.vertexAttribI3uiv(location, array); break;
+    case 4: this.gl.vertexAttribI4uiv(location, array); break;
+    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
+    }
   }
 
   // Specify values for generic vertex attributes
@@ -245,7 +271,7 @@ export default class VertexArray extends Resource {
     case 2: this.gl.vertexAttrib2f(location, v0, v1); break;
     case 3: this.gl.vertexAttrib3f(location, v0, v1, v2); break;
     case 4: this.gl.vertexAttrib4f(location, v0, v1, v2, v3); break;
-    default: throw new Error('vertex attribute size must be between 1 and 4');
+    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
     }
 
     // assert(gl instanceof WebGL2RenderingContext, 'WebGL2 required');

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -36,7 +36,6 @@ const PARAMETERS = [
   GL_VERTEX_ATTRIB_ARRAY_DIVISOR
 ];
 
-const ERR_GENERIC_ATTRBUTE_LENGTH = 'vertex attribute size must be between 1 and 4';
 const ERR_ELEMENTS = 'elements must be GL.ELEMENT_ARRAY_BUFFER';
 
 export default class VertexArray extends Resource {
@@ -212,66 +211,65 @@ export default class VertexArray extends Resource {
 
   // Specify values for generic vertex attributes
   setGeneric({location, array}) {
-    log.warn(0, 'VertexAttributes.setGeneric is not well tested');
-    // throw new Error('vertex attribute size must be between 1 and 4');
-
-    const {gl} = this;
-
     switch (array.constructor) {
     case Float32Array:
       this._setGenericFloatArray(location, array);
       break;
     case Int32Array:
-      assert(isWebGL2(gl));
       this._setGenericIntArray(location, array);
       break;
     case Uint32Array:
-      assert(isWebGL2(gl));
       this._setGenericUintArray(location, array);
       break;
     default:
+      this.setGenericValues(location, ...array);
     }
   }
 
   _setGenericFloatArray(location, array) {
+    const {gl} = this;
     switch (array.length) {
-    case 1: this.gl.vertexAttrib1fv(location, array); break;
-    case 2: this.gl.vertexAttrib2fv(location, array); break;
-    case 3: this.gl.vertexAttrib3fv(location, array); break;
-    case 4: this.gl.vertexAttrib4fv(location, array); break;
-    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
+    case 1: gl.vertexAttrib1fv(location, array); break;
+    case 2: gl.vertexAttrib2fv(location, array); break;
+    case 3: gl.vertexAttrib3fv(location, array); break;
+    case 4: gl.vertexAttrib4fv(location, array); break;
+    default: assert(false);
     }
   }
 
   _setGenericIntArray(location, array) {
+    const {gl} = this;
+    assert(isWebGL2(gl));
     switch (array.length) {
-    case 1: this.gl.vertexAttribI1iv(location, array); break;
-    case 2: this.gl.vertexAttribI2iv(location, array); break;
-    case 3: this.gl.vertexAttribI3iv(location, array); break;
-    case 4: this.gl.vertexAttribI4iv(location, array); break;
-    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
+    case 1: gl.vertexAttribI1iv(location, array); break;
+    case 2: gl.vertexAttribI2iv(location, array); break;
+    case 3: gl.vertexAttribI3iv(location, array); break;
+    case 4: gl.vertexAttribI4iv(location, array); break;
+    default: assert(false);
     }
   }
 
   _setGenericUintArray(location, array) {
+    const {gl} = this;
+    assert(isWebGL2(gl));
     switch (array.length) {
-    case 1: this.gl.vertexAttribI1uiv(location, array); break;
-    case 2: this.gl.vertexAttribI2uiv(location, array); break;
-    case 3: this.gl.vertexAttribI3uiv(location, array); break;
-    case 4: this.gl.vertexAttribI4uiv(location, array); break;
-    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
+    case 1: gl.vertexAttribI1uiv(location, array); break;
+    case 2: gl.vertexAttribI2uiv(location, array); break;
+    case 3: gl.vertexAttribI3uiv(location, array); break;
+    case 4: gl.vertexAttribI4uiv(location, array); break;
+    default: assert(false);
     }
   }
 
   // Specify values for generic vertex attributes
   setGenericValues(location, v0, v1, v2, v3) {
-    log.warn(0, 'VertexAttributes.setGenericValues is not well tested');
+    const {gl} = this;
     switch (arguments.length - 1) {
-    case 1: this.gl.vertexAttrib1f(location, v0); break;
-    case 2: this.gl.vertexAttrib2f(location, v0, v1); break;
-    case 3: this.gl.vertexAttrib3f(location, v0, v1, v2); break;
-    case 4: this.gl.vertexAttrib4f(location, v0, v1, v2, v3); break;
-    default: throw new Error(ERR_GENERIC_ATTRBUTE_LENGTH);
+    case 1: gl.vertexAttrib1f(location, v0); break;
+    case 2: gl.vertexAttrib2f(location, v0, v1); break;
+    case 3: gl.vertexAttrib3f(location, v0, v1, v2); break;
+    case 4: gl.vertexAttrib4f(location, v0, v1, v2, v3); break;
+    default: assert(false);
     }
 
     // assert(gl instanceof WebGL2RenderingContext, 'WebGL2 required');

--- a/test/webgl/vertex-array.spec.js
+++ b/test/webgl/vertex-array.spec.js
@@ -57,9 +57,7 @@ test('WebGL#VertexAttributes#enable', t => {
     vertexAttributes.disable(i);
   }
 
-  t.equal(vertexAttributes.getParameter(GL.VERTEX_ATTRIB_ARRAY_ENABLED, {location: 0}), true,
-    'vertex attribute 0 should **NOT** be disabled');
-  for (let i = 1; i < MAX_ATTRIBUTES; i++) {
+  for (let i = 0; i < MAX_ATTRIBUTES; i++) {
     t.equal(vertexAttributes.getParameter(GL.VERTEX_ATTRIB_ARRAY_ENABLED, {location: i}), false,
       `vertex attribute ${i} should now be disabled`);
   }

--- a/test/webgl/vertex-array.spec.js
+++ b/test/webgl/vertex-array.spec.js
@@ -57,7 +57,9 @@ test('WebGL#VertexAttributes#enable', t => {
     vertexAttributes.disable(i);
   }
 
-  for (let i = 0; i < MAX_ATTRIBUTES; i++) {
+  t.equal(vertexAttributes.getParameter(GL.VERTEX_ATTRIB_ARRAY_ENABLED, {location: 0}), true,
+    'vertex attribute 0 should **NOT** be disabled');
+  for (let i = 1; i < MAX_ATTRIBUTES; i++) {
     t.equal(vertexAttributes.getParameter(GL.VERTEX_ATTRIB_ARRAY_ENABLED, {location: i}), false,
       `vertex attribute ${i} should now be disabled`);
   }


### PR DESCRIPTION
- Fix: `VertexArray.setGeneric`
- New: `isGeneric` flag in attribute definition. If `true`, treat attribute as generic. `attribute.value` must be a typed array of size 1-4 in this case.