### PR TITLE
Fix `model.render` inconsistencies

### DIFF
--- a/docs/api-reference/core/model.md
+++ b/docs/api-reference/core/model.md
@@ -52,8 +52,8 @@ model.render({
 | `setAttributes` | Sets map of attributes (Arrays or buffers) |
 | `getUniforms` | Returns map of currently stored uniforms |
 | `setUniforms` | Stores named uniforms {key, value} |
-| `render` | Takes uniforms |
-| `draw` | Applies any gl settings temporarily and calls `render` |
+| `render` | Renders the model with provided uniforms, attributes and samplers |
+| `draw` | Applies gl settings temporarily and calls `render` |
 | `onBeforeRender` | Called before model renders |
 | `onAfterRender` | Called after model renders |
 | `setProgramState` | Sets uniforms, attributes, textures, uses program |
@@ -82,6 +82,31 @@ The constructor for the Model class. Use this to create a new Model.
   * `geometry` - geometry object, from which attributes, vertex count and drawing mode are deduced.
   * `onBeforeRender` - function to be called before every time this model is drawn.
   * `onAfterRender` - function to be called after every time this model is drawn.
+
+### draw
+
+Render the model.
+
+#### Parameters
+
+* `opts` - contains following named properties.
+  * `moduleSettings` - any uniforms needed by shader modules.
+  * `uniforms` - uniform values to be used for drawing.
+  * `attributes` - attribute definitions to be used for drawing.
+  * `samplers` - texture mappings to be used for drawing.
+  * `parameters` - temporary gl settings to be applied to this draw call.
+  * `framebuffer` - if provided, render to framebuffer
+
+### render
+
+Render the model.
+
+#### Parameters
+
++ `uniforms` - uniform values to be used for drawing.
++ `attributes` - attribute definitions to be used for drawing.
++ `samplers` - texture mappings to be used for drawing.
+
 
 ## Remarks
 * All instance methods in `Model` are chainable

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,6 +16,7 @@ In v4 we added WebGL state management which automatically tracks all WebGL state
 
 `Model.draw` now supports `moduleSettings` parameters to update shader module settings.
 
+`Model.render` now supports `attributes` and `samplers` arguments to be used for drawing.
 
 ## Version 4.0
 

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -105,6 +105,7 @@ export default class Model extends Object3D {
 
     // TODO - remove?
     this.buffers = {};
+    this.samplers = {};
     this.userData = {};
     this.drawParams = {};
     this.dynamic = false;
@@ -334,13 +335,15 @@ export default class Model extends Object3D {
     return this;
   }
 
-  render(uniforms = {}, attributes = {}, parameters = {}, samplers = {}) {
+  render(uniforms = {}, attributes = {}, samplers = {}) {
     addModel(this);
 
     const resolvedUniforms = this.addViewUniforms(uniforms);
     getOverrides(this.id, resolvedUniforms);
 
     this.setUniforms(resolvedUniforms);
+    this.setAttributes(attributes);
+    Object.assign(this.samplers, samplers);
 
     log.group(LOG_DRAW_PRIORITY,
       `>>> RENDERING MODEL ${this.id}`, {collapsed: log.priority <= 2});


### PR DESCRIPTION
- `draw` calls `this.render(uniforms, attributes, samplers)` without the `parameters` argument
- `render` never uses `attributes` and `samplers`
- `setProgramState` uses `this.samplers` which is never defined

https://github.com/uber/luma.gl/issues/269

Tested: node, browser, website examples