### PR TITLE
Do not mark `needsRedraw` unless something changed

### DIFF
--- a/src/core/model.js
+++ b/src/core/model.js
@@ -12,6 +12,7 @@ import {assembleShaders} from '../shadertools';
 
 import {addModel, removeModel, logModel, getOverrides} from '../debug/seer-integration';
 import Query from '../webgl/query';
+import {equals} from 'math.gl';
 import assert from 'assert';
 
 const MSG_INSTANCED_PARAM_DEPRECATED = `\
@@ -258,9 +259,11 @@ export default class Model extends Object3D {
   }
 
   setAttributes(attributes = {}) {
-    Object.assign(this.attributes, attributes);
-    this._createBuffersFromAttributeDescriptors(attributes);
-    this.setNeedsRedraw();
+    if (Object.keys(attributes).length > 0) {
+      Object.assign(this.attributes, attributes);
+      this._createBuffersFromAttributeDescriptors(attributes);
+      this.setNeedsRedraw();
+    }
     return this;
   }
 
@@ -274,9 +277,15 @@ export default class Model extends Object3D {
     // application, these are marked deprecated in 5.0, remove them in deck.gl in 6.0.
     // Disabling since it gets too noisy in console, these are documented as deprecated.
     // this._checkForDeprecatedUniforms(uniforms);
-    checkUniformValues(uniforms, this.id);
-    Object.assign(this.uniforms, uniforms);
-    this.setNeedsRedraw();
+    const somethingChanged = Object.keys(uniforms).some(key => {
+      return !equals(uniforms[key], this.uniforms[key]);
+    });
+
+    if (somethingChanged) {
+      checkUniformValues(uniforms, this.id);
+      Object.assign(this.uniforms, uniforms);
+      this.setNeedsRedraw();
+    }
     return this;
   }
 

--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -335,3 +335,25 @@ export function getUniformsTable({
 
   return {table, count, unusedTable, unusedCount};
 }
+
+/**
+ * Given two values of a uniform, returns `true` if they are equal
+ */
+export function areUniformsEqual(uniform1, uniform2) {
+  if (Array.isArray(uniform1) || ArrayBuffer.isView(uniform1)) {
+    if (!uniform2) {
+      return false;
+    }
+    const len = uniform1.length;
+    if (uniform2.length !== len) {
+      return false;
+    }
+    for (let i = 0; i < len; i++) {
+      if (uniform1[i] !== uniform2[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return uniform1 === uniform2;
+}

--- a/test/webgl/uniforms.spec.js
+++ b/test/webgl/uniforms.spec.js
@@ -2,7 +2,7 @@
 import test from 'tape-catch';
 import {Program, Texture2D} from 'luma.gl';
 import 'luma.gl/headless';
-import {checkUniformValues} from 'luma.gl/webgl/uniforms';
+import {checkUniformValues, areUniformsEqual} from 'luma.gl/webgl/uniforms';
 
 import {fixture} from '../setup';
 
@@ -251,4 +251,65 @@ test('WebGL2#Uniforms Program setUniforms', t => {
     t.end();
   }
 
+});
+
+test('WebGL#Uniforms areUniformsEqual', t => {
+  const {gl} = fixture;
+
+  const TEST_TEXTURE = new Texture2D(gl);
+
+  const TEST_CASES = [
+    {
+      title: 'Numeric values',
+      value1: 1,
+      value2: 1,
+      equals: true
+    }, {
+      title: 'Numeric values',
+      value1: 1,
+      value2: 2,
+      equals: false
+    }, {
+      title: 'Texture objects',
+      value1: TEST_TEXTURE,
+      value2: TEST_TEXTURE,
+      equals: true
+    }, {
+      title: 'Texture objects',
+      value1: TEST_TEXTURE,
+      value2: new Texture2D(gl),
+      equals: false
+    }, {
+      title: 'null',
+      value1: null,
+      value2: null,
+      equals: true
+    }, {
+      title: 'Array vs array',
+      value1: [0, 0, 0],
+      value2: [0, 0, 0],
+      equals: true
+    }, {
+      title: 'TypedArray vs array',
+      value1: new Float32Array(3),
+      value2: [0, 0, 0],
+      equals: true
+    }, {
+      title: 'Array different length',
+      value1: [0, 0, 0, 0],
+      value2: new Float32Array(3),
+      equals: false
+    }, {
+      title: 'Array vs null',
+      value1: new Float32Array(3),
+      value2: null,
+      equals: false
+    }
+  ];
+
+  TEST_CASES.forEach(testCase => {
+    t.is(areUniformsEqual(testCase.value1, testCase.value2), testCase.equals, testCase.title);
+  });
+
+  t.end();
 });


### PR DESCRIPTION
Default calls to `updateModuleSettings` call `setUniforms` which causes deck.gl to redraw even if no uniform is changed.