### PR TITLE
closes https://github.com/uber/deck.gl/issues/1293

### DIFF
--- a/src/webgl-utils/create-canvas.js
+++ b/src/webgl-utils/create-canvas.js
@@ -5,10 +5,13 @@ import {log} from '../utils';
 
 const isBrowser = typeof window !== 'undefined';
 
-let isPageLoaded = false;
+let isPageLoaded = isBrowser && document.readyState === 'complete';
 
 const pageLoadPromise = isBrowser ?
   new Promise((resolve, reject) => {
+    if (isPageLoaded) {
+      return resolve(document);
+    }
     window.onload = () => {
       isPageLoaded = true;
       resolve(document);

--- a/src/webgl-utils/create-canvas.js
+++ b/src/webgl-utils/create-canvas.js
@@ -10,7 +10,8 @@ let isPageLoaded = isBrowser && document.readyState === 'complete';
 const pageLoadPromise = isBrowser ?
   new Promise((resolve, reject) => {
     if (isPageLoaded) {
-      return resolve(document);
+      resolve(document);
+      return
     }
     window.onload = () => {
       isPageLoaded = true;

--- a/src/webgl-utils/create-canvas.js
+++ b/src/webgl-utils/create-canvas.js
@@ -11,7 +11,7 @@ const pageLoadPromise = isBrowser ?
   new Promise((resolve, reject) => {
     if (isPageLoaded) {
       resolve(document);
-      return
+      return;
     }
     window.onload = () => {
       isPageLoaded = true;


### PR DESCRIPTION
fixes bug where promise never resolves on pages that are loaded already (https://github.com/uber/deck.gl/issues/1293)

also should potentially fix issues with hot reloading code where this will be re-executed

in the future i would recommend moving off `window.onload` and add some error handling/timeouts for this promise