### PR TITLE
Transform Feedback: Add Support to Model.draw and minor API changes.

### DIFF
--- a/docs/api-reference/core/model.md
+++ b/docs/api-reference/core/model.md
@@ -70,7 +70,8 @@ The constructor for the Model class. Use this to create a new Model.
 * `gl` - WebGL context.
 * `opts` - contains following named properties.
   * `vs` - (VertexShader|*string*) - A vertex shader object, or source as a string.
-  * `fs` - (FragmentShader|*string*) - A fragment shader object, ot source as a string.
+  * `fs` - (FragmentShader|*string*) - A fragment shader object, or source as a string.
+  * `varyings` - An array of vertex shader ouput variables, that needs to be recorded (used in Transformfeedback flow).
   * `modules` - shader modules to be applied.
   * `moduleSettings` - any uniforms needed by shader modules.
   * `program` - pre created program to use, when provided, vs, ps and modules are not used.
@@ -96,6 +97,7 @@ Render the model.
   * `samplers` - texture mappings to be used for drawing.
   * `parameters` - temporary gl settings to be applied to this draw call.
   * `framebuffer` - if provided, render to framebuffer
+  * `transformFeedback` - an instance `TranformFeedback` object, that gets activated for this rendering.
 
 ### render
 
@@ -103,9 +105,10 @@ Render the model.
 
 #### Parameters
 
-+ `uniforms` - uniform values to be used for drawing.
-+ `attributes` - attribute definitions to be used for drawing.
-+ `samplers` - texture mappings to be used for drawing.
+* `uniforms` - uniform values to be used for drawing.
+* `attributes` - attribute definitions to be used for drawing.
+* `samplers` - texture mappings to be used for drawing.
+* `transformFeedback` - an instance `TranformFeedback` object, that gets activated for this rendering.
 
 
 ## Remarks

--- a/docs/api-reference/webgl/program.md
+++ b/docs/api-reference/webgl/program.md
@@ -118,6 +118,7 @@ The heart of the luma.gl API, the `Program.draw` the entry point for running sha
 
     transformFeedback = null,
     samplers = {},
+    parameters = {},
     start,
     end
   })
@@ -136,6 +137,7 @@ The heart of the luma.gl API, the `Program.draw` the entry point for running sha
 * `transformFeedback`=`null` - optional `TransformFeedback` object containing buffers that will receive the output of the transform feedback operation.
 * `uniforms`=`{}` - a map of uniforms that will be set before the draw call.
 * `samplers`=`{}` - a map of texture `Sampler`s that will be bound before the draw call.
+* `parameters` - temporary gl settings to be applied to this draw call.
 
 Runs the shaders in the program, on the attributes and uniforms.
 * Indexed rendering uses the element buffer (`GL.ELEMENT_ARRAY_BUFFER`), make sure your attributes or `VertexArray` contains one.

--- a/docs/api-reference/webgl/transform-feedback.md
+++ b/docs/api-reference/webgl/transform-feedback.md
@@ -66,8 +66,9 @@ withSettings({[GL.RASTERIZER_DISCARD]: true]}, () => {
 
 ### constructor
 
-* `gl` (`WebGL2RenderingContext`) gl - context
-* `opts` (`Object`=`{}`) - options
+* `gl` - (`WebGL2RenderingContext`) gl - context
+* `opts` - (`Object`={}) - options
+  * `buffers` - buffers that gets bound to `TRANSFORM_FEEDBACK_BUFFER` target for recording vertex shader outputs.
 
 WebGL APIs [`gl.createTransformFeedback`](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/createTransformFeedback)
 

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -1,6 +1,6 @@
 /* eslint quotes: ["error", "single", { "allowTemplateLiterals": true }]*/
 // A scenegraph object node
-import {GL, Buffer, Program, withParameters, checkUniformValues, isWebGL} from '../webgl';
+import {GL, Buffer, Program, checkUniformValues, isWebGL} from '../webgl';
 // import {withParameters} from '../webgl/context-state';
 import {getUniformsTable, areUniformsEqual} from '../webgl/uniforms';
 import {getDrawMode} from '../geometry/geometry';
@@ -346,13 +346,11 @@ export default class Model extends Object3D {
       this.updateModuleSettings(moduleSettings);
     }
 
-    const {program: {gl}} = this;
     if (framebuffer) {
       parameters = Object.assign(parameters, {framebuffer});
     }
-    withParameters(gl, parameters,
-      () => this.render(uniforms, attributes, samplers, transformFeedback)
-    );
+
+    this.render(uniforms, attributes, samplers, transformFeedback, parameters);
 
     if (framebuffer) {
       framebuffer.log({priority: LOG_DRAW_PRIORITY, message: `Rendered to ${framebuffer.id}`});
@@ -361,7 +359,7 @@ export default class Model extends Object3D {
     return this;
   }
 
-  render(uniforms = {}, attributes = {}, samplers = {}, transformFeedback = null) {
+  render(uniforms = {}, attributes = {}, samplers = {}, transformFeedback = null, parameters = {}) {
     addModel(this);
 
     const resolvedUniforms = this.addViewUniforms(uniforms);
@@ -390,6 +388,7 @@ export default class Model extends Object3D {
     this._timerQueryStart();
 
     this.program.draw({
+      parameters,
       drawMode: this.getDrawMode(),
       vertexCount: this.getVertexCount(),
       transformFeedback,

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -329,7 +329,8 @@ export default class Model extends Object3D {
     samplers = {},
     parameters = {},
     settings,
-    framebuffer = null
+    framebuffer = null,
+    transformFeedback = null
   } = {}) {
     if (settings) {
       log.deprecated('settings', 'parameters');
@@ -345,7 +346,7 @@ export default class Model extends Object3D {
       parameters = Object.assign(parameters, {framebuffer});
     }
     withParameters(gl, parameters,
-      () => this.render(uniforms, attributes, samplers)
+      () => this.render(uniforms, attributes, samplers, transformFeedback)
     );
 
     if (framebuffer) {
@@ -355,7 +356,7 @@ export default class Model extends Object3D {
     return this;
   }
 
-  render(uniforms = {}, attributes = {}, samplers = {}) {
+  render(uniforms = {}, attributes = {}, samplers = {}, transformFeedback = null) {
     addModel(this);
 
     const resolvedUniforms = this.addViewUniforms(uniforms);
@@ -386,6 +387,7 @@ export default class Model extends Object3D {
     this.program.draw({
       drawMode: this.getDrawMode(),
       vertexCount: this.getVertexCount(),
+      transformFeedback,
       isIndexed,
       indexType,
       isInstanced,

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -72,6 +72,9 @@ export default class Model extends Object3D {
     onBeforeRender = () => {},
     onAfterRender = () => {},
 
+    // TransformFeedback
+    varyings = null,
+
     // Other opts
     timerQueryEnabled = false
   } = {}) {
@@ -83,7 +86,8 @@ export default class Model extends Object3D {
       moduleSettings,
       defaultUniforms,
       program,
-      shaderCache
+      shaderCache,
+      varyings
     });
 
     this.uniforms = {};
@@ -157,7 +161,8 @@ export default class Model extends Object3D {
     moduleSettings,
     defaultUniforms,
     program,
-    shaderCache
+    shaderCache,
+    varyings
   }) {
 
     this.getModuleUniforms = x => {};
@@ -177,7 +182,7 @@ export default class Model extends Object3D {
       if (shaderCache) {
         program = shaderCache.getProgram(this.gl, {vs, fs, id: this.id});
       } else {
-        program = new Program(this.gl, {vs, fs});
+        program = new Program(this.gl, {vs, fs, varyings});
       }
 
       const {getUniforms} = assembleResult;

--- a/src/webgl/context-state.js
+++ b/src/webgl/context-state.js
@@ -138,6 +138,18 @@ export function setParameters(gl, parameters) {
 export function withParameters(gl, parameters, func) {
   // assertWebGLContext(gl);
 
+  let emptyParametes = true;
+  /* eslint-disable no-unused-vars  */
+  for (const key in parameters) {
+    emptyParametes = false;
+    break;
+  }
+  /* eslint-enable no-unused-vars  */
+
+  if (emptyParametes) {
+    return func(gl);
+  }
+
   const {nocatch = true} = parameters;
   // frameBuffer not supported use framebuffer
   assert(!parameters.frameBuffer);

--- a/src/webgl/context-state.js
+++ b/src/webgl/context-state.js
@@ -138,15 +138,16 @@ export function setParameters(gl, parameters) {
 export function withParameters(gl, parameters, func) {
   // assertWebGLContext(gl);
 
-  let emptyParametes = true;
+  let emptyParameters = true;
   /* eslint-disable no-unused-vars  */
   for (const key in parameters) {
-    emptyParametes = false;
+    emptyParameters = false;
     break;
   }
   /* eslint-enable no-unused-vars  */
 
-  if (emptyParametes) {
+  if (emptyParameters) {
+    // Avoid setting state if no parameters provided. Just call and return
     return func(gl);
   }
 

--- a/src/webgl/program.js
+++ b/src/webgl/program.js
@@ -86,19 +86,19 @@ export default class Program extends Resource {
     transformFeedback = null,
     uniforms = {},
     samplers = {},
-    parameters = {}
+    parameters = null
   }) {
     vertexArray = vertexArray || VertexArray.getDefaultArray(this.gl);
     vertexArray.bind(() => {
 
       this.gl.useProgram(this.handle);
 
-      if (transformFeedback) {
-        if (parameters[GL.RASTERIZER_DISCARD]) {
-          // bypass fragment shader
-          this.gl.enable(GL.RASTERIZER_DISCARD);
-        }
+      if (parameters) {
+        log.error('Program.draw({prameters}) not needed to disable RASTERIZATION, \
+          it is implict when transformFeedback parameter passed to input object');
+      }
 
+      if (transformFeedback) {
         const primitiveMode = getTransformFeedbackMode({drawMode});
         transformFeedback.begin(primitiveMode);
       }
@@ -122,11 +122,6 @@ export default class Program extends Resource {
 
       if (transformFeedback) {
         transformFeedback.end();
-
-        if (parameters[GL.RASTERIZER_DISCARD]) {
-          // resume fragment shader
-          this.gl.disable(GL.RASTERIZER_DISCARD);
-        }
       }
 
     });

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -34,7 +34,7 @@ export default class TranformFeedback extends Resource {
     this.bindBuffers(buffers, {clear: true});
   }
 
-  bindBuffers(buffers = {}, {clear, varyingMap = {}}) {
+  bindBuffers(buffers = {}, {clear = false, varyingMap = {}} = {}) {
     if (clear) {
       this._unbindBuffers();
       this.buffers = {};

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -52,6 +52,7 @@ export default class TranformFeedback extends Resource {
   // program.use, should we move these methods (begin/pause/resume/end) to the Program?
   begin(primitiveMode) {
     this._bindBuffers();
+    this.gl.enable(GL.RASTERIZER_DISCARD);
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
     this.gl.beginTransformFeedback(primitiveMode);
     return this;
@@ -62,11 +63,13 @@ export default class TranformFeedback extends Resource {
     this.gl.pauseTransformFeedback();
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
+    this.gl.disable(GL.RASTERIZER_DISCARD);
     return this;
   }
 
   resume() {
     this._bindBuffers();
+    this.gl.enable(GL.RASTERIZER_DISCARD);
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
     this.gl.resumeTransformFeedback();
     return this;
@@ -77,6 +80,7 @@ export default class TranformFeedback extends Resource {
     this.gl.endTransformFeedback();
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
+    this.gl.disable(GL.RASTERIZER_DISCARD);
     return this;
   }
 

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -52,7 +52,6 @@ export default class TranformFeedback extends Resource {
   // program.use, should we move these methods (begin/pause/resume/end) to the Program?
   begin(primitiveMode) {
     this._bindBuffers();
-    this.gl.enable(GL.RASTERIZER_DISCARD);
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
     this.gl.beginTransformFeedback(primitiveMode);
     return this;
@@ -63,13 +62,11 @@ export default class TranformFeedback extends Resource {
     this.gl.pauseTransformFeedback();
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
-    this.gl.disable(GL.RASTERIZER_DISCARD);
     return this;
   }
 
   resume() {
     this._bindBuffers();
-    this.gl.enable(GL.RASTERIZER_DISCARD);
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
     this.gl.resumeTransformFeedback();
     return this;
@@ -80,7 +77,6 @@ export default class TranformFeedback extends Resource {
     this.gl.endTransformFeedback();
     this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
-    this.gl.disable(GL.RASTERIZER_DISCARD);
     return this;
   }
 

--- a/test/webgl/context-state.spec.js
+++ b/test/webgl/context-state.spec.js
@@ -381,3 +381,39 @@ test('WebGLState#withParameters framebuffer', t => {
 
   t.end();
 });
+
+test('WebGLState#withParameters empty parameters object', t => {
+  const {gl} = fixture;
+
+  resetParameters(gl);
+
+  setParameters(gl, {
+    clearColor: [0, 0, 0, 0],
+    [GL.BLEND]: false
+  });
+
+  let clearColor = getParameter(gl, GL.COLOR_CLEAR_VALUE);
+  let blendState = getParameter(gl, GL.BLEND);
+  t.deepEqual(clearColor, [0, 0, 0, 0],
+    `got expected value ${stringifyTypedArray(clearColor)}`);
+  t.deepEqual(blendState, false,
+    `got expected value ${stringifyTypedArray(blendState)}`);
+
+  withParameters(gl, {}, () => {
+    clearColor = getParameter(gl, GL.COLOR_CLEAR_VALUE);
+    blendState = getParameter(gl, GL.BLEND);
+    t.deepEqual(clearColor, [0, 0, 0, 0],
+      `got expected value ${stringifyTypedArray(clearColor)}`);
+    t.deepEqual(blendState, false,
+      `got expected value ${stringifyTypedArray(blendState)}`);
+  });
+
+  clearColor = getParameter(gl, GL.COLOR_CLEAR_VALUE);
+  blendState = getParameter(gl, GL.BLEND);
+  t.deepEqual(clearColor, [0, 0, 0, 0],
+    `got expected value ${stringifyTypedArray(clearColor)}`);
+  t.deepEqual(blendState, false,
+    `got expected value ${stringifyTypedArray(blendState)}`);
+
+  t.end();
+});

--- a/test/webgl/program.spec.js
+++ b/test/webgl/program.spec.js
@@ -63,3 +63,22 @@ test('WebGL#Program buffer update', t => {
 
   t.end();
 });
+
+test('WebGL#Program draw', t => {
+  const {gl} = fixture;
+
+  let program = new Program(gl, {fs, vs});
+
+  program = program.setBuffers({
+    positions: new Buffer(gl, {target: GL.ARRAY_BUFFER, data: BUFFER_DATA, size: 3}),
+    unusedAttributeName: new Buffer(gl, {target: GL.ARRAY_BUFFER, data: BUFFER_DATA, size: 3})
+  });
+
+  program.draw({vertexCount: 3});
+  t.ok(program instanceof Program, 'Program draw successful');
+
+  program.draw({vertexCount: 3, parameters: {blend: true}});
+  t.ok(program instanceof Program, 'Program draw with parameters is successful');
+
+  t.end();
+});

--- a/test/webgl/transform-feedback.spec.js
+++ b/test/webgl/transform-feedback.spec.js
@@ -1,4 +1,4 @@
-import {TransformFeedback} from 'luma.gl';
+import {TransformFeedback, Buffer} from 'luma.gl';
 import 'luma.gl/headless';
 import test from 'tape-catch';
 
@@ -33,6 +33,34 @@ test('WebGL#TransformFeedback constructor/delete', t => {
 
   tf.delete();
   t.ok(tf instanceof TransformFeedback, 'TransformFeedback repeated delete successful');
+
+  t.end();
+});
+
+test('WebGL#TransformFeedback bindBuffers', t => {
+  const {gl2} = fixture;
+
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  const tf = new TransformFeedback(gl2);
+  const buffer1 = new Buffer(gl2);
+  const buffer2 = new Buffer(gl2);
+
+  tf.bindBuffers({
+    0: buffer1,
+    1: buffer2
+  });
+  t.ok(tf instanceof TransformFeedback, 'TransformFeedback bindBuffers successful');
+
+  tf.bindBuffers({
+    0: buffer1,
+    1: buffer2
+  }, {clear: true});
+  t.ok(tf instanceof TransformFeedback, 'TransformFeedback bindBuffers with clear is successful');
 
   t.end();
 });


### PR DESCRIPTION
- Add TF support to Model class.
- Move `withParameters` from` Model.draw` to `Program.draw`, so temporary state settings can be applied in both case.
- Return early (no state push/pop) from `withParametes` when `parameters` object is empty.
  

Verified using test-browser, examples and deck.gl Wind example.