### PR TITLE
Vertex array api

### DIFF
--- a/examples/core/transform-feedback-instanced/app.js
+++ b/examples/core/transform-feedback-instanced/app.js
@@ -7,7 +7,7 @@
 
 import {
   AnimationLoop, Buffer, TransformFeedback, VertexArray,
-  setParameters, Model, Geometry
+  setParameters, Model
 } from 'luma.gl';
 
 const OFFSET_LOCATION = 0;

--- a/examples/core/transform-feedback-instanced/app.js
+++ b/examples/core/transform-feedback-instanced/app.js
@@ -138,10 +138,8 @@ const animationLoop = new AnimationLoop({
       id: 'Model-Render',
       vs: DRAW_VS,
       fs: DRAW_FS,
-      geometry: new Geometry({
-        drawMode: gl.TRIANGLE_FAN,
-        vertexCount: 3
-      }),
+      drawMode: gl.TRIANGLE_FAN,
+      vertexCount: 3,
       isInstanced: true,
       instanceCount: NUM_INSTANCES
     });
@@ -151,10 +149,8 @@ const animationLoop = new AnimationLoop({
       vs: EMIT_VS,
       fs: EMIT_FS,
       varyings: EMIT_VARYINGS,
-      geometry: new Geometry({
-        drawMode: gl.POINTS,
-        vertexCount: NUM_INSTANCES
-      }),
+      drawMode: gl.POINTS,
+      vertexCount: NUM_INSTANCES,
       isInstanced: false
     });
 

--- a/examples/core/transform-feedback/app.css
+++ b/examples/core/transform-feedback/app.css
@@ -1,8 +1,0 @@
-body {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 13px;
-  -webkit-font-smoothing: antialiased;
-  margin:0;
-  padding:0;
-  overflow:hidden;
-}

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -258,6 +258,9 @@ export default class Model extends Object3D {
 
   // TODO - just set attributes, don't hold on to geometry
   setGeometry(geometry) {
+    if (!geometry) {
+      return this;
+    }
     this.geometry = geometry;
     this.vertexCount = geometry.getVertexCount();
     this.drawMode = geometry.drawMode;

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -6,7 +6,7 @@ import {getUniformsTable, areUniformsEqual} from '../webgl/uniforms';
 import {getDrawMode} from '../geometry/geometry';
 
 import Object3D from '../core/object-3d';
-import {log, formatValue} from '../utils';
+import {log, formatValue, isObjectEmpty} from '../utils';
 import {MODULAR_SHADERS} from '../shadertools/shaders';
 import {assembleShaders} from '../shadertools';
 
@@ -118,7 +118,9 @@ export default class Model extends Object3D {
     this.needsRedraw = true;
 
     // Attributes and buffers
-    this.setGeometry(geometry);
+    if (geometry) {
+      this.setGeometry(geometry);
+    }
 
     this.attributes = {};
     this.setAttributes(attributes);
@@ -258,9 +260,6 @@ export default class Model extends Object3D {
 
   // TODO - just set attributes, don't hold on to geometry
   setGeometry(geometry) {
-    if (!geometry) {
-      return this;
-    }
     this.geometry = geometry;
     this.vertexCount = geometry.getVertexCount();
     this.drawMode = geometry.drawMode;
@@ -274,19 +273,15 @@ export default class Model extends Object3D {
   }
 
   setAttributes(attributes = {}) {
-    let isEmpty = true;
-    /* eslint-disable no-unused-vars */
-    for (const key in attributes) {
-      isEmpty = false;
-      break;
+    // Reutrn early if no attributes to set.
+    if (isObjectEmpty(attributes)) {
+      return this;
     }
-    /* eslint-enable no-unused-vars */
 
-    if (!isEmpty) {
-      Object.assign(this.attributes, attributes);
-      this._createBuffersFromAttributeDescriptors(attributes);
-      this.setNeedsRedraw();
-    }
+    Object.assign(this.attributes, attributes);
+    this._createBuffersFromAttributeDescriptors(attributes);
+    this.setNeedsRedraw();
+
     return this;
   }
 

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -391,7 +391,7 @@ export default class Model extends Object3D {
     log.group(LOG_DRAW_PRIORITY,
       `>>> RENDERING MODEL ${this.id}`, {collapsed: log.priority <= 2});
 
-    this.setProgramState();
+    this.setProgramState({vertexArray});
 
     this._logAttributesAndUniforms(2, resolvedUniforms);
 
@@ -432,11 +432,12 @@ export default class Model extends Object3D {
   }
   /* eslint-enable max-params  */
 
-  setProgramState() {
+  setProgramState({vertexArray = null} = {}) {
     const {program} = this;
     program.use();
     this.drawParams = {};
     program.setBuffers(this.buffers, {drawParams: this.drawParams});
+    program.checkAttributeBindings({vertexArray});
     program.setUniforms(this.uniforms, this.samplers);
     return this;
   }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -88,3 +88,15 @@ export function isPowerOfTwo(n) {
   assert((typeof n === 'number'), 'Input must be a number');
   return n && ((n & (n - 1)) === 0);
 }
+
+// Returns true if given object is empty, false otherwise.
+export function isObjectEmpty(obj) {
+  let isEmpty = true;
+  /* eslint-disable no-unused-vars  */
+  for (const key in obj) {
+    isEmpty = false;
+    break;
+  }
+  /* eslint-enable no-unused-vars  */
+  return isEmpty;
+}

--- a/src/webgl/context-state.js
+++ b/src/webgl/context-state.js
@@ -2,6 +2,7 @@
 import GL from '../webgl-utils/constants';
 import {pushContextState, popContextState} from '../webgl-utils/track-context-state';
 import assert from 'assert';
+import {isObjectEmpty} from '../utils';
 
 import {
   getParameter,
@@ -138,15 +139,7 @@ export function setParameters(gl, parameters) {
 export function withParameters(gl, parameters, func) {
   // assertWebGLContext(gl);
 
-  let emptyParameters = true;
-  /* eslint-disable no-unused-vars  */
-  for (const key in parameters) {
-    emptyParameters = false;
-    break;
-  }
-  /* eslint-enable no-unused-vars  */
-
-  if (emptyParameters) {
+  if (isObjectEmpty(parameters)) {
     // Avoid setting state if no parameters provided. Just call and return
     return func(gl);
   }

--- a/src/webgl/program.js
+++ b/src/webgl/program.js
@@ -169,11 +169,6 @@ export default class Program extends Resource {
     drawParams.isIndexed = false;
     drawParams.indexType = null;
 
-    // Reutrn early if no buffers to be bound.
-    if (isObjectEmpty(buffers)) {
-      return this;
-    }
-
     const {locations, elements} = this._sortBuffersByLocation(buffers);
 
     // Process locations in order
@@ -381,8 +376,14 @@ export default class Program extends Resource {
 
   _sortBuffersByLocation(buffers) {
     let elements = null;
-    const locations = new Array(this._attributeCount);
+    let locations = [];
 
+    // Reutrn early if no buffers to be bound.
+    if (isObjectEmpty(buffers)) {
+      return {locations, elements};
+    }
+
+    locations = new Array(this._attributeCount);
     for (const bufferName in buffers) {
       const buffer = buffers[bufferName];
       const location = this._attributeToLocationMap[bufferName];

--- a/website/contents/demos.js
+++ b/website/contents/demos.js
@@ -12,6 +12,8 @@ export {default as FragmentDemo} from '../../examples/core/fragment/app.js';
 export {default as PickingDemo} from '../../examples/core/picking/app.js';
 export {default as ShadowmapDemo} from '../../examples/core/shadowmap/app.js';
 export {default as TransformFeedbackDemo} from '../../examples/core/transform-feedback/app.js';
+export {default as TransformFeedbackInstancingDemo} from
+  '../../examples/core/transform-feedback-instanced/app.js';
 
 export {default as Lesson01} from '../../examples/lessons/01/app.js';
 export {default as Lesson02} from '../../examples/lessons/02/app.js';

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -83,6 +83,13 @@ export const EXAMPLE_PAGES = [
           demo: 'TransformFeedbackDemo',
           code: `${GITHUB_TREE}/examples/core/transform-feedback`
         }
+      },
+      {
+        name: 'Transform Feedback Instancing',
+        content: {
+          demo: 'TransformFeedbackInstancingDemo',
+          code: `${GITHUB_TREE}/examples/core/transform-feedback-instanced`
+        }
       }
     ]
   },


### PR DESCRIPTION
- Add a method to`VertexArray` to query currently bound attribute locations.
- In `Program`, get bound locations data from `VertexArray` object (custom or default), to generate warnings on unbound locations.
- When clear is requested, we were only clearing internal object but not clearing actual buffer bindings, added a new method to `VertexArray` to do it.
- Do not crash if Model is created without a `Geometry` object.

Tested with examples, test-browser.
Fixes #387 