### PR TITLE
Fix animation loop parameter setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Pre-releases
 
+#5.1.0-beta.?
+- Fix AnimationLoop.setViewParameters
+
 ## 5.1.0-beta.2 - Feb 09, 2018
 - Update docs for Model class
 - 5.1 Audit comments (#399)

--- a/src/core/animation-loop.js
+++ b/src/core/animation-loop.js
@@ -74,22 +74,27 @@ export default class AnimationLoop {
     return this;
   }
 
-  // Update parameters (TODO - should these be specified in `start`?)
-  setViewParameters({
-    autoResizeDrawingBuffer = true,
-    autoResizeCanvas = true,
-    autoResizeViewport = true,
-    useDevicePixels = true,
-    useDevicePixelRatio = null // deprecated
-  }) {
-    this.autoResizeViewport = autoResizeViewport;
-    this.autoResizeCanvas = autoResizeCanvas;
-    this.autoResizeDrawingBuffer = autoResizeDrawingBuffer;
-    this.useDevicePixels = useDevicePixels;
-    if (useDevicePixelRatio !== null) {
-      log.deprecated('useDevicePixelRatio', 'useDevicePixels');
-      this.useDevicePixels = useDevicePixelRatio;
+  // Update parameters
+  setViewParameters(opts) {
+    if ('autoResizeViewport' in opts) {
+      this.autoResizeViewport = opts.autoResizeViewport;
     }
+    if ('autoResizeCanvas' in opts) {
+      this.autoResizeCanvas = opts.autoResizeCanvas;
+    }
+    if ('autoResizeDrawingBuffer' in opts) {
+      this.autoResizeDrawingBuffer = opts.autoResizeDrawingBuffer;
+    }
+    if ('useDevicePixels' in opts) {
+      this.useDevicePixels = opts.useDevicePixels;
+    }
+
+    // DEPRECATED
+    if ('useDevicePixelRatio' in opts) {
+      log.deprecated('useDevicePixelRatio', 'useDevicePixels');
+      this.useDevicePixels = opts.useDevicePixelRatio;
+    }
+
     return this;
   }
 


### PR DESCRIPTION
Parameters must be independently settable. This issue is causing problems for deck.gl auto resize feature. 

This is as small fix for 5.1, will open a more extensive PR for 5.2.