### PR TITLE
Fix browser test

### DIFF
--- a/test/webgl/uniforms.spec.js
+++ b/test/webgl/uniforms.spec.js
@@ -74,7 +74,7 @@ void main(void) {
 
   v = texture2D(s2d, v2);
 
-  gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+  gl_FragColor = vec4(transform_v2, 1.0, 1.0) + vec4(transform_v3, 1.0) + transform_v4;
 }
 `;
 


### PR DESCRIPTION
https://github.com/uber/luma.gl/issues/412

Chrome's shader optimization removed uniforms that do not contribute to the final output (`gl_FragColor`)