### PR TITLE
Transform: Add updateBuffers method

### DIFF
--- a/docs/api-reference/core/experimental/transform.md
+++ b/docs/api-reference/core/experimental/transform.md
@@ -7,7 +7,7 @@ The `Transform` class provides easy interface to perform Transform Feedback oper
 | **Method**      | **Description** |
 | ---             | --- |
 | `constructor`   | creates a `Transform` object |
-| `updateBuffers` | Update some or all buffer bindings |
+| `update` | Update some or all buffer bindings |
 | `run`           | Performs one iteration of TransformFeedback |
 | `swapBuffers`   | Swaps source and destination buffers |
 | `getBuffer`     | Returns current destination buffer of given varying |
@@ -95,9 +95,9 @@ bufferWithNewValues = transform.getBuffer('outValue');
 ...
 ```
 
-### Use case : Update one or more buffers using updateBuffers.
+### Use case : Update one or more buffers using update() method..
 
-Once `Transform` object is constructed and used, one or more source or destination buffers can be updated using `updateBuffers`.
+Once `Transform` object is constructed and used, one or more source or destination buffers can be updated using `update`.
 
 ```js
 // transform is set up as above
@@ -105,7 +105,7 @@ Once `Transform` object is constructed and used, one or more source or destinati
 
 // update buffer binding for 'inValue' attribute
 const newSourceBuffer = new Buffer(gl, {data: newSourceData});
-transform.updateBuffers({
+transform.update({
   sourceBuffers: {
     inValue: newSourceBuffer
   }
@@ -135,7 +135,7 @@ Constructs a `Transform` object, creates `Model` and `TransformFeedback` instanc
 
 Deletes all owned resources, `Model`, `TransformFeedback` and any `Buffer` objects that are crated internally.
 
-### updateBuffers
+### update
 
 Updates buffer bindings with provided buffer objects for one or more source or destination buffers.
 

--- a/src/core/experimental/transform.js
+++ b/src/core/experimental/transform.js
@@ -4,6 +4,7 @@ import TransformFeedback from '../../webgl/transform-feedback';
 import Model from '../model';
 import {isWebGL2, assertWebGL2Context} from '../../webgl/context';
 import assert from 'assert';
+import {log} from '../../utils';
 
 const PASS_THROUGH_FS = `\
 void main()
@@ -49,7 +50,10 @@ export default class Transform {
     // to create destinaitonBuffers with layout of corresponding source buffer.
     assert(destinationBuffers || sourceDestinationMap);
 
-    this.bindBuffers({sourceBuffers, destinationBuffers, sourceDestinationMap});
+    if (sourceDestinationMap) {
+      this.sourceDestinationMap = sourceDestinationMap;
+      this._buffersSwapable = true;
+    }
 
     let index = 0;
     this.varyings = [];
@@ -60,82 +64,48 @@ export default class Transform {
       index++;
     }
 
-    // setup TransformFeedback objects.
-    this.transformFeedbacks[0] = new TransformFeedback(this.gl, {
-      buffers: this.destinationBuffers[0],
-      varyingMap: this.varyingMap
-    });
-    if (this._buffersSwapable) {
-      this.transformFeedbacks[1] = new TransformFeedback(this.gl, {
-        buffers: this.destinationBuffers[1],
-        varyingMap: this.varyingMap
-      });
-    }
-
-    // Append matching version string to FS.
-    let fs = PASS_THROUGH_FS;
-    const vsLines = vs.split('\n');
-    if (vsLines[0].indexOf('#version ') === 0) {
-      fs = `\
-${vsLines[0]}
-${PASS_THROUGH_FS}
-`;
-    }
-
-    this.model = new Model(this.gl, {
-      vs,
-      fs,
-      varyings: this.varyings,
-      drawMode,
-      vertexCount: elementCount
-    });
+    this._bindBuffers({sourceBuffers, destinationBuffers});
+    this._buildModel({vs, drawMode, elementCount});
   }
 
-  // build source and destination buffers
-  bindBuffers({
+  // Update some or all buffer bindings.
+  updateBuffers({
     sourceBuffers = null,
-    destinationBuffers = null,
-    sourceDestinationMap = null
+    destinationBuffers = null
   }) {
+    if (!sourceBuffers && !destinationBuffers) {
+      log.warn('Transform : no buffers to updated');
+    }
+    const {currentIndex, varyingMap, _buffersSwapable, transformFeedbacks} = this;
 
-    this.sourceBuffers[0] = {};
     for (const bufferName in sourceBuffers) {
       assert(sourceBuffers[bufferName] instanceof Buffer);
-      this.sourceBuffers[0][bufferName] = sourceBuffers[bufferName];
+      this.sourceBuffers[currentIndex][bufferName] = sourceBuffers[bufferName];
     }
-
-    this.destinationBuffers[0] = {};
     for (const bufferName in destinationBuffers) {
       assert(destinationBuffers[bufferName] instanceof Buffer);
-      this.destinationBuffers[0][bufferName] = destinationBuffers[bufferName];
+      this.destinationBuffers[currentIndex][bufferName] = destinationBuffers[bufferName];
     }
+    transformFeedbacks[currentIndex].bindBuffers(
+      this.destinationBuffers[currentIndex], {varyingMap}
+    );
 
-    if (sourceDestinationMap) {
-      this._buffersSwapable = true;
-      this.sourceBuffers[1] = {};
-      this.destinationBuffers[1] = {};
+    if (_buffersSwapable) {
+      const nextIndex = (currentIndex + 1) % 2;
 
-      for (const sourceBufferName in sourceDestinationMap) {
-        const destinationBufferName = sourceDestinationMap[sourceBufferName];
-        if (!this.destinationBuffers[0][destinationBufferName]) {
-          // Create new buffer with same layout and settings as source buffer
-          const sourceBuffer = this.sourceBuffers[0][sourceBufferName];
-          const {bytes, type, usage, layout} = sourceBuffer;
-          this.destinationBuffers[0][destinationBufferName] =
-            new Buffer(this.gl, {bytes, type, usage, layout});
-          this._buffersToDelete.push(this.destinationBuffers[0][destinationBufferName]);
-        }
-
-        this.sourceBuffers[1][sourceBufferName] =
-          this.destinationBuffers[0][destinationBufferName];
-        this.destinationBuffers[1][destinationBufferName] =
-          this.sourceBuffers[0][sourceBufferName];
+      for (const sourceBufferName in this.sourceDestinationMap) {
+        const destinationBufferName = this.sourceDestinationMap[sourceBufferName];
+        this.sourceBuffers[nextIndex][sourceBufferName] =
+          this.destinationBuffers[currentIndex][destinationBufferName];
+        this.destinationBuffers[nextIndex][destinationBufferName] =
+          this.sourceBuffers[currentIndex][sourceBufferName];
       }
+      transformFeedbacks[nextIndex].bindBuffers(
+        this.destinationBuffers[nextIndex], {varyingMap}
+      );
     }
 
-    return this;
   }
-
   // Delete owned resources.
   delete() {
     for (const buffer of this._buffersToDelete) {
@@ -166,5 +136,84 @@ ${PASS_THROUGH_FS}
   getBuffer(varyingName = null) {
     assert(varyingName && this.destinationBuffers[this.currentIndex][varyingName]);
     return this.destinationBuffers[this.currentIndex][varyingName];
+  }
+
+  // Private
+  // build source and destination buffers
+  _bindBuffers({
+    sourceBuffers = null,
+    destinationBuffers = null,
+    clear = false
+  }) {
+    const {_buffersSwapable} = this;
+    this.sourceBuffers[0] = {};
+    for (const bufferName in sourceBuffers) {
+      assert(sourceBuffers[bufferName] instanceof Buffer);
+      this.sourceBuffers[0][bufferName] = sourceBuffers[bufferName];
+    }
+    this.destinationBuffers[0] = {};
+    for (const bufferName in destinationBuffers) {
+      assert(destinationBuffers[bufferName] instanceof Buffer);
+      this.destinationBuffers[0][bufferName] = destinationBuffers[bufferName];
+    }
+
+    if (_buffersSwapable) {
+      this.sourceBuffers[1] = {};
+      this.destinationBuffers[1] = {};
+
+      for (const sourceBufferName in this.sourceDestinationMap) {
+        const destinationBufferName = this.sourceDestinationMap[sourceBufferName];
+        if (!this.destinationBuffers[0][destinationBufferName]) {
+          // Create new buffer with same layout and settings as source buffer
+          const sourceBuffer = this.sourceBuffers[0][sourceBufferName];
+          const {bytes, type, usage, layout} = sourceBuffer;
+          this.destinationBuffers[0][destinationBufferName] =
+            new Buffer(this.gl, {bytes, type, usage, layout});
+          this._buffersToDelete.push(this.destinationBuffers[0][destinationBufferName]);
+        }
+
+        this.sourceBuffers[1][sourceBufferName] =
+          this.destinationBuffers[0][destinationBufferName];
+        this.destinationBuffers[1][destinationBufferName] =
+          this.sourceBuffers[0][sourceBufferName];
+      }
+    }
+
+    return this;
+  }
+
+  // build Model and TransformFeedback objects
+  _buildModel({
+    vs, drawMode, elementCount
+  }) {
+    const {varyings, varyingMap, _buffersSwapable} = this;
+
+    // Append matching version string to FS.
+    let fs = PASS_THROUGH_FS;
+    const vsLines = vs.split('\n');
+    if (vsLines[0].indexOf('#version ') === 0) {
+      fs = `\
+${vsLines[0]}
+${PASS_THROUGH_FS}
+`;
+    }
+
+    this.model = new Model(this.gl, {
+      vs,
+      fs,
+      varyings,
+      drawMode,
+      vertexCount: elementCount
+    });
+    this.transformFeedbacks[0] = new TransformFeedback(this.gl, {
+      buffers: this.destinationBuffers[0],
+      varyingMap
+    });
+    if (_buffersSwapable) {
+      this.transformFeedbacks[1] = new TransformFeedback(this.gl, {
+        buffers: this.destinationBuffers[1],
+        varyingMap: this.varyingMap
+      });
+    }
   }
 }

--- a/test/core/experimental/transform.spec.js
+++ b/test/core/experimental/transform.spec.js
@@ -130,7 +130,7 @@ test('WebGL#Transform swapBuffers', t => {
   t.end();
 });
 
-test('WebGL#Transform updateBuffers', t => {
+test('WebGL#Transform update', t => {
   const {gl2} = fixture;
 
   if (!gl2) {
@@ -160,7 +160,7 @@ test('WebGL#Transform updateBuffers', t => {
   sourceBuffer.delete();
   sourceBuffer = new Buffer(gl2, {data: sourceData});
 
-  transform.updateBuffers({
+  transform.update({
     sourceBuffers: {
       inValue: sourceBuffer
     }

--- a/test/core/experimental/transform.spec.js
+++ b/test/core/experimental/transform.spec.js
@@ -36,7 +36,7 @@ test('WebGL#Transform constructor/delete', t => {
   const sourceData = new Float32Array([10, 20, 31, 0, -57]);
   const sourceBuffer = new Buffer(gl2, {data: sourceData});
 
-  const bufferMap = new Transform(gl2, {
+  const transform = new Transform(gl2, {
     sourceBuffers: {
       inValue: sourceBuffer
     },
@@ -48,13 +48,13 @@ test('WebGL#Transform constructor/delete', t => {
     elementCount: 5
   });
 
-  t.ok(bufferMap instanceof Transform, 'Transform construction successful');
+  t.ok(transform instanceof Transform, 'Transform construction successful');
 
-  bufferMap.delete();
-  t.ok(bufferMap instanceof Transform, 'Transform delete successful');
+  transform.delete();
+  t.ok(transform instanceof Transform, 'Transform delete successful');
 
-  bufferMap.delete();
-  t.ok(bufferMap instanceof Transform, 'Transform repeated delete successful');
+  transform.delete();
+  t.ok(transform instanceof Transform, 'Transform repeated delete successful');
 
   t.end();
 });
@@ -71,7 +71,7 @@ test('WebGL#Transform run', t => {
   const sourceData = new Float32Array([10, 20, 31, 0, -57]);
   const sourceBuffer = new Buffer(gl2, {data: sourceData});
 
-  const bufferMap = new Transform(gl2, {
+  const transform = new Transform(gl2, {
     sourceBuffers: {
       inValue: sourceBuffer
     },
@@ -83,12 +83,12 @@ test('WebGL#Transform run', t => {
     elementCount: 5
   });
 
-  bufferMap.run();
+  transform.run();
 
   const expectedData = sourceData.map(x => x * 2);
-  const outData = bufferMap.getBuffer('outValue').getData();
+  const outData = transform.getBuffer('outValue').getData();
 
-  t.deepEqual(expectedData, outData, 'Transform.getData: is successful');
+  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
 
   t.end();
 });
@@ -105,7 +105,7 @@ test('WebGL#Transform swapBuffers', t => {
   const sourceData = new Float32Array([10, 20, 31, 0, -57]);
   const sourceBuffer = new Buffer(gl2, {data: sourceData});
 
-  const bufferMap = new Transform(gl2, {
+  const transform = new Transform(gl2, {
     sourceBuffers: {
       inValue: sourceBuffer
     },
@@ -117,15 +117,60 @@ test('WebGL#Transform swapBuffers', t => {
     elementCount: 5
   });
 
-  bufferMap.run();
+  transform.run();
 
-  bufferMap.swapBuffers();
-  bufferMap.run();
+  transform.swapBuffers();
+  transform.run();
 
   const expectedData = sourceData.map(x => x * 4);
-  const outData = bufferMap.getBuffer('outValue').getData();
+  const outData = transform.getBuffer('outValue').getData();
 
-  t.deepEqual(expectedData, outData, 'Transform.getData: is successful');
+  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
+
+  t.end();
+});
+
+test('WebGL#Transform updateBuffers', t => {
+  const {gl2} = fixture;
+
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  let sourceData = new Float32Array([10, 20, 31, 0, -57]);
+  let sourceBuffer = new Buffer(gl2, {data: sourceData});
+
+  const transform = new Transform(gl2, {
+    sourceBuffers: {
+      inValue: sourceBuffer
+    },
+    vs: VS,
+    sourceDestinationMap: {
+      inValue: 'outValue'
+    },
+    varyings: ['outValue'],
+    elementCount: 5
+  });
+
+  transform.run();
+
+  sourceData = new Float32Array([1, 2, 3, 0, -5]);
+  sourceBuffer.delete();
+  sourceBuffer = new Buffer(gl2, {data: sourceData});
+
+  transform.updateBuffers({
+    sourceBuffers: {
+      inValue: sourceBuffer
+    }
+  });
+  transform.run();
+
+  const expectedData = sourceData.map(x => x * 2);
+  const outData = transform.getBuffer('outValue').getData();
+
+  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
 
   t.end();
 });


### PR DESCRIPTION
For #401

Add a new method, `updateBuffers` to handle the use cases , where one or more buffer bindings can be updated while keeping the others as is.

Updated unit tests and documentation.

Verified with unit tests, TF examples, and deck.gl attribute transitions.