### PR TITLE
Fix a crash when Model object created without geometry.

### DIFF
--- a/src/core/model.js
+++ b/src/core/model.js
@@ -175,7 +175,9 @@ export default class Model extends Object3D {
     let redraw = false;
     redraw = redraw || this.needsRedraw;
     this.needsRedraw = this.needsRedraw && !clearRedrawFlags;
-    redraw = redraw || this.geometry.getNeedsRedraw({clearRedrawFlags});
+    if (this.geometry) {
+      redraw = redraw || this.geometry.getNeedsRedraw({clearRedrawFlags});
+    }
     return redraw;
   }
 
@@ -532,7 +534,11 @@ count: ${this.stats.profileFrameCount}`
       const attributeTable = this._getAttributesTable({
         header: `${this.id} attributes`,
         program: this.program,
-        attributes: Object.assign({}, this.geometry.attributes, this.attributes)
+        attributes: Object.assign(
+          {},
+          this.geometry && this.geometry.attributes,
+          this.attributes
+        )
       });
       log.table(priority, attributeTable);
 


### PR DESCRIPTION
Fix crash, that happens when a `Model` object is created without a `Geometry` object.

More context:
All of our layers use geometry object, but for GPGPU features I am creating `Model` object without geometry (attributes, and vertex counts are updated after `Model` object is created).

Verified running unit tests.