### PR TITLE
[FOR DISCUSSION] make vertexCount and instanceCount optional on `Model` object

### DIFF
--- a/examples/core/transform-feedback-instanced/app.js
+++ b/examples/core/transform-feedback-instanced/app.js
@@ -139,9 +139,9 @@ const animationLoop = new AnimationLoop({
       vs: DRAW_VS,
       fs: DRAW_FS,
       drawMode: gl.TRIANGLE_FAN,
-      vertexCount: 3,
-      isInstanced: true,
-      instanceCount: NUM_INSTANCES
+      // vertexCount: 3,
+      isInstanced: true
+      // instanceCount: NUM_INSTANCES
     });
 
     const modelTransform = new Model(gl, {
@@ -150,7 +150,7 @@ const animationLoop = new AnimationLoop({
       fs: EMIT_FS,
       varyings: EMIT_VARYINGS,
       drawMode: gl.POINTS,
-      vertexCount: NUM_INSTANCES,
+      // vertexCount: NUM_INSTANCES,
       isInstanced: false
     });
 

--- a/examples/core/transform-feedback-instanced/app.js
+++ b/examples/core/transform-feedback-instanced/app.js
@@ -139,9 +139,7 @@ const animationLoop = new AnimationLoop({
       vs: DRAW_VS,
       fs: DRAW_FS,
       drawMode: gl.TRIANGLE_FAN,
-      // vertexCount: 3,
       isInstanced: true
-      // instanceCount: NUM_INSTANCES
     });
 
     const modelTransform = new Model(gl, {
@@ -150,7 +148,6 @@ const animationLoop = new AnimationLoop({
       fs: EMIT_FS,
       varyings: EMIT_VARYINGS,
       drawMode: gl.POINTS,
-      // vertexCount: NUM_INSTANCES,
       isInstanced: false
     });
 

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -18,7 +18,7 @@ const MSG_INSTANCED_PARAM_DEPRECATED = `\
 Warning: Model constructor: parameter "instanced" renamed to "isInstanced".
 This will become a hard error in a future version of luma.gl.`;
 
-const ERR_MODEL_PARAMS = 'Model needs drawMode and vertexCount';
+const ERR_MODEL_PARAMS = 'Model needs drawMode';
 
 const LOG_DRAW_PRIORITY = 2;
 
@@ -57,7 +57,7 @@ export default class Model extends Object3D {
     isInstanced = false, // Enables instanced rendering
     instanced, // deprecated
     vertexCount = undefined,
-    instanceCount = 0,
+    instanceCount = undefined,
 
     // Extra uniforms and attributes (beyond geometry, material, camera)
     drawMode,
@@ -143,7 +143,7 @@ export default class Model extends Object3D {
     this.onAfterRender = onAfterRender;
 
     // assert(program || program instanceof Program);
-    assert(this.drawMode !== undefined && Number.isFinite(this.vertexCount), ERR_MODEL_PARAMS);
+    assert(this.drawMode !== undefined, ERR_MODEL_PARAMS);
 
     this.timerQueryEnabled = timerQueryEnabled && Query.isSupported(this.gl, {timer: true});
     this.timeElapsedQuery = undefined;

--- a/src/webgl/buffer.js
+++ b/src/webgl/buffer.js
@@ -295,11 +295,8 @@ export default class Buffer extends Resource {
   }
 
   // returns number of elements in the buffer
-  getElementsCount() {
-    if (this.layout.instanced) {
-      return {instanceCount: this.elementCount};
-    }
-    return {vertexCount: this.elementCount};
+  get elementcount() {
+    return this.elementCount;
   }
 
   // RESOURCE METHODS

--- a/src/webgl/buffer.js
+++ b/src/webgl/buffer.js
@@ -122,6 +122,8 @@ export default class Buffer extends Resource {
     this.data = data;
     this.type = type;
     this.usage = usage;
+    const ArrayType = getTypedArrayFromGLType(this.type, {clamped: false});
+    this.elementCount = this.bytes / ArrayType.BYTES_PER_ELEMENT;
 
     // Call after type is set
     this.setDataLayout(Object.assign(opts));
@@ -293,6 +295,14 @@ export default class Buffer extends Resource {
     return this.gl.getIndexedParameter(binding, index);
   }
 
+  // returns number of elements in the buffer
+  getElementCount() {
+    if (this.instanced) {
+      return {instanceCount: this.elementCount};
+    }
+    return {vertexCount: this.elementCount};
+  }
+
   // RESOURCE METHODS
 
   _createHandle() {
@@ -312,8 +322,7 @@ export default class Buffer extends Resource {
 
   _getAvailableElementCount(srcByteOffset) {
     const ArrayType = getTypedArrayFromGLType(this.type, {clamped: false});
-    const sourceElementCount = this.bytes / ArrayType.BYTES_PER_ELEMENT;
     const sourceElementOffset = srcByteOffset / ArrayType.BYTES_PER_ELEMENT;
-    return sourceElementCount - sourceElementOffset;
+    return this.elementCount - sourceElementOffset;
   }
 }

--- a/src/webgl/buffer.js
+++ b/src/webgl/buffer.js
@@ -96,8 +96,7 @@ export default class Buffer extends Resource {
     offset = 0,
     stride = 0,
     normalized = false,
-    integer = false,
-    instanced = 0
+    integer = false
   } = {}) {
     const opts = arguments[0];
 
@@ -296,8 +295,8 @@ export default class Buffer extends Resource {
   }
 
   // returns number of elements in the buffer
-  getElementCount() {
-    if (this.instanced) {
+  getElementsCount() {
+    if (this.layout.instanced) {
       return {instanceCount: this.elementCount};
     }
     return {vertexCount: this.elementCount};

--- a/src/webgl/program.js
+++ b/src/webgl/program.js
@@ -94,14 +94,14 @@ export default class Program extends Resource {
   // that have sane defaults.
   draw({
     drawMode = GL.TRIANGLES,
-    vertexCount,
+    vertexCount = undefined,
     offset = 0,
     start,
     end,
     isIndexed = false,
     indexType = GL.UNSIGNED_SHORT,
     isInstanced = false,
-    instanceCount = 0,
+    instanceCount = undefined,
     vertexArray = null,
     transformFeedback = null,
     uniforms = {},
@@ -120,6 +120,11 @@ export default class Program extends Resource {
 
       this.setUniforms(uniforms, samplers);
 
+      if (!vertexCount || !instanceCount) {
+        const elementsCount = vertexArray.getElementsCount();
+        vertexCount = vertexCount || elementsCount.vertexCount;
+        instanceCount = instanceCount || elementsCount.instanceCount;
+      }
       withParameters(this.gl, parameters,
         () => {
           // TODO - Use polyfilled WebGL2RenderingContext instead of ANGLE extension
@@ -179,6 +184,7 @@ export default class Program extends Resource {
       if (!buffer) {
         this.vertexAttributes.disable(location);
       } else if (buffer instanceof Buffer) {
+        -TODO- here layout data comes from buffer.
         const divisor = buffer.layout.instanced ? 1 : 0;
         this.vertexAttributes.setBuffer({location, buffer});
         this.vertexAttributes.setDivisor(location, divisor);

--- a/src/webgl/program.js
+++ b/src/webgl/program.js
@@ -184,7 +184,6 @@ export default class Program extends Resource {
       if (!buffer) {
         this.vertexAttributes.disable(location);
       } else if (buffer instanceof Buffer) {
-        -TODO- here layout data comes from buffer.
         const divisor = buffer.layout.instanced ? 1 : 0;
         this.vertexAttributes.setBuffer({location, buffer});
         this.vertexAttributes.setDivisor(location, divisor);

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -99,19 +99,17 @@ export default class VertexArray extends Resource {
     let instanceCount = null;
     for (const location in this._filledLocations) {
       const bufferOrArray = this._filledLocations[location];
-      if (bufferOrArray instanceof Buffer) {
-        const elementCount = bufferOrArray.getElementsCount();
-        if (elementCount.instanceCount) {
-          instanceCount = instanceCount && Math.min(elementCount.instanceCount, instanceCount) ||
-            elementCount.instanceCount;
-        }
-        if (elementCount.vertexCount) {
-          vertexCount = vertexCount && Math.min(elementCount.vertexCount, vertexCount) ||
-            elementCount.vertexCount;
+      if (bufferOrArray.buffer instanceof Buffer) {
+        const {buffer, layout} = bufferOrArray;
+        const elementCount = buffer.elementCount;
+        if (layout.instanced) {
+          instanceCount = instanceCount && Math.min(elementCount, instanceCount) || elementCount;
+        } else {
+          vertexCount = vertexCount && Math.min(elementCount, vertexCount) || elementCount;
         }
       } else {
         // Generic attribute
-        // TODO: can this be an instanced?
+        // TODO: can this be instanced?
         vertexCount = vertexCount && Math.min(vertexCount, bufferOrArray.length) ||
           bufferOrArray.length;
       }
@@ -173,7 +171,6 @@ export default class VertexArray extends Resource {
     for (const location in locations) {
       const bufferData = locations[location];
       if (bufferData) {
-        -TODO- here layout data can be in-addition to buffer.
         const {buffer, layout} = this._getBufferAndLayout(bufferData);
         this.setBuffer({location, buffer, layout});
         this.setDivisor(location, layout.instanced ? 1 : 0);
@@ -243,7 +240,7 @@ export default class VertexArray extends Resource {
     layout = layout !== undefined ? layout : buffer.layout;
     assert(target, 'setBuffer needs target');
     assert(layout, 'setBuffer called on uninitialized buffer');
-    this._filledLocations[location] = buffer;
+    this._filledLocations[location] = {buffer, layout};
 
     this.bind(() => {
       // a non-zero named buffer object must be bound to the GL_ARRAY_BUFFER target

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -93,7 +93,7 @@ export default class VertexArray extends Resource {
     return this._filledLocations;
   }
 
-  // Returns the minimum element count of all bound instance buffers.
+  // Returns the minimum element count of all bound buffers.
   getElementsCount() {
     let vertexCount = null;
     let instanceCount = null;
@@ -101,7 +101,8 @@ export default class VertexArray extends Resource {
       const bufferOrArray = this._filledLocations[location];
       if (bufferOrArray.buffer instanceof Buffer) {
         const {buffer, layout} = bufferOrArray;
-        const elementCount = buffer.elementCount;
+        assert(layout && layout.size);
+        const elementCount = buffer.elementCount / layout.size;
         if (layout.instanced) {
           instanceCount = instanceCount && Math.min(elementCount, instanceCount) || elementCount;
         } else {

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -94,25 +94,32 @@ export default class VertexArray extends Resource {
   }
 
   // Returns the minimum element count of all bound instance buffers.
-  getElementCount() {
-    let vertexCount = 0;
-    let instanceCount = 0;
+  getElementsCount() {
+    let vertexCount = null;
+    let instanceCount = null;
     for (const location in this._filledLocations) {
       const bufferOrArray = this._filledLocations[location];
       if (bufferOrArray instanceof Buffer) {
-        const elementCount = bufferOrArray.getElementCount();
+        const elementCount = bufferOrArray.getElementsCount();
         if (elementCount.instanceCount) {
-          instanceCount = Math.min(elementCount.instanceCount, instanceCount);
+          instanceCount = instanceCount && Math.min(elementCount.instanceCount, instanceCount) ||
+            elementCount.instanceCount;
         }
         if (elementCount.vertexCount) {
-          vertexCount = Math.min(elementCount.vertexCount, vertexCount);
+          vertexCount = vertexCount && Math.min(elementCount.vertexCount, vertexCount) ||
+            elementCount.vertexCount;
         }
       } else {
         // Generic attribute
-        vertexCount = Math.min(vertexCount, bufferOrArray.length);
+        // TODO: can this be an instanced?
+        vertexCount = vertexCount && Math.min(vertexCount, bufferOrArray.length) ||
+          bufferOrArray.length;
       }
     }
-    return {vertexCount, instanceCount};
+    return {
+      vertexCount: vertexCount || 0,
+      instanceCount: instanceCount || 0
+    };
   }
 
   // Register an optional buffer name to location mapping
@@ -166,6 +173,7 @@ export default class VertexArray extends Resource {
     for (const location in locations) {
       const bufferData = locations[location];
       if (bufferData) {
+        -TODO- here layout data can be in-addition to buffer.
         const {buffer, layout} = this._getBufferAndLayout(bufferData);
         this.setBuffer({location, buffer, layout});
         this.setDivisor(location, layout.instanced ? 1 : 0);

--- a/test/webgl/buffer.spec.js
+++ b/test/webgl/buffer.spec.js
@@ -177,3 +177,22 @@ test('WebGL#Buffer getData', t => {
 
   t.end();
 });
+
+test('WebGL#Buffer getElementsCount', t => {
+  const {gl} = fixture;
+
+  let buffer;
+  let elementsCounts;
+
+  buffer = new Buffer(gl, {data: new Float32Array([1, 2, 3])});
+  elementsCounts = buffer.getElementsCount();
+  t.equal(elementsCounts.vertexCount, 3, 'Vertex count should match');
+  t.ok(!elementsCounts.instance, 'buffer doesnt contain any instance data');
+
+  buffer = new Buffer(gl, {data: new Float32Array([1, 2, 3, 4]), instanced: true});
+  elementsCounts = buffer.getElementsCount();
+  t.equal(elementsCounts.instanceCount, 4, 'Instance cout should match');
+  t.ok(!elementsCounts.vertexCount, 'buffer contains instance data');
+
+  t.end();
+});

--- a/test/webgl/buffer.spec.js
+++ b/test/webgl/buffer.spec.js
@@ -178,21 +178,19 @@ test('WebGL#Buffer getData', t => {
   t.end();
 });
 
-test('WebGL#Buffer getElementsCount', t => {
+test('WebGL#Buffer elementcount', t => {
   const {gl} = fixture;
 
   let buffer;
-  let elementsCounts;
+  let elementCount;
 
   buffer = new Buffer(gl, {data: new Float32Array([1, 2, 3])});
-  elementsCounts = buffer.getElementsCount();
-  t.equal(elementsCounts.vertexCount, 3, 'Vertex count should match');
-  t.ok(!elementsCounts.instance, 'buffer doesnt contain any instance data');
+  elementCount = buffer.elementcount;
+  t.equal(elementCount, 3, 'Vertex count should match');
 
   buffer = new Buffer(gl, {data: new Float32Array([1, 2, 3, 4]), instanced: true});
-  elementsCounts = buffer.getElementsCount();
-  t.equal(elementsCounts.instanceCount, 4, 'Instance cout should match');
-  t.ok(!elementsCounts.vertexCount, 'buffer contains instance data');
+  elementCount = buffer.elementcount;
+  t.equal(elementCount, 4, 'Vertex count should match');
 
   t.end();
 });

--- a/test/webgl/vertex-array.spec.js
+++ b/test/webgl/vertex-array.spec.js
@@ -66,14 +66,9 @@ test('WebGL#VertexAttributes#enable', t => {
 
 test('WebGL#vertexAttributes#WebGL2 support', t => {
   const {gl} = fixture;
-  // if (!gl2) {
-  //   t.comment('WebGL2 not available, skipping tests');
-  //   t.end();
-  //   return;
-  // }
 
-  if (!VertexArray.isSupported(gl, {instancedArrays: true})) {
-    t.comment('- instanced arrays not enabled: skipping tests');
+  if (!VertexArray.isSupported(gl)) {
+    t.comment('- VertexArray not supported: skipping tests');
     t.end();
     return;
   }
@@ -93,15 +88,18 @@ test('WebGL#vertexAttributes#WebGL2 support', t => {
 test('WebGL#VertexArray#getElementsCount', t => {
   const {gl} = fixture;
   if (!VertexArray.isSupported(gl)) {
-    t.comment('- instanced arrays not enabled: skipping tests');
+    t.comment('- VertexArray not supported: skipping tests');
     t.end();
     return;
   }
 
   const buffer1 = new Buffer(gl, {data: new Float32Array([1, 2, 3, 4, 5])});
-  const buffer2 = new Buffer(gl, {data: new Float32Array([1, 2]), instanced: true});
-  const buffer3 = new Buffer(gl, {data: new Float32Array([1, 2, 3])});
-  const buffer4 = new Buffer(gl, {data: new Float32Array([1]), instanced: true});
+  const buffer2 = new Buffer(gl, {data: new Float32Array([1, 2, 3]), instanced: true});
+  const buffer3 = new Buffer(gl, {data: new Float32Array([1, 2, 3, 4]), size: 2});
+  const buffer4 = new Buffer(gl, {data: new Float32Array([1, 2]), instanced: true, size: 2});
+
+  // buffer3 is the buffer with least number of vertices : 2
+  // buffer4 is the buffer with least number of instances : 1
 
   const va = new VertexArray(gl, {
     buffers: {
@@ -114,7 +112,7 @@ test('WebGL#VertexArray#getElementsCount', t => {
 
   let elementsCount = va.getElementsCount();
 
-  t.equal(elementsCount.vertexCount, 3);
+  t.equal(elementsCount.vertexCount, 2);
   t.equal(elementsCount.instanceCount, 1);
 
   // only bind non instanced buffers.
@@ -124,6 +122,6 @@ test('WebGL#VertexArray#getElementsCount', t => {
   }, {clear: true});
   elementsCount = va.getElementsCount();
 
-  t.equal(elementsCount.vertexCount, 3);
+  t.equal(elementsCount.vertexCount, 2);
   t.equal(elementsCount.instanceCount, 0);
 });

--- a/test/webgl/vertex-array.spec.js
+++ b/test/webgl/vertex-array.spec.js
@@ -1,5 +1,5 @@
 import test from 'tape-catch';
-import {GL, createGLContext, Buffer} from 'luma.gl';
+import {GL, Buffer} from 'luma.gl';
 import {VertexArray} from 'luma.gl';
 import {fixture} from '../setup';
 
@@ -65,17 +65,22 @@ test('WebGL#VertexAttributes#enable', t => {
 });
 
 test('WebGL#vertexAttributes#WebGL2 support', t => {
-  const {gl2} = fixture;
+  const {gl} = fixture;
+  // if (!gl2) {
+  //   t.comment('WebGL2 not available, skipping tests');
+  //   t.end();
+  //   return;
+  // }
 
-  if (!VertexArray.isSupported(gl2, {instancedArrays: true})) {
+  if (!VertexArray.isSupported(gl, {instancedArrays: true})) {
     t.comment('- instanced arrays not enabled: skipping tests');
     t.end();
     return;
   }
 
-  const vertexAttributes = VertexArray.getDefaultArray(gl2);
+  const vertexAttributes = VertexArray.getDefaultArray(gl);
 
-  const MAX_ATTRIBUTES = VertexArray.getMaxAttributes(gl2);
+  const MAX_ATTRIBUTES = VertexArray.getMaxAttributes(gl);
 
   for (let i = 0; i < MAX_ATTRIBUTES; i++) {
     t.equal(vertexAttributes.getParameter(GL.VERTEX_ATTRIB_ARRAY_DIVISOR, {location: i}), 0,
@@ -87,6 +92,11 @@ test('WebGL#vertexAttributes#WebGL2 support', t => {
 
 test('WebGL#VertexArray#getElementsCount', t => {
   const {gl} = fixture;
+  if (!VertexArray.isSupported(gl)) {
+    t.comment('- instanced arrays not enabled: skipping tests');
+    t.end();
+    return;
+  }
 
   const buffer1 = new Buffer(gl, {data: new Float32Array([1, 2, 3, 4, 5])});
   const buffer2 = new Buffer(gl, {data: new Float32Array([1, 2]), instanced: true});


### PR DESCRIPTION
Fixes #417

Main idea: Make vertexCount and InstanceCount optional when creating `Model` object, if any of them or not specified, during draw time, element count is queried from all bound buffers, instanceCount is set to minimum of element count of all instance buffers and vertexCount is set to minimum of element count of all non instanced buffers.

Given, a buffer can be created once but bound with different layouts (instanced vs non-instanced, and different sizes), we need to save both buffer and layout all currently bound buffers.

Verified with unit tests for `Buffer` and `VertexArray` and updated TF demo to use this new feature.

TODO: documentation.