### PR TITLE
Fix exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export {
   installParameterDefinitions} from './webgl/api/debug-parameters';
 
 export {default as Buffer} from './webgl/buffer';
-export {default as Shader, VertexShader, FragmentShader} from './webgl/shader';
+export {Shader, VertexShader, FragmentShader} from './webgl/shader';
 export {default as Program} from './webgl/program';
 export {default as Framebuffer} from './webgl/framebuffer';
 export {default as Renderbuffer} from './webgl/renderbuffer';
@@ -147,9 +147,7 @@ export { // Moved to math.gl
   Vector3,
   Vector4,
   Matrix4,
-  Quaternion,
-  Euler,
-  SphericalCoordinates
+  Quaternion
 } from 'math.gl';
 
 // DEPRECATED IN V3.0

--- a/src/shadertools/modules/lighting/lighting.js
+++ b/src/shadertools/modules/lighting/lighting.js
@@ -89,3 +89,10 @@ function getPointUniforms(points) {
     pointSpecularColor: pointSpecularColors
   };
 }
+
+export default {
+  name,
+  vs: vertexShader,
+  fs: fragmentShader,
+  getUniforms
+};

--- a/src/webgl-utils/index.js
+++ b/src/webgl-utils/index.js
@@ -28,8 +28,7 @@ export {
 
 export {
   trackContextCreation,
-  createContext,
-  resizeViewport
+  createContext
 } from './create-context';
 
 export {default as polyfillContext} from './polyfill-context';

--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -43,7 +43,7 @@ export {
 
 // WebGL1 objects
 export {default as Buffer} from './buffer';
-export {default as Shader, VertexShader, FragmentShader} from './shader';
+export {Shader, VertexShader, FragmentShader} from './shader';
 export {default as Program} from './program';
 export {default as Framebuffer} from './framebuffer';
 export {default as Renderbuffer} from './renderbuffer';
@@ -60,8 +60,7 @@ export {
 } from './clear';
 
 export {
-  readPixels,
-  readPixelsFromBuffer
+  readPixels
 } from './functions';
 
 export {


### PR DESCRIPTION
Fixed some invalid exports of undefined modules, add the default export of the lighting shader module.

In addition, `Euler` and `SphericalCoordinates` have been removed from `math.gl`