### PR TITLE
Fix framebuffer target for WebGL1 context

### DIFF
--- a/src/webgl-utils/set-parameters.js
+++ b/src/webgl-utils/set-parameters.js
@@ -2,6 +2,7 @@
 // Also knows default values of all parameters, enabling fast cache initialization
 // Provides base functionality for the state caching.
 import GL from './constants';
+import {isWebGL2} from '../webgl/context';
 import assert from 'assert';
 
 // DEFAULT SETTINGS - FOR FAST CACHE INITIALIZATION AND CONTEXT RESETS
@@ -85,7 +86,8 @@ const hint = (gl, value, key) => gl.hint(key, value);
 const pixelStorei = (gl, value, key) => gl.pixelStorei(key, value);
 
 const drawFramebuffer = (gl, value) => {
-  return gl.bindFramebuffer(GL.DRAW_FRAMEBUFFER, value);
+  const target = isWebGL2(gl) ? GL.DRAW_FRAMEBUFFER : GL.FRAMEBUFFER;
+  return gl.bindFramebuffer(target, value);
 };
 const readFramebuffer = (gl, value) => {
   return gl.bindFramebuffer(GL.READ_FRAMEBUFFER, value);


### PR DESCRIPTION
For #435 
#### Background
Enums used for reading Framebuffer binding are compatible between WebGL1 and WebGL2 as they have the same value.
```
const GLenum DRAW_FRAMEBUFFER_BINDING = 0x8CA6;
const GLenum FRAMEBUFFER_BINDING            = 0x8CA6;
```
But it is not the same case for enums used in setting the Framebuffer bidning:

```
const GLenum FRAMEBUFFER                    = 0x8D40
const GLenum DRAW_FRAMEBUFFER        = 0x8CA9
```

Use the correct target when updating the framebuffer binding.

#### Change List
-  Fix framebuffer target for WebGL1 context

Verified using existing unit test on Safari(WebGL1) and Chrome(WebGL2).
