### PR TITLE
WebGL2 : Add asynchronous mode for readPixels using PBOs.

### DIFF
--- a/docs/api-reference/webgl/framebuffer.md
+++ b/docs/api-reference/webgl/framebuffer.md
@@ -249,7 +249,7 @@ Clears the contents (pixels) of the framebuffer attachments.
 
 ### readPixels
 
-Reads data into an array object.
+Supports, two modes of operation, `Synchronous` and `Asynchronous`. In `Synchronous` mode copies data into an array Object, in `Asynchronous` mode copies data into a Buffer object. `Asynchronous` mode is supported only when `WebGL2` context is used, when using `WebGL`, it falls back to `Synchronous` mode.
 
 Parameters
 * `x` - (*number*, default: 0) X offset of the area to be copied,
@@ -259,28 +259,15 @@ Parameters
 * `format` - (*GLenum*, default: GL.RGBA) The format of the data.
 * `type` - (*GLenum*, default: type of buffer) The type of the data.
 * `pixelArray` - (*Array*, default: null) Array object, into which data to be copied.
-
-* Readpixels can be slow as it requires a roundtrip to the GPU
-* Reading from floating point textures is dependent on an extension both in WebGL1 and WebGL2.
-* When supported, the `{format: GL.RGBA`, type: GL.FLOAT, ...}` combination becomes valid for reading from a floating-point color buffer.
-
-This function makes calls to the following WebGL APIs:
-
-[gl.readPixels](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
-
-### readPixelsAsync (WebGL2)
-
-Reads data into provided `Buffer` object. Function returns right away without waiting for actual copy to happen. Actual copy of data happens on GPU.
-
-Parameters
-* `x` - (*number*, default: 0) X offset of the area to be copied,
-* `y` - (*number*, default: 0) Y offset of the area to be copied,
-* `width` - (*number*, default: framebuffer width) The width of the area to be copied,
-* `height` - (*number*, default: framebuffer height) The height of the area to be copied,
-* `format` - (*GLenum*, default: GL.RGBA) The format of the data.
-* `type` - (*GLenum*, default: type of buffer) The type of the data.
 * `buffer` - (*Buffer*) Buffer object, into which data to be copied.
 * `byteOffset` - (*number*, default: 0) Byte offset from which data should be copied into buffer.
+
+Notes:
+
+* `pixelArray` is used in `Synchronous` mode and `buffer` and `bufferOffset` are used in `Asynchronous` mode.
+* In `Synchronous` mode, readpixels can be slow as it requires a roundtrip to the GPU
+* Reading from floating point textures is dependent on an extension both in WebGL1 and WebGL2.
+* When supported, the `{format: GL.RGBA`, type: GL.FLOAT, ...}` combination becomes valid for reading from a floating-point color buffer.
 
 This function makes calls to the following WebGL APIs:
 

--- a/docs/api-reference/webgl/framebuffer.md
+++ b/docs/api-reference/webgl/framebuffer.md
@@ -249,14 +249,16 @@ Clears the contents (pixels) of the framebuffer attachments.
 
 ### readPixels
 
-App can provide pixelArray or have it auto allocated by this method
-    x = 0,
-    y = 0,
-    width,
-    height,
-    format = GL.RGBA,
-    type,
-    pixelArray = null
+Reads data into an array object.
+
+Parameters
+* `x` - (*number*, default: 0) X offset of the area to be copied,
+* `y` - (*number*, default: 0) Y offset of the area to be copied,
+* `width` - (*number*, default: framebuffer width) The width of the area to be copied,
+* `height` - (*number*, default: framebuffer height) The height of the area to be copied,
+* `format` - (*GLenum*, default: GL.RGBA) The format of the data.
+* `type` - (*GLenum*, default: type of buffer) The type of the data.
+* `pixelArray` - (*Array*, default: null) Array object, into which data to be copied.
 
 * Readpixels can be slow as it requires a roundtrip to the GPU
 * Reading from floating point textures is dependent on an extension both in WebGL1 and WebGL2.
@@ -266,6 +268,23 @@ This function makes calls to the following WebGL APIs:
 
 [gl.readPixels](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
 
+### readPixelsAsync (WebGL2)
+
+Reads data into provided `Buffer` object. Function returns right away without waiting for actual copy to happen. Actual copy of data happens on GPU.
+
+Parameters
+* `x` - (*number*, default: 0) X offset of the area to be copied,
+* `y` - (*number*, default: 0) Y offset of the area to be copied,
+* `width` - (*number*, default: framebuffer width) The width of the area to be copied,
+* `height` - (*number*, default: framebuffer height) The height of the area to be copied,
+* `format` - (*GLenum*, default: GL.RGBA) The format of the data.
+* `type` - (*GLenum*, default: type of buffer) The type of the data.
+* `buffer` - (*Buffer*) Buffer object, into which data to be copied.
+* `byteOffset` - (*number*, default: 0) Byte offset from which data should be copied into buffer.
+
+This function makes calls to the following WebGL APIs:
+
+[gl.readPixels](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
 
 ### blit (WebGL2)
 

--- a/docs/api-reference/webgl/framebuffer.md
+++ b/docs/api-reference/webgl/framebuffer.md
@@ -80,7 +80,30 @@ withParameters(gl, {framebuffer: framebuffer1}, () => {
 });
 // framebuffer1 is not longer bound
 ```
+Reading data from a framebuffer color attachment.
+```js
+// With CPU and GPU sync
+const data = framebuffer.readPixels({
+  x: 0,
+  y: 0,
+  width: 10,
+  height: 10});
 
+// Without CPU and GPU sync
+const buffer = framebuffer.readPixelsToBuffer({
+  x: 0,
+  y: 0,
+  width: 10,
+  height: 10});
+
+// Returned `Buffer` object can be used to read data into an Array object ...
+const data = buffer.getData();
+
+//or can be used as source for a vertex shader attribute using `Model` object.
+model.setAttributes({
+  attribute_name: buffer
+});
+```
 Blitting between framebuffers (WebGL2)
 ```js
 framebuffer.blit({
@@ -249,7 +272,7 @@ Clears the contents (pixels) of the framebuffer attachments.
 
 ### readPixels
 
-Supports, two modes of operation, `Synchronous` and `Asynchronous`. In `Synchronous` mode copies data into an array Object, in `Asynchronous` mode copies data into a Buffer object. `Asynchronous` mode is supported only when `WebGL2` context is used, when using `WebGL`, it falls back to `Synchronous` mode.
+Reads data into an Array object and returns it. A new Array object is created when not provided. This method requires a sync between CPU and GPU as pixel values are copied from GPU texture memory to CPU Array object memory. This could introduce a delay as it waits for GPU to finish updating the texture. For asynchronous read, check `readPixelsToBuffer` method.
 
 Parameters
 * `x` - (*number*, default: 0) X offset of the area to be copied,
@@ -257,21 +280,43 @@ Parameters
 * `width` - (*number*, default: framebuffer width) The width of the area to be copied,
 * `height` - (*number*, default: framebuffer height) The height of the area to be copied,
 * `format` - (*GLenum*, default: GL.RGBA) The format of the data.
-* `type` - (*GLenum*, default: type of buffer) The type of the data.
+* `type` - (*GLenum*, default: type of `pixelArray` or `UNSIGNED_BYTE`) The type of the data.
 * `pixelArray` - (*Array*, default: null) Array object, into which data to be copied.
-* `buffer` - (*Buffer*) Buffer object, into which data to be copied.
-* `byteOffset` - (*number*, default: 0) Byte offset from which data should be copied into buffer.
 
 Notes:
 
-* `pixelArray` is used in `Synchronous` mode and `buffer` and `bufferOffset` are used in `Asynchronous` mode.
-* In `Synchronous` mode, readpixels can be slow as it requires a roundtrip to the GPU
 * Reading from floating point textures is dependent on an extension both in WebGL1 and WebGL2.
 * When supported, the `{format: GL.RGBA`, type: GL.FLOAT, ...}` combination becomes valid for reading from a floating-point color buffer.
 
 This function makes calls to the following WebGL APIs:
 
-[gl.readPixels](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
+[`gl.readPixels`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
+
+### readPixelsToBuffer
+
+Reads data into A `Buffer` object and returns it. A new `Buffer` object is created when not provided. This method avoids a sync between CPU and GPU as pixel values are copied from GPU texture memory to GPU Buffer memory. This method returns right away without any delays.
+
+A CPU and GPU sync will be triggered when the returned buffer data is read using `buffer.getData()`, but applications can delay this read, which can reduces the delay due to the sync, or the sync can be completely avoided by using the `Buffer` as the source of input to the GPU (either as `ARRAY_BUFFER` or `PIXEL_UNPACK_BUFFER`).
+
+Parameters
+* `x` - (*number*, default: 0) X offset of the area to be copied,
+* `y` - (*number*, default: 0) Y offset of the area to be copied,
+* `width` - (*number*, default: framebuffer width) The width of the area to be copied,
+* `height` - (*number*, default: framebuffer height) The height of the area to be copied,
+* `format` - (*GLenum*, default: GL.RGBA) The format of the data.
+* `type` - (*GLenum*, default: type of `buffer` or `UNSIGNED_BYTE`) The type of the data.
+* `buffer` - (*Buffer*) Buffer object, into which data to be copied.
+* `byteOffset` - (*number*, default: 0) Byte offset from which data should be copied into buffer.
+
+Notes:
+
+* Reading from floating point textures is dependent on an extension both in WebGL1 and WebGL2.
+* When supported, the `{format: GL.RGBA`, type: GL.FLOAT, ...}` combination becomes valid for reading from a floating-point color buffer.
+
+This function makes calls to the following WebGL APIs:
+
+[`gl.readPixels`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer), [`gl.bindBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindBuffer)
+
 
 ### blit (WebGL2)
 

--- a/docs/api-reference/webgl/framebuffer.md
+++ b/docs/api-reference/webgl/framebuffer.md
@@ -292,7 +292,7 @@ This function makes calls to the following WebGL APIs:
 
 [`gl.readPixels`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/readPixels), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
 
-### readPixelsToBuffer
+### readPixelsToBuffer (WebGL2)
 
 Reads data into A `Buffer` object and returns it. A new `Buffer` object is created when not provided. This method avoids a sync between CPU and GPU as pixel values are copied from GPU texture memory to GPU Buffer memory. This method returns right away without any delays.
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,10 +9,13 @@ In addition to these notes, always check the [Upgrade Guide](/#/documentation/up
 
 Date: Target April, 2018
 
-## Transform class (New)
+## Transform class (New, WebGL2)
 
 The new [`Transform`](/#/documentation/api-reference/transform) class provides an easy-to-use interface to perform Transform Feedback operations.
 
+## Framebuffer Asynchronous Read (New, WebGL2)
+
+A new method [`readPixelsToBuffer`](/#/documentation/api-reference/framebuffer) is added to asynchronously read pixel data into a `Buffer` object. This way applications have the freedom to reduce the CPU-GPU sync time or completely avoid it by using the `Buffer` object as data source for the GPU.
 
 ## Node.js Support Changes
 

--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -311,8 +311,8 @@ export default class Framebuffer extends Resource {
     return pixelArray;
   }
 
-  // Reades data into provided buffer object asynchronusly
-  // This Function doesn't wait for copy to be complete, which happens on GPU.
+  // Reads data into provided buffer object asynchronusly
+  // This function doesn't wait for copy to be complete, it program it to happen on GPU.
   readPixelsAsync({
     x = 0,
     y = 0,

--- a/src/webgl/helpers/format-utils.js
+++ b/src/webgl/helpers/format-utils.js
@@ -1,0 +1,37 @@
+import assert from '../../utils/assert';
+
+const GL_ALPHA = 0x1906;
+const GL_RGB = 0x1907;
+const GL_RGBA = 0x1908;
+const GL_UNSIGNED_BYTE = 0x1401;
+const GL_UNSIGNED_SHORT_4_4_4_4 = 0x8033;
+const GL_UNSIGNED_SHORT_5_5_5_1 = 0x8034;
+const GL_UNSIGNED_SHORT_5_6_5 = 0x8363;
+const GL_FLOAT = 0x1406;
+
+// Returns number of components in a specific readPixels WebGL format
+export function glFormatToComponents(format) {
+  switch (format) {
+  case GL_ALPHA: return 1;
+  case GL_RGB: return 3;
+  case GL_RGBA: return 4;
+  // TODO: Add support for additional WebGL2 formats
+  default: assert(false); return 0;
+  }
+}
+
+// Return byte count for given readPixels WebGL type
+export function glTypeToBytes(type) {
+  switch (type) {
+  case GL_UNSIGNED_BYTE:
+    return 1;
+  case GL_UNSIGNED_SHORT_5_6_5:
+  case GL_UNSIGNED_SHORT_4_4_4_4:
+  case GL_UNSIGNED_SHORT_5_5_5_1:
+    return 2;
+  case GL_FLOAT:
+    return 4;
+  // TODO: Add support for additional WebGL2 types
+  default: assert(false); return 0;
+  }
+}

--- a/test/src/webgl/framebuffer.spec.js
+++ b/test/src/webgl/framebuffer.spec.js
@@ -371,7 +371,7 @@ test('WebGL#Framebuffer readPixelsAsync', t => {
     }
   });
   const color = new Float32Array(6);
-  const clearColor = [0, -0.35, 12340.25, 0.005];
+  const clearColor = [0.25, -0.35, 12340.25, 0.005];
 
   framebuffer.checkStatus();
   framebuffer.clear({color: clearColor});

--- a/test/src/webgl/framebuffer.spec.js
+++ b/test/src/webgl/framebuffer.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import test from 'tape-catch';
-import {GL, Framebuffer, Renderbuffer, Texture2D, Buffer, isWebGL2} from 'luma.gl';
+import {GL, Framebuffer, Renderbuffer, Texture2D, Buffer} from 'luma.gl';
 import {fixture} from 'luma.gl/test/setup';
 const EPSILON = 0.0000001;
 const TEST_CASES = [
@@ -238,7 +238,7 @@ test('WebGL2#Framebuffer readPixels', t => {
   t.end();
 });
 
-function testReadPixeslToBuffer(t, bufferCreation) {
+function testReadPixelsToBuffer(t, bufferCreation) {
   const {gl2} = fixture;
   if (!gl2) {
     t.comment('WebGL2 not available, skipping tests');
@@ -250,8 +250,8 @@ function testReadPixeslToBuffer(t, bufferCreation) {
   const {abs} = Math;
   const dataBytes = 6 * 4; // 6 floats
   const colorTexture = new Texture2D(gl, {
-    format: isWebGL2(gl) ? GL.RGBA32F : GL.RGBA,
-    type: isWebGL2(gl) ? GL.FLOAT : GL.UNSIGNED_BYTE,
+    format: GL.RGBA32F,
+    type: GL.FLOAT,
     dataFormat: GL.RGBA,
     mipmap: false
   });
@@ -290,11 +290,11 @@ function testReadPixeslToBuffer(t, bufferCreation) {
 }
 
 test('WebGL#Framebuffer readPixelsToBuffer', t => {
-  testReadPixeslToBuffer(t, false);
+  testReadPixelsToBuffer(t, false);
 });
 
 test('WebGL#Framebuffer readPixelsToBuffer (buffer creation)', t => {
-  testReadPixeslToBuffer(t, true);
+  testReadPixelsToBuffer(t, true);
 });
 
 /*


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #451 
<!-- For other PRs without open issue -->
#### Background
WebGL2 adds new buffer binding point `PIXEL_PACK_BUFFER`, that can be used to read data from `Framebuffer` object into a `Buffer` object without syncing CPU with GPU. This will keep the data in GPU memory and could increase application performance in some cases.

<!-- For all the PRs -->
#### Change List
- Add asynchronous mode for `Framebuffer.readPixels` method.
