### PR TITLE
Fix failing canCompileGLGSExtension browser test

### DIFF
--- a/src/webgl-context/context-features.js
+++ b/src/webgl-context/context-features.js
@@ -56,11 +56,12 @@ export {FEATURES};
 // the OES_standard_derivatives extension fails to compile in IE11 even though its included
 // in the list of supported extensions.
 const compiledGlslExtensions = {};
-export function canCompileGLGSExtension(gl, cap) {
+// opts allows user agent to be overridden for testing
+export function canCompileGLGSExtension(gl, cap, opts = {}) {
   const feature = WEBGL_FEATURES[cap];
   assert(feature, cap);
 
-  if (!isOldIE()) {
+  if (!isOldIE(opts)) {
     return true;
   }
 

--- a/test/src/webgl-context/context-features.spec.js
+++ b/test/src/webgl-context/context-features.spec.js
@@ -1,6 +1,6 @@
-import {hasFeature, hasFeatures, getFeatures, FEATURES} from 'luma.gl';
+import {canCompileGLGSExtension, hasFeature, hasFeatures, getFeatures, FEATURES} from 'luma.gl';
 import test from 'tape-catch';
-// import sinon from 'sinon';
+import sinon from 'sinon';
 
 import {fixture} from 'luma.gl/test/setup';
 
@@ -78,49 +78,58 @@ test('webgl#caps#hasFeatures(WebGL2)', t => {
   t.end();
 });
 
-/*
-NOTE: Disabling the test as it crashes when tested by 'npm run test-brwoser'
- when it crashes it also leave global state modified, causing failure in other unit tests
 test('webgl#caps#canCompileGLGSExtension', t => {
   const {gl} = fixture;
-  const oldNavigator = window.navigator;
+
+  const userAgentNonIE = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36';
+  const userAgentOldIE = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
 
   t.ok(typeof canCompileGLGSExtension === 'function', 'canCompileGLGSExtension defined');
 
   // Non-IE version.
   const getShaderParameterStub = sinon.stub(gl, 'getShaderParameter');
-  window.navigator = {
-    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36'
-  };
-  t.equals(
-    canCompileGLGSExtension(gl, FEATURES.GLSL_DERIVATIVES),
-    true,
-    'returns true when feature can be compiled'
-  );
-  t.notOk(getShaderParameterStub.called, 'should not call getShaderParameterStub');
-
-  // Old-IE version.
-  window.navigator = {
-    userAgent: 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
-  };
-
   getShaderParameterStub.returns(true);
   t.equals(
-    canCompileGLGSExtension(gl, FEATURES.GLSL_DERIVATIVES),
+    canCompileGLGSExtension(gl, FEATURES.GLSL_DERIVATIVES, {
+      userAgent: userAgentNonIE
+    }),
     true,
     'returns true when feature can be compiled'
   );
-  t.ok(getShaderParameterStub.called, 'should call getShaderParameterStub');
+
+  t.notOk(
+    getShaderParameterStub.called,
+    'getShaderParameter should not be called when userAgent is not IE 11'
+  );
+
+  // Old-IE version.
+  getShaderParameterStub.returns(true);
+  t.equals(
+    canCompileGLGSExtension(gl, FEATURES.GLSL_DERIVATIVES, {
+      userAgent: userAgentOldIE
+    }),
+    true,
+    'returns true when feature can be compiled'
+  );
+
+  t.ok(
+    getShaderParameterStub.called,
+    'getShaderParameter should be called when userAgent is IE 11'
+  );
 
   getShaderParameterStub.returns(false);
   t.equals(
-    canCompileGLGSExtension(gl, FEATURES.GLSL_DERIVATIVES),
+    canCompileGLGSExtension(gl, FEATURES.GLSL_DERIVATIVES, {
+      userAgent: userAgentOldIE
+    }),
     true,
     'memoizes previous call'
   );
 
   t.equals(
-    canCompileGLGSExtension(gl, FEATURES.GLSL_TEXTURE_LOD),
+    canCompileGLGSExtension(gl, FEATURES.GLSL_TEXTURE_LOD, {
+      userAgent: userAgentOldIE
+    }),
     false,
     'returns false when feature can not be compiled'
   );
@@ -130,9 +139,6 @@ test('webgl#caps#canCompileGLGSExtension', t => {
     'should throw exception if feature does not exist'
   );
 
-  // Restore the navigator to pre-test version.
-  window.navigator = oldNavigator;
   getShaderParameterStub.restore();
   t.end();
 });
-*/

--- a/test/src/webgl-context/context-features.spec.js
+++ b/test/src/webgl-context/context-features.spec.js
@@ -1,6 +1,6 @@
 import {canCompileGLGSExtension, hasFeature, hasFeatures, getFeatures, FEATURES} from 'luma.gl';
 import test from 'tape-catch';
-import sinon from 'sinon';
+import {makeSpy} from 'probe.gl/test-utils';
 
 import {fixture} from 'luma.gl/test/setup';
 
@@ -87,7 +87,7 @@ test('webgl#caps#canCompileGLGSExtension', t => {
   t.ok(typeof canCompileGLGSExtension === 'function', 'canCompileGLGSExtension defined');
 
   // Non-IE version.
-  const getShaderParameterStub = sinon.stub(gl, 'getShaderParameter');
+  const getShaderParameterStub = makeSpy(gl, 'getShaderParameter');
   getShaderParameterStub.returns(true);
   t.equals(
     canCompileGLGSExtension(gl, FEATURES.GLSL_DERIVATIVES, {


### PR DESCRIPTION
For #457 

Sorry for breaking the browser tests!

#### Change List
- Override userAgent check in `isOldIE` method through `opts` parameter.

#### Notes

Before I noticed that @ibgreen introduced the `opts` param to "inject" the user agent into the `isOldIE` method, I had tried another method that is a bit more complicated but has the benefit of localizing the override as well as not requiring us to pass the test options through the call stack. Code looks like the following:


Add helper method to mock userAgent. This is necessary because `window.navigator` is not writable in the browser environment which is why the tests were only failing when running in the browser.

```
// Helper method to allow us to mock the userAgent across node and browser tests.
function mockUserAgent(value) {
  if (!window.navigator) {
    window.navigator = {};
  }

  const previousUserAgent = window.navigator.userAgent;
  Object.defineProperty(window.navigator, 'userAgent', {
    value,
    writable: true
  });

  return () => {
    mockUserAgent(previousUserAgent);
  };
}
```

In test code:
```
const restoreUserAgent = mockUserAgent(
    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36');
// call method such as canCompileGLGSExtension();

// reset user agent
restoreUserAgent();
```

If you'd before this style of userAgent mocking, I can update the review. Otherwise, hopefully this resolves the issue for good.