### PR TITLE
PickingModule: Add picking_filterColor method

### DIFF
--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -132,8 +132,7 @@ varying vec3 color;
 void main(void) {
   gl_FragColor = vec4(color, 1.);
   gl_FragColor = dirlight_filterColor(gl_FragColor);
-  gl_FragColor = picking_filterHighlightColor(gl_FragColor);
-  gl_FragColor = picking_filterPickingColor(gl_FragColor);
+  gl_FragColor = picking_filterColor(gl_FragColor);
 }
 `
   };

--- a/src/shadertools/modules/picking/README.md
+++ b/src/shadertools/modules/picking/README.md
@@ -17,22 +17,30 @@ main() {
 }
 ```
 
-In your fragment shader, you simply apply (call) the `picking_filterPickingColor` filter function at the very end of the shader. This will return the normal color, or the highlight color, or the picking color, as appropriate.
+In your fragment shader, you simply apply (call) the `picking_filterColor` filter function at the very end of the shader. This will return the normal color, or the highlight color, or the picking color, as appropriate.
+```
+main() {
+  gl_FragColor = ...
+  gl_FragColor = picking_filterColor(color);
+}
+```
+
+If highlighting is not needed, you simply apply (call) the `picking_filterPickingColor` filter function at the very end of the shader. This will return the normal color or the picking color, as appropriate.
 ```
 main() {
   gl_FragColor = ...
   gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 ```
-If you would like to apply the highlight color to the currently selected element call `picking_filterHighlightColor` before calling `picking_filterPickingColor`. You can also apply other filters on the non-picking color (vertex or highlight color) by placing those instruction between these two function calls.
 
+If additional filters need to be applied on the non-picking color (vertex or highlight color) you can use above functions in following order.
  ```
 main() {
-   gl_FragColor = picking_filterHighlightColor(color);
+   gl_FragColor = ...
+   gl_FragColor = picking_filterHighlightColor(gl_FragColor);
     ... apply any filters on gl_FragColor ...
   gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
-
 ```
 
 ## JavaScript Functions

--- a/src/shadertools/modules/picking/picking.js
+++ b/src/shadertools/modules/picking/picking.js
@@ -87,6 +87,16 @@ vec4 picking_filterPickingColor(vec4 color) {
   vec3 pickingColor = picking_vRGBcolor_Aselected.rgb;
   return picking_uActive ? vec4(pickingColor, 1.0) : color;
 }
+
+/*
+ * Returns picking color if picking is enabled if not
+ * highlight color if this item is selected, otherwise unmodified argument.
+ */
+vec4 picking_filterColor(vec4 color) {
+  vec4 highightColor = picking_filterHighlightColor(color);
+  return picking_filterPickingColor(highightColor);
+}
+
 `;
 
 export default {


### PR DESCRIPTION
#### Background
Add a convenience method in picking module , that can be used when highlighting enabled with no custom filters. 
<!-- For all the PRs -->
#### Change List
- PickingModule: Add picking_filterColor method
