### PR TITLE
Integrate test-browser with "git commit"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ node_js:
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
   - npm run build
+script:
+  - npm run test-ci

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bench": "node test/bench/node.js",
     "bench-browser": "webpack-dev-server --config test/webpack.config.js  --env.bench --progress --hot --open",
     "test": "npm run lint && npm run build && npm run test-node && npm run test-dist &&  npm run collect-metrics && npm run test-browser-puppet",
+    "test-ci": "npm run lint && npm run build && npm run test-node && npm run test-dist &&  npm run collect-metrics",
     "test-cover": "NODE_ENV=test tape -r babel-register test/node.js && nyc report",
     "test-fast": "node test/node.js",
     "test-fp64": "(cd src/shadertools/test && webpack-dev-server --progress --hot --open)",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "publish-beta": "npm run build && npm run test-fast && npm publish --tag beta",
     "bench": "node test/bench/node.js",
     "bench-browser": "webpack-dev-server --config test/webpack.config.js  --env.bench --progress --hot --open",
-    "test": "npm run lint && npm run build && npm run test-node && npm run test-dist &&  npm run collect-metrics",
+    "test": "npm run lint && npm run build && npm run test-node && npm run test-dist &&  npm run collect-metrics && npm run test-browser-puppet",
     "test-cover": "NODE_ENV=test tape -r babel-register test/node.js && nyc report",
     "test-fast": "node test/node.js",
     "test-fp64": "(cd src/shadertools/test && webpack-dev-server --progress --hot --open)",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "math.gl": ">=1.1.0-alpha.1",
-    "probe.gl": ">=1.0.0-alpha.10",
+    "probe.gl": ">=1.0.0-alpha.11",
     "seer": "^0.2.4",
     "webgl-debug": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5099,9 +5099,9 @@ private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
-probe.gl@>=1.0.0-alpha.10:
-  version "1.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-1.0.0-alpha.10.tgz#c40c1af9d16d1a69929df3d5d92675920f99622d"
+probe.gl@>=1.0.0-alpha.11:
+  version "1.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-1.0.0-alpha.11.tgz#50e00a77fc770acb32430aca88a9d12ba113a5a7"
   dependencies:
     babel-runtime "^6.11.6"
 


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
Add browser based unit tests to regular npm test which is integrated with "git commit", with this we can have better check to prevent regression.
<!-- For all the PRs -->
#### Change List
- Bump probe.gl to 1.0.0-alpha.11 which has some improvements to fix issues in test-browser
- Add test-browser to npm test
