### PR TITLE
Allow null uniforms

### DIFF
--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -208,7 +208,7 @@ function checkUniformValue(value) {
   }
 
   // Check if single value is a number
-  if (Number.isFinite(value)) {
+  if (isFinite(value)) {
     return true;
   } else if (value === true || value === false) {
     return true;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #470
<!-- For other PRs without open issue -->
#### Background
In #460 we changed single uniform value checking from `isFinite()` to more strict `Number.isFinite()`,  this doesn't allow `null` value for uniforms. This is causing deck.gl `render-test` fail since `outline` shader is using null value for `outline_uShadowmap` (default value), but within the shader this uniform is ignored using `outlineEnabled` uniform.

This may be true in other shder modules, until we enforce no 'null' value for all uniforms in all modules we should allow `null` values for uniforms.
<!-- For all the PRs -->
#### Change List
- Allow null uniforms
