### PR TITLE
Fix browser test of Framebuffer.blit

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -24,8 +24,7 @@
             "safari": "10.1",
             "node": "8"
           },
-          "modules": false,
-          "debug": true
+          "modules": false
         }]
       ]
     },

--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -507,11 +507,11 @@ export default class Framebuffer extends Resource {
 
     const prevDrawHandle = gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, this.handle);
     const prevReadHandle = gl.bindFramebuffer(GL_READ_FRAMEBUFFER, srcFramebuffer.handle);
-    const prevReadBuffer = gl.readBuffer(attachment);
+    gl.readBuffer(attachment);
     gl.blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
-    gl.readBuffer(prevReadBuffer);
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, prevReadHandle);
-    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, prevDrawHandle);
+    gl.readBuffer(this.readBuffer);
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, prevReadHandle || null);
+    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, prevDrawHandle || null);
 
     return this;
   }


### PR DESCRIPTION
For #495
#### Background
- readBuffer API does not return a value.
#### Change List
- Fix to Framebuffer.blit
- Remove debug setting from `.babelrc` to reduce console noise when building.
