### PR TITLE
Add discard too picking.js fragment shader

### DIFF
--- a/src/shadertools/modules/picking/picking.js
+++ b/src/shadertools/modules/picking/picking.js
@@ -85,6 +85,9 @@ vec4 picking_filterHighlightColor(vec4 color) {
  */
 vec4 picking_filterPickingColor(vec4 color) {
   vec3 pickingColor = picking_vRGBcolor_Aselected.rgb;
+  if (picking_uActive && length(pickingColor) < 0.001) {
+    discard;
+  }
   return picking_uActive ? vec4(pickingColor, 1.0) : color;
 }
 


### PR DESCRIPTION
For #432

#### Background
https://github.com/uber/deck.gl/blob/1caf4b2b50fef27c526498e22eea75eb77befb6a/dev-docs/RFCs/v5.3/picking-overlapping-objects-rfc.md

#### Change List
- Add discard when picking color is all zero