### PR TITLE
fix broken links by removing first slash

### DIFF
--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -5,9 +5,9 @@ luma.gl constains a lot of classes and functions that might make new users wonde
 | Folder                           | Description |
 | ---                              | --- |
 | src/webgl | A set of classes covering all **WebGL objects**. Currently luma.gl supports WebGL 2.0. These classes organize the sprawling WebGL API and makes it easy to work with in JavaScript. |
-| src/core | A set of common classes across all 3D graphics applications. They are on a higher abstraction level than the WebGL API. luma.gl's signature [`Model`](/#/documentation/api-reference/model) class is in this folder. |
-| src/geometry | This folder contains a collection of geometric primitives extending from the base `Geometry` class, including `ConeGeometry`, `CubeGeometry`, `IcoSphereGeometry`, `PlaneGeometry`, `SphereGeometry`, `SphereGeometry`. They can be used to create [`Models`](/#/documentation/api-reference/model) class with common geometries|
-| src/models | Some predefined subclasses of [`Models`](/#/documentation/api-reference/model) created from simple geometries from the `src/geometry` folder|
+| src/core | A set of common classes across all 3D graphics applications. They are on a higher abstraction level than the WebGL API. luma.gl's signature [`Model`](#/documentation/api-reference/model) class is in this folder. |
+| src/geometry | This folder contains a collection of geometric primitives extending from the base `Geometry` class, including `ConeGeometry`, `CubeGeometry`, `IcoSphereGeometry`, `PlaneGeometry`, `SphereGeometry`, `SphereGeometry`. They can be used to create [`Models`](#/documentation/api-reference/model) class with common geometries|
+| src/models | Some predefined subclasses of [`Models`](#/documentation/api-reference/model) created from simple geometries from the `src/geometry` folder|
 | src/io | Node.js and browser file loaders. Also enables using streams in browser. |
 | src/packages/events | A very simple browser event handling class used by luma.gl examples |
 | src/shadertools | luma.gl's internal shader module system and shader assembler utility |
@@ -17,15 +17,15 @@ luma.gl constains a lot of classes and functions that might make new users wonde
 
 The heart of luma.gl is the `webgl` module, a set of JavaScript class wrappers covering all WebGL objects. From luma.gl v4, These classes help organize the sprawling WebGL2 API and makes it much easier to program WebGL2 in JavaScript.
 
-After creating a context, perhaps with luma.gl's [`createGLContext`](/#/documentation/api-reference/create-context) function, you have can start instantiating luma.gl's WebGL2 classes: [`Buffer`](/#/documentation/api-reference/buffer), [`FrameBuffer`](/#/documentation/api-reference/framebuffer), [`RenderBuffer`](/#/documentation/api-reference/renderbuffer), [`Program`](/#/documentation/api-reference/program), [`Shader`](/#/documentation/api-reference/shader), [`Texture2D`](/#/documentation/api-reference/texture-2), [`Texture2DArray`](/#/documentation/api-reference/texture-2-array), [`Texture3D`](/#/documentation/api-reference/texture-3d), [`TextureCube`](/#/documentation/api-reference/texture-cube), [`Query`](/#/documentation/api-reference/query), [`Sampler`](/#/documentation/api-reference/sampler), [`TransformFeedback`](/#/documentation/api-reference/transform-feedback), [`VertexArrayObject`](/#/documentation/api-reference/vertex-array)
+After creating a context, perhaps with luma.gl's [`createGLContext`](#/documentation/api-reference/create-context) function, you have can start instantiating luma.gl's WebGL2 classes: [`Buffer`](#/documentation/api-reference/buffer), [`FrameBuffer`](#/documentation/api-reference/framebuffer), [`RenderBuffer`](#/documentation/api-reference/renderbuffer), [`Program`](#/documentation/api-reference/program), [`Shader`](#/documentation/api-reference/shader), [`Texture2D`](#/documentation/api-reference/texture-2), [`Texture2DArray`](#/documentation/api-reference/texture-2-array), [`Texture3D`](#/documentation/api-reference/texture-3d), [`TextureCube`](#/documentation/api-reference/texture-cube), [`Query`](#/documentation/api-reference/query), [`Sampler`](#/documentation/api-reference/sampler), [`TransformFeedback`](#/documentation/api-reference/transform-feedback), [`VertexArrayObject`](#/documentation/api-reference/vertex-array)
 
 ## Core Classes
 
-The `core` classes, with the signature [`Model`](/#/documentation/api-reference/model) class, represents a set of objects that is common in most 3D rendering libraries or engines. These objects are at higher abstraction levels than the actual WebGL objects and that can serve as the basic building blocks for most 3D applications.
+The `core` classes, with the signature [`Model`](#/documentation/api-reference/model) class, represents a set of objects that is common in most 3D rendering libraries or engines. These objects are at higher abstraction levels than the actual WebGL objects and that can serve as the basic building blocks for most 3D applications.
 
-* [`Model`](/#/documentation/api-reference/model) - A renderable object with program, attributes, uniforms and other state required for rendering 3D objects on the screen
-* [`Geometry`](/#/documentation/api-reference/geometry) - Holds attributes and drawType for a primitive geometric object
-* [`AnimationLoop`](/#/documentation/api-reference/animation-loop) - A simple animation loop that connects with browser's animation mechanism
+* [`Model`](#/documentation/api-reference/model) - A renderable object with program, attributes, uniforms and other state required for rendering 3D objects on the screen
+* [`Geometry`](#/documentation/api-reference/geometry) - Holds attributes and drawType for a primitive geometric object
+* [`AnimationLoop`](#/documentation/api-reference/animation-loop) - A simple animation loop that connects with browser's animation mechanism
 
 <!---
 * [`Object3D`](api-reference/core/object3d) - Base class, golds position, rotation, scale (TBD)
@@ -38,7 +38,7 @@ A `Geomtry` object holds a set of attributes (native JavaScript arrays) (vertice
 
 There are several basic geometry classes predefined in luma.gl: `Geometry`, `ConeGeometry`, `CubeGeometry`, `IcoSphereGeometry`, `PlaneGeometry`, `SphereGeometry`, `SphereGeometry`. They are all subclasses of the `Geometry` class.
 
-Corresponding to those geometry objects, luma.gl also provides commonly used [`Model`](/#/documentation/api-reference/model) classes that consist of basic geometries. These include [`Cone`](/#/documentation/api-reference/model), [`Cube`](/#/documentation/api-reference/model-cube), [`Cylinder`](/#/documentation/api-reference/model-cylinder), [`IcoSphere`](/#/documentation/api-reference/model-icosphere), [`Plane`](/#/documentation/api-reference/model-plane) and [`Sphere`](/#/documentation/api-reference/model-sphere), etc...
+Corresponding to those geometry objects, luma.gl also provides commonly used [`Model`](#/documentation/api-reference/model) classes that consist of basic geometries. These include [`Cone`](#/documentation/api-reference/model), [`Cube`](#/documentation/api-reference/model-cube), [`Cylinder`](#/documentation/api-reference/model-cylinder), [`IcoSphere`](#/documentation/api-reference/model-icosphere), [`Plane`](#/documentation/api-reference/model-plane) and [`Sphere`](#/documentation/api-reference/model-sphere), etc...
 
 
 Users are encouraged to write their own geometries and models and luma.gl could include them in its future releases.

--- a/docs/api-reference/advanced/design-notes.md
+++ b/docs/api-reference/advanced/design-notes.md
@@ -9,7 +9,7 @@ This is a scratch pad with various notes made during research of the luma.gl API
 * No ownership of WebGL context. Use your luma.gl context with other WebGL code, or use luma.gl with WebGL contexts created by other frameworks.
 
 API Design
-Note: luma.gl is not a "classic WebGL framework", in the sense that it intentionally doesn't try to hide WebGL from the developer under higher levels of abstraction (while a couple of higher level classes, like [`Model`](/#/documentation/api-reference/model), are offered, they do not ).
+Note: luma.gl is not a "classic WebGL framework", in the sense that it intentionally doesn't try to hide WebGL from the developer under higher levels of abstraction (while a couple of higher level classes, like [`Model`](#/documentation/api-reference/model), are offered, they do not ).
 
 
 ## WebGL Extensions

--- a/docs/api-reference/advanced/vertex-attributes.md
+++ b/docs/api-reference/advanced/vertex-attributes.md
@@ -4,7 +4,7 @@ WebGL provides an API to manipulate the global "vertex attributes array", which 
 
 This module offers set of functions for manipulating WebGL's global "vertex attributes array". Essentially, this module collects all WebGL `gl.vertexAttrib*` methods and `gl.VERTEX_ATTRIB_ARRAY_*` queries in a small JavaScript friendly package.
 
-**Note** It is usually not necessary to manipulate the vertex attributes array directly in luma.gl applications. It is often simpler to just supply named attribute buffers to the [`Model`](/#/documentation/api-reference/model) class, and rely on that class to automatically manage the vertex attributes array before running a program (e.g. when rendering, picking etc).
+**Note** It is usually not necessary to manipulate the vertex attributes array directly in luma.gl applications. It is often simpler to just supply named attribute buffers to the [`Model`](#/documentation/api-reference/model) class, and rely on that class to automatically manage the vertex attributes array before running a program (e.g. when rendering, picking etc).
 
 
 ### Overview of Vertex Attributes

--- a/docs/api-reference/core/README.md
+++ b/docs/api-reference/core/README.md
@@ -1,6 +1,6 @@
 # Core API Reference
 
-The `core module`, with the signature [`Model`](/#/documentation/api-reference/model) class, represent a set of fairly traditional 3D library classes on a slightly higher abstraction level than the WebGL2 API, that can serve as the basic building blocks for most applications.
+The `core module`, with the signature [`Model`](#/documentation/api-reference/model) class, represent a set of fairly traditional 3D library classes on a slightly higher abstraction level than the WebGL2 API, that can serve as the basic building blocks for most applications.
 
 Also contains a limited scene graph system that provides primitive hierarchy of 3D objects with positioning, grouping, traversal and scene support.
 
@@ -11,9 +11,9 @@ Note that the `Model` class is in many ways the quintessential luma.gl class. It
 
 The core module provides the following classes
 
-* [`AnimationFrame`](/#/documentation/api-reference/animation-frame) - render loop / app life cycle support
-* [`Model`](/#/documentation/api-reference/model) - A renderable object with attributes and uniforms.
-* [`Geometry`](/#/documentation/api-reference/geometry) - Holds attributes and drawType for a geometric primitive
+* [`AnimationFrame`](#/documentation/api-reference/animation-frame) - render loop / app life cycle support
+* [`Model`](#/documentation/api-reference/model) - A renderable object with attributes and uniforms.
+* [`Geometry`](#/documentation/api-reference/geometry) - Holds attributes and drawType for a geometric primitive
 
 ## Methods
 

--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -152,6 +152,6 @@ For the `onRenderFrame` callback, the parameter object will contain the followin
 * You can instantiate multiple `AnimationLoop` classes in parallel, rendering into the same or different `WebGLRenderingContext`s.
 * Works both in browser and under Node.js.
 * All `AnimationLoop` methods can be chained.
-* Postpones context creation until the page (i.e. all HTML) has been loaded. At this time it is safe to specify canvas ids when calling [`createGLContext`](/#/documentation/api-reference/create-context).
+* Postpones context creation until the page (i.e. all HTML) has been loaded. At this time it is safe to specify canvas ids when calling [`createGLContext`](#/documentation/api-reference/create-context).
 * The supplied callback function must return a WebGLRenderingContext or an error will be thrown.
 * This callback registration function should not be called if a `WebGLRenderingContext` was supplied to the AnimationLoop constructor.

--- a/docs/api-reference/core/model.md
+++ b/docs/api-reference/core/model.md
@@ -1,9 +1,9 @@
 # Model
 
 For most luma.gl  applications, the `Model` class is probably the most important class. It holds all the data necessary to draw an object in luma.gl, e.g.:
-* **shaders** (via a [`Program`](/#/documentation/api-reference/program) instance)
-* **shader modules** [see `Shader Modules`](/#/documentation/api-reference/shader-modules)
-* **vertex attributes** (e.g. a [`Geometry`](/#/documentation/api-reference/geometry) instance, plus any additional attributes for instanced rendering)
+* **shaders** (via a [`Program`](#/documentation/api-reference/program) instance)
+* **shader modules** [see `Shader Modules`](#/documentation/api-reference/shader-modules)
+* **vertex attributes** (e.g. a [`Geometry`](#/documentation/api-reference/geometry) instance, plus any additional attributes for instanced rendering)
 * **uniforms** these can also reference textures.
 
 It offers:

--- a/docs/api-reference/events/event.md
+++ b/docs/api-reference/events/event.md
@@ -1,6 +1,6 @@
 # Event
 
-Provides the [`Events`](/#/documentation/api-reference/event) object to bind events to the canvas to interact with 3D objects.
+Provides the [`Events`](#/documentation/api-reference/event) object to bind events to the canvas to interact with 3D objects.
 
 ### Examples:
 
@@ -83,7 +83,7 @@ Creates a set of events for the given domElement that can be handled through a c
 
 You can also provide callback functions for the events you need to
 handle. The first parameter of the callback is the event object
-described [here](/#/documentation/api-reference/event). If `picking` is set to `true` in the
+described [here](#/documentation/api-reference/event). If `picking` is set to `true` in the
 options, then the second parameter of the callback may be an
 `O3D` that is the target of the mouse event. If no target
 exists for the mouse event then a falsy value will be provided. The

--- a/docs/api-reference/models/README--not-in-use.md
+++ b/docs/api-reference/models/README--not-in-use.md
@@ -5,13 +5,13 @@ A geometry holds a set of attributes (native JavaScript arrays)
 
 | **Class** | **Description** |
 | --- | --- | --- |
-| [`Geometry`](/#/documentation/api-reference/geometry) | Base class, holds vertex attributes and drawType |
-| [`ConeGeometry`](/#/documentation/api-reference/geometry#ConeGeometry) | Vertex attributes for a cone |
-| [`CubeGeometry`](/#/documentation/api-reference/geometry#CubeGeometry) | Vertex attributes for a cube |
-| [`IcoSphereGeometry`](/#/documentation/api-reference/geometry#IcoSphereGeometry) | Vertex attributes for an icosahedron |
-| [`PlaneGeometry`](/#/documentation/api-reference/geometry#PlaneGeometry) | Vertex attributes for a plane |
-| [`SphereGeometry`](/#/documentation/api-reference/geometry#SphereGeometry) | Vertex attributes for a sphere |
-| [`SphereGeometry`](/#/documentation/api-reference/geometry#SphereGeometry) | Vertex attributes for a sphere |
+| [`Geometry`](#/documentation/api-reference/geometry) | Base class, holds vertex attributes and drawType |
+| [`ConeGeometry`](#/documentation/api-reference/geometry#ConeGeometry) | Vertex attributes for a cone |
+| [`CubeGeometry`](#/documentation/api-reference/geometry#CubeGeometry) | Vertex attributes for a cube |
+| [`IcoSphereGeometry`](#/documentation/api-reference/geometry#IcoSphereGeometry) | Vertex attributes for an icosahedron |
+| [`PlaneGeometry`](#/documentation/api-reference/geometry#PlaneGeometry) | Vertex attributes for a plane |
+| [`SphereGeometry`](#/documentation/api-reference/geometry#SphereGeometry) | Vertex attributes for a sphere |
+| [`SphereGeometry`](#/documentation/api-reference/geometry#SphereGeometry) | Vertex attributes for a sphere |
 
 It should be fairly straightforward to use other primitives, e.g. from npm modules. As long as you have a number of attributes you can wrap them in a `Geometry` or set them directly on a `Model` or a `Program`.
 

--- a/docs/api-reference/models/cone.md
+++ b/docs/api-reference/models/cone.md
@@ -1,6 +1,6 @@
 # Cone
 
-Creates a cone model. Inherits methods from [`Model`](/#/documentation/api-reference/model).
+Creates a cone model. Inherits methods from [`Model`](#/documentation/api-reference/model).
 
 ## Usage
 

--- a/docs/api-reference/models/cube.md
+++ b/docs/api-reference/models/cube.md
@@ -1,6 +1,6 @@
 # Cube
 
-Create a white cube model. Inherits methods from [`Model`](/#/documentation/api-reference/model)
+Create a white cube model. Inherits methods from [`Model`](#/documentation/api-reference/model)
 
 ## Usage
 
@@ -14,7 +14,7 @@ var whiteCube = new Cube(gl, {
 
 ### constructor
 
-Creates a Cube model. Inherits methods from [`Model`](/#/documentation/api-reference/model).
+Creates a Cube model. Inherits methods from [`Model`](#/documentation/api-reference/model).
 
 
 Use this to create a new Cube. Accepts the same properties and options as Model constructor but has preset for `vertices`, `normals` and `indices`.

--- a/docs/api-reference/models/cylinder.md
+++ b/docs/api-reference/models/cylinder.md
@@ -1,6 +1,6 @@
 # Cylinder
 
-Creates a cylinder model. Inherits methods from [`Model`](/#/documentation/api-reference/model).
+Creates a cylinder model. Inherits methods from [`Model`](#/documentation/api-reference/model).
 
 
 ## Usage

--- a/docs/api-reference/models/ico-sphere.md
+++ b/docs/api-reference/models/ico-sphere.md
@@ -1,6 +1,6 @@
 # IcoSphere
 
-Creates a sphere model by subdividing an Icosahedron. Inherits methods from [`Model`](/#/documentation/api-reference/model).
+Creates a sphere model by subdividing an Icosahedron. Inherits methods from [`Model`](#/documentation/api-reference/model).
 
 ## Usage
 

--- a/docs/api-reference/models/plane.md
+++ b/docs/api-reference/models/plane.md
@@ -1,6 +1,6 @@
 # Plane
 
-Creates a plane. Inherits methods from [`Model`](/#/documentation/api-reference/model).
+Creates a plane. Inherits methods from [`Model`](#/documentation/api-reference/model).
 
 ## Usage
 

--- a/docs/api-reference/models/sphere.md
+++ b/docs/api-reference/models/sphere.md
@@ -1,6 +1,6 @@
 # Sphere
 
-Creates a sphere model. Inherits methods from [`Model`](/#/documentation/api-reference/model).
+Creates a sphere model. Inherits methods from [`Model`](#/documentation/api-reference/model).
 
 ## Usage
 

--- a/docs/api-reference/webgl/README--not-in-use.md
+++ b/docs/api-reference/webgl/README--not-in-use.md
@@ -18,25 +18,25 @@ These objects all inherit from the [`Resource`](resource.html) class.
 | ----------------------------------- | ============== | =============== |
 | **Resource Class**                  | **WebGL Type** | **Description** |
 | ----------------------------------- | ============== | =============== |
-| [`Buffer`](/#/documentation/api-reference/buffer)             | [`WebGLBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer) | Holds memory on GPU |
-| [`Framebuffer`](/#/documentation/api-reference/framebuffer)   | [`WebGLFrameBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLFrameBuffer) | Off-screen render target, Container for textures and renderbuffers. |
-| [`Renderbuffer`](/#/documentation/api-reference/renderbuffer) | [`WebGLRenderBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderBuffer) | Holds image data that is optimized for rendering but does not supporting sampling |
-| [`Program`](/#/documentation/api-reference/program)           | [`WebGLProgram`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLProgram) | Shaders, attributes and uniforms. |
-| [`Shader`](/#/documentation/api-reference/shader)             | [`WebGLShader`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLProgram) | Holds a compiled GLSL shader program. |
-| [`Texture2D`](/#/documentation/api-reference/texture-2d)         | [`WebGLTexture(GL.TEXTURE_2D)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds a loaded texture in a format that supports sampling |
-| [`TextureCube`](/#/documentation/api-reference/texture-cube)       | [`WebGLTexture(GL.TEXTURE_CUBE)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds 6 textures |
-| [`Texture2DArray`](/#/documentation/api-reference/texture-2d-array) **WebGL2** | [`WebGLTexture(GL.TEXTURE_2D_ARRAY)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds an array of textures |
-| [`Texture3D`](/#/documentation/api-reference/texture-3d) **WebGL2** | [`WebGLTexture(GL.TEXTURE_3D)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds a stack of textures |
-| [`Query`](/#/documentation/api-reference/query) **WebGL2/ext*** | [`WebGLQuery`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLQuery) | Occlusion, Tranform Feedback and Performance Queries |
-| [`Sampler`](/#/documentation/api-reference/sampler) **WebGL2** | [`WebGLSampler`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLSampler) | Stores texture sampling params  |
-| [`Sync`](/#/documentation/api-reference/sync) **WebGL2**      | [`WebGLSync`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLSync) | Synchronize GPU and app. |
-| [`TransformFeedback`](/#/documentation/api-reference/transform-feedback) **WebGL2** | [`WebGLTransformFeedback`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTransformFeedback) | Capture Vertex Shader output |
-| [`VertexArrayObject`](/#/documentation/api-reference/vertex-array-object) **WebGL2/ext** | [`WebGLVertexArrayObject`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLVertexArrayObject) | Save global vertex attribute array. |
+| [`Buffer`](#/documentation/api-reference/buffer)             | [`WebGLBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer) | Holds memory on GPU |
+| [`Framebuffer`](#/documentation/api-reference/framebuffer)   | [`WebGLFrameBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLFrameBuffer) | Off-screen render target, Container for textures and renderbuffers. |
+| [`Renderbuffer`](#/documentation/api-reference/renderbuffer) | [`WebGLRenderBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderBuffer) | Holds image data that is optimized for rendering but does not supporting sampling |
+| [`Program`](#/documentation/api-reference/program)           | [`WebGLProgram`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLProgram) | Shaders, attributes and uniforms. |
+| [`Shader`](#/documentation/api-reference/shader)             | [`WebGLShader`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLProgram) | Holds a compiled GLSL shader program. |
+| [`Texture2D`](#/documentation/api-reference/texture-2d)         | [`WebGLTexture(GL.TEXTURE_2D)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds a loaded texture in a format that supports sampling |
+| [`TextureCube`](#/documentation/api-reference/texture-cube)       | [`WebGLTexture(GL.TEXTURE_CUBE)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds 6 textures |
+| [`Texture2DArray`](#/documentation/api-reference/texture-2d-array) **WebGL2** | [`WebGLTexture(GL.TEXTURE_2D_ARRAY)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds an array of textures |
+| [`Texture3D`](#/documentation/api-reference/texture-3d) **WebGL2** | [`WebGLTexture(GL.TEXTURE_3D)`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture) | Holds a stack of textures |
+| [`Query`](#/documentation/api-reference/query) **WebGL2/ext*** | [`WebGLQuery`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLQuery) | Occlusion, Tranform Feedback and Performance Queries |
+| [`Sampler`](#/documentation/api-reference/sampler) **WebGL2** | [`WebGLSampler`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLSampler) | Stores texture sampling params  |
+| [`Sync`](#/documentation/api-reference/sync) **WebGL2**      | [`WebGLSync`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLSync) | Synchronize GPU and app. |
+| [`TransformFeedback`](#/documentation/api-reference/transform-feedback) **WebGL2** | [`WebGLTransformFeedback`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLTransformFeedback) | Capture Vertex Shader output |
+| [`VertexArrayObject`](#/documentation/api-reference/vertex-array-object) **WebGL2/ext** | [`WebGLVertexArrayObject`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLVertexArrayObject) | Save global vertex attribute array. |
 
 | ----------------------------------- | ============== | =============== |
 | **Class/Module**                    | **WebGL Type** | **Description** |
 | ----------------------------------- | ============== | =============== |
-| [`context`](/#/documentation/api-reference/webgl-context)           | [`WebGLRenderingContext`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext) | The main GL context. |
+| [`context`](#/documentation/api-reference/webgl-context)           | [`WebGLRenderingContext`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext) | The main GL context. |
 | [`VertexAttributes`](vertex-attributes.html) | [`gl.vertexAttrib*`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer)  | Manipulates shader attributes (TBD merge with VAO?) |
 
 

--- a/docs/api-reference/webgl/context-features/get-features.md
+++ b/docs/api-reference/webgl/context-features/get-features.md
@@ -1,3 +1,3 @@
 # getFeatures
 
-This function returns an object containing all available features (as defined in the [extension table](/#/documentation/api-reference/has-features#optional-feature-detection)) on this platform.
+This function returns an object containing all available features (as defined in the [extension table](#/documentation/api-reference/has-features#optional-feature-detection)) on this platform.

--- a/docs/api-reference/webgl/context-features/has-features.md
+++ b/docs/api-reference/webgl/context-features/has-features.md
@@ -6,7 +6,7 @@ WebGL capabilities can vary quite dramatically between browsers (from minimal We
 
 To simplify detecting and working with conditionally available capabilities (or "features") luma.gl provides:
 
-* A set of functions (e.g. [`isWebGL2`](/#/documentation/api-reference/is-webgl-2), [`getFeatures`](/#/documentation/api-reference/get-features) and `hasFeatures`, described in this document) that enable you to check if the application is currently running on an environment that supports a certain feature (regardless of whether it is supported through e.g. WebGL2 or a WebGL1 extension).
+* A set of functions (e.g. [`isWebGL2`](#/documentation/api-reference/is-webgl-2), [`getFeatures`](#/documentation/api-reference/get-features) and `hasFeatures`, described in this document) that enable you to check if the application is currently running on an environment that supports a certain feature (regardless of whether it is supported through e.g. WebGL2 or a WebGL1 extension).
 
 In addition, luma.gl's WebGL classes transparently use WebGL extensions or WebGL2 APIs as appropriate, meaning that the amount of conditional logic in application code can be kept to a minimum. Once you have established that a capability exists, luma.gl offers you one unified way to use it.
 
@@ -113,7 +113,7 @@ Parameters to `hasFeatures`:
 | `FEATURES.VERTEX_ARRAY_OBJECT`        | **YES** | *      | `VertexArrayObjects` can be created [`OES_vertex_array_object`](https://developer.mozilla.org/en-US/docs/Web/API/OES_vertex_array_object) |
 | `FEATURES.ELEMENT_INDEX_UINT32`       | **YES** | *      | 32 bit indices available for `GL.ELEMENT_ARRAY_BUFFER`s [`OES_element_index_uint`](https://developer.mozilla.org/en-US/docs/Web/API/OES_element_index_uint) |
 | `FEATURES.BLEND_MINMAX`               | **YES** | *      | `GL.MIN`, `GL.MAX` blending modes are available: [`EXT_blend_minmax`](https://developer.mozilla.org/en-US/docs/Web/API/EXT_blend_minmax) |
-| `FEATURES.TIMER_QUERY`                | *       | *      | [`Query`](/#/documentation/api-reference/query) objects support asynchronous GPU timings [`EXT_disjoint_timer_query_webgl2`](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/), [`EXT_disjoint_timer_query`](https://developer.mozilla.org/en-US/docs/Web/API/EXT_disjoint_timer_query) |
+| `FEATURES.TIMER_QUERY`                | *       | *      | [`Query`](#/documentation/api-reference/query) objects support asynchronous GPU timings [`EXT_disjoint_timer_query_webgl2`](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/), [`EXT_disjoint_timer_query`](https://developer.mozilla.org/en-US/docs/Web/API/EXT_disjoint_timer_query) |
 | **`Texture`s and `Framebuffer`s** |    |        | |
 | `FEATURES.TEXTURE_FLOAT`              | **YES** | *      | Floating point (`Float32Array`) textures can be created and set as samplers (Note that filtering and rendering need to be queried separately, even in WebGL2)  [`OES_texture_float`](https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float) |
 | `FEATURES.TEXTURE_HALF_FLOAT`         | **YES** |        | Half float (`Uint16Array`) textures can be created and set as samplers [`OES_texture_half_float`](https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_half_float) [`WEBGL_color_buffer_float`](https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_color_buffer_float) |

--- a/docs/api-reference/webgl/program.md
+++ b/docs/api-reference/webgl/program.md
@@ -1,6 +1,6 @@
 # Program
 
-A `Program` contains a matched pair of vertex and fragment [shaders](/#/documentation/api-reference/shader) that can be exectued on the GPU by calling `Program.draw()`. Programs handle compilation and linking of shaders, setting and unsetting buffers (attributes), setting uniform values etc.
+A `Program` contains a matched pair of vertex and fragment [shaders](#/documentation/api-reference/shader) that can be exectued on the GPU by calling `Program.draw()`. Programs handle compilation and linking of shaders, setting and unsetting buffers (attributes), setting uniform values etc.
 
 | **Method**      | **Description** |
 | ---             | --- |

--- a/docs/api-reference/webgl/renderbuffer.md
+++ b/docs/api-reference/webgl/renderbuffer.md
@@ -1,6 +1,6 @@
 # Renderbuffer
 
-`Renderbuffer`s are WebGL Objects that contain textures. They are optimized for use as render targets, while vanilla `Texture`s may not be, and are the logical choice when you do not need to sample (i.e. in a post-pass shader) from the produced image. If you do need to sample (such as when reading depth back in a second shader pass), use [`Texture`](/#/documentation/api-reference/texture) instead. In addition, in WebGL2, `Renderbuffer` can do [Multisampling (MSAA)](https://www.khronos.org/opengl/wiki/Multisampling) just like standard framebuffer.
+`Renderbuffer`s are WebGL Objects that contain textures. They are optimized for use as render targets, while vanilla `Texture`s may not be, and are the logical choice when you do not need to sample (i.e. in a post-pass shader) from the produced image. If you do need to sample (such as when reading depth back in a second shader pass), use [`Texture`](#/documentation/api-reference/texture) instead. In addition, in WebGL2, `Renderbuffer` can do [Multisampling (MSAA)](https://www.khronos.org/opengl/wiki/Multisampling) just like standard framebuffer.
 
 For additional information, see [OpenGL Wiki](https://www.opengl.org/wiki/Renderbuffer_Object)
 
@@ -116,7 +116,7 @@ The "internal" format of the `Renderbuffer`.
 | `GL.DEPTH_COMPONENT16` |  16 depth bits |
 | `GL.STENCIL_INDEX8`    |  8 stencil bits |
 
-This table lists the basic formats supported in WebGL1. For a full table of formats supported in WebGL2 and via WebGL extensions, see [Texture](/#/documentation/api-reference/texture).
+This table lists the basic formats supported in WebGL1. For a full table of formats supported in WebGL2 and via WebGL extensions, see [Texture](#/documentation/api-reference/texture).
 
 | Sized Internal Format   | Format               | Type | Depth Bits | Stencil Bits |
 | ---                     | ---                  | ---  | ---        | --- |
@@ -185,6 +185,6 @@ When using a WebGL 2 context, the following values are available additionally:
 
 ## Remarks
 
-* The only way to work with a renderbuffer, besides creating it, is to attach it to a [`Framebuffer`](/#/documentation/api-reference/framebuffer).
+* The only way to work with a renderbuffer, besides creating it, is to attach it to a [`Framebuffer`](#/documentation/api-reference/framebuffer).
 * A `Renderbuffer` cannot be accessed by a shader in any way.
 * Multisampling is only available in WebGL2

--- a/docs/api-reference/webgl/sampler.md
+++ b/docs/api-reference/webgl/sampler.md
@@ -2,14 +2,14 @@
 
 A [Sampler object](https://www.khronos.org/opengl/wiki/Sampler_Object) is an OpenGL Object that stores the sampling parameters for a texture access inside of a shader. While texture sampling parameters can be specified directly on textures, samplers allow them to be specified independently. Thus, by using samplers an application can render the same texture with different parameters without duplicating the texture or modifying the texture parameters.
 
-To use a sampler, bind it to the same texture unit as a texture to control sampling for that texture. When using the higher level [`Model`](/#/documentation/api-reference/model) class, samplers can be specified using uniform names instead of texture indices.
+To use a sampler, bind it to the same texture unit as a texture to control sampling for that texture. When using the higher level [`Model`](#/documentation/api-reference/model) class, samplers can be specified using uniform names instead of texture indices.
 
 For more information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Sampler_Object).
 
 
 ## Usage
 
-Sampler inherits from [Resource](/#/documentation/api-reference/resource) and supports the same use cases.
+Sampler inherits from [Resource](#/documentation/api-reference/resource) and supports the same use cases.
 
 Create a new `Sampler`
 ```js
@@ -64,7 +64,7 @@ sampler2.bind(1);
 
 ### Base Class
 
-`Sampler` inherits methods and members from [Resource](/#/documentation/api-reference/resource), with the following remarks:
+`Sampler` inherits methods and members from [Resource](#/documentation/api-reference/resource), with the following remarks:
 
 * `handle` - Handle to the underlying `WebGLSampler` object
 * `getParameters` uses WebGL APIs [WebGLRenderingContext.getSamplerParameter](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/getSamplerParameter)

--- a/docs/api-reference/webgl/texture-2d-array.md
+++ b/docs/api-reference/webgl/texture-2d-array.md
@@ -4,7 +4,7 @@ A `Texture2DArray` holds a array of textures of the same size and format. The en
 
 Texture arrays can be used as texture atlases if all textures are of the same size and format.
 
-Most texture related functionality is implemented by and documented on the [Texture](/#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
+Most texture related functionality is implemented by and documented on the [Texture](#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
 
 
 ## Usage
@@ -29,7 +29,7 @@ if (Texture2DArray.isSupported()) {
 
 ## Methods
 
-`Texture2DArray` is a subclass of the [Texture](/#/documentation/api-reference/texture) and [Resource](/#/documentation/api-reference/resource) classes and inherit all methods and members of those classes.
+`Texture2DArray` is a subclass of the [Texture](#/documentation/api-reference/texture) and [Resource](#/documentation/api-reference/resource) classes and inherit all methods and members of those classes.
 
 
 ### Texture2DArray.isSupported(gl)

--- a/docs/api-reference/webgl/texture-2d.md
+++ b/docs/api-reference/webgl/texture-2d.md
@@ -2,7 +2,7 @@
 
 2D textures hold basic "single image" textures (although technically they can contain multiple mimap levels). They hold image memory of a certain format and size, determined at initialization time. They can be read from using shaders and written to by attaching them to frame buffers.
 
-Most texture related functionality is implemented by and documented on the [Texture](/#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
+Most texture related functionality is implemented by and documented on the [Texture](#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
 
 
 ## Usage
@@ -95,4 +95,4 @@ new Texture2D(gl, {
 * `parameters`=`{}` (*object*) - map of texture sampler parameters.
 * `pixelStore`=`{}` (*object*) - map of pixel store parameters (controls how `data` is interpreted when Textures are initialized from memory)
 
-Note that since many of the constructor parameters are common to all the `Texture` classes they are detailed in [`Texture`](/#/documentation/api-reference/texture). Sampler parameters are specified in [Sampler](/#/documentation/api-reference/sampler), and pixel store parameters are specified in [State Management](/#/documentation/api-reference/get-parameter)
+Note that since many of the constructor parameters are common to all the `Texture` classes they are detailed in [`Texture`](#/documentation/api-reference/texture). Sampler parameters are specified in [Sampler](#/documentation/api-reference/sampler), and pixel store parameters are specified in [State Management](#/documentation/api-reference/get-parameter)

--- a/docs/api-reference/webgl/texture-3d.md
+++ b/docs/api-reference/webgl/texture-3d.md
@@ -4,7 +4,7 @@ A `Texture3D` holds a number of textures of the same size and format. The entire
 
 3D textures are typically used to store volumetric data or for 3D lookup tables in shaders.
 
-Most texture related functionality is implemented by and documented on the [Texture](/#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
+Most texture related functionality is implemented by and documented on the [Texture](#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
 
 
 ## Usage

--- a/docs/api-reference/webgl/texture-cube.md
+++ b/docs/api-reference/webgl/texture-cube.md
@@ -4,7 +4,7 @@ A texture cube holds six textures that represent faces of the cube. A main featu
 
 `TextureCube`s are typically used to store environment maps. As an example, by rendering an environment into a texture cube, reflections in objects can then be rendered efficiently.
 
-Most texture related functionality is implemented by and documented on the [Texture](/#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
+Most texture related functionality is implemented by and documented on the [Texture](#/documentation/api-reference/texture) base class. For additional information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
 
 
 # Usage

--- a/docs/api-reference/webgl/texture.md
+++ b/docs/api-reference/webgl/texture.md
@@ -3,10 +3,10 @@
 A `Texture` is a WebGL object that contains one or more images that all have the same image format. Shaders can read from textures (through a sampler uniform) and they can be set up as render targets (by attaching them to a framebuffer).
 
 Note: This section describes the `Texture` base class that implements functionality common to all four types of WebGL:
-* [`Texture2D`](/#/documentation/api-reference/texture-2d) - Contains a "normal" image texture
-* [`TextureCube`](/#/documentation/api-reference/texture-cube) - Holds 6 textures representing sides of a cube.
-* [`Texture2DArray`](/#/documentation/api-reference/texture-2d-array) (WebGL2) - Holds an array of textures
-* [`Texture3D`](/#/documentation/api-reference/texture-3d) (WebGL2) - Holds a "stack" of textures which enables 3D interpolation.
+* [`Texture2D`](#/documentation/api-reference/texture-2d) - Contains a "normal" image texture
+* [`TextureCube`](#/documentation/api-reference/texture-cube) - Holds 6 textures representing sides of a cube.
+* [`Texture2DArray`](#/documentation/api-reference/texture-2d-array) (WebGL2) - Holds an array of textures
+* [`Texture3D`](#/documentation/api-reference/texture-3d) (WebGL2) - Holds a "stack" of textures which enables 3D interpolation.
 
 For more details see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Texture).
 
@@ -15,7 +15,7 @@ Note that textures have a lot of optional capabilities made available by extensi
 
 ## Usage
 
-* For additional usage examples, `Texture` inherits from [`Resource`](/#/documentation/api-reference/resource).
+* For additional usage examples, `Texture` inherits from [`Resource`](#/documentation/api-reference/resource).
 
 Configuring a Texture
 ```js
@@ -68,15 +68,15 @@ Sampler parameters can be accessed using `Texture.getParameter`, e.g:
 ### constructor
 
 The texture class cannot be constructed directly. It is a base class that provides common methods the the concrete texture classes.
-* [`Texture2D`](/#/documentation/api-reference/texture-2d),
-* [`TextureCube`](/#/documentation/api-reference/texture-cube),
-* [`Texture2DArray`](/#/documentation/api-reference/texture-2d-array) and
-* [`Texture3D`](/#/documentation/api-reference/texture-3d).
+* [`Texture2D`](#/documentation/api-reference/texture-2d),
+* [`TextureCube`](#/documentation/api-reference/texture-cube),
+* [`Texture2DArray`](#/documentation/api-reference/texture-2d-array) and
+* [`Texture3D`](#/documentation/api-reference/texture-3d).
 
 The constructors for these classes should be used to create textures. They constructors all take common parameters, many of which are specified in this document.
 
-* Sampling parameters are described in [`Sampler`](/#/documentation/api-reference/sampler).
-* Pixel store parameters are described in [`State Management`](/#/documentation/api-reference/get-parameter).
+* Sampling parameters are described in [`Sampler`](#/documentation/api-reference/sampler).
+* Pixel store parameters are described in [`State Management`](#/documentation/api-reference/get-parameter).
 
 
 ### generateMipmap

--- a/docs/api-reference/webgl/transform-feedback.md
+++ b/docs/api-reference/webgl/transform-feedback.md
@@ -4,7 +4,7 @@
 
 The state managed by `TransformFeedback` objects includes the buffers the GPU will use to record the requested varyings.
 
-When `TransformFeedback` objects must be "activated" (`TransformFeedback.begin`) before it can be used. There a number of caveats to be aware of when manually managing `TransformFeedback` object activation, see the remarks. For this reason, luma.gl [`Program.draw`](/#/documentation/api-reference/program) call takes an optional `TransformFeedback` object as a parameter and activates and deactivates it before and after the draw call.
+When `TransformFeedback` objects must be "activated" (`TransformFeedback.begin`) before it can be used. There a number of caveats to be aware of when manually managing `TransformFeedback` object activation, see the remarks. For this reason, luma.gl [`Program.draw`](#/documentation/api-reference/program) call takes an optional `TransformFeedback` object as a parameter and activates and deactivates it before and after the draw call.
 
 Finally, note that when using transform feedback it is frequently desirable to turn off rasterization: `gl.enable(GL.RASTERIZER_DISCARD)` to prevent the fragment shader from running.
 

--- a/docs/api-reference/webgl/uniform-buffer-layout.md
+++ b/docs/api-reference/webgl/uniform-buffer-layout.md
@@ -122,5 +122,5 @@ Use the following WebGL types to declare uniforms corresponding to your GLSL dat
 ## Remarks
 
 * WebGL requires the data representing the uniforms in to be laid out in memory according to specific rules (essentially some padding needs to be injected between successive values to facilitate memory access by the GPU).
-* Note that WebGL2 uniform buffers are just [Buffer](/#/documentation/api-reference/buffer) objects and can be manipulated directly. The `UniformBufferLayout` class is not a WebGL2 object, it is just an optional helper class that makes it easy to create and update a block of memory with the required layout.
+* Note that WebGL2 uniform buffers are just [Buffer](#/documentation/api-reference/buffer) objects and can be manipulated directly. The `UniformBufferLayout` class is not a WebGL2 object, it is just an optional helper class that makes it easy to create and update a block of memory with the required layout.
 * More information on the `std140` layout specification: [OpenGL spec](https://khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=137)

--- a/docs/api-reference/webgl/vertex-array.md
+++ b/docs/api-reference/webgl/vertex-array.md
@@ -2,7 +2,7 @@
 
 A `VertexArray` holds a WebGL `VertexArrayObject` which stores a set of `Buffer` bindings representing the input data to GLSL shaders (in much the same way that a `TransformFeedback` object stores a set of `Buffer` bindings for output data from shaders).
 
-Note that it is usually not necessary to manipulate `VertexArray`s directly in luma.gl applications. It is often simpler to just supply named attribute buffers to the [`Model`](/#/documentation/api-reference/model) class, and rely on that class to automatically manage the vertex attributes array before running a program (e.g. when rendering, picking etc).
+Note that it is usually not necessary to manipulate `VertexArray`s directly in luma.gl applications. It is often simpler to just supply named attribute buffers to the [`Model`](#/documentation/api-reference/model) class, and rely on that class to automatically manage the vertex attributes array before running a program (e.g. when rendering, picking etc).
 
 For more information, see [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_Array_Object) as well as the remarks at the end.
 
@@ -282,7 +282,7 @@ Each vertex attribute has these properties:
 - An integer normalization policy (see below).
 - An integer conversion policy (see below) **WebGL2**.
 
-Normally attributes are set to a [`WebGLBuffer`](/#/documentation/api-reference/buffer) that stores unique values for each vertex/instance, combined with information about the layout of data in the memory managed by the buffer.
+Normally attributes are set to a [`WebGLBuffer`](#/documentation/api-reference/buffer) that stores unique values for each vertex/instance, combined with information about the layout of data in the memory managed by the buffer.
 
 Attributes can also be set to a single vertex value (or "generic" value) instead of a full array. This single value will then be passed to every invocation of the vertex shader effectively representing a constant attribute value. A typical example could be to specify a single color for all vertices, instead of providing a buffer with unique colors per vertex.
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -5,12 +5,12 @@
 
 ### Running under Node.js
 
-[Using with Node](/#/documentation/get-started/using-with-node): `"import luma.gl/headless"` is no longer required for luma.gl to load headless gl and the usage has been deprecated. You can now simply remove any such import statements from your code.
+[Using with Node](#/documentation/get-started/using-with-node): `"import luma.gl/headless"` is no longer required for luma.gl to load headless gl and the usage has been deprecated. You can now simply remove any such import statements from your code.
 
 
 ### Using Debug Contexts
 
-[Debugging](/#/documentation/get-started/debugging): The Khronos group's `WebGLDeveloperTools` are automatically installed when luma.gl is installed, but are not actually bundled into the application unless explicitly imported. This avoids impacting the size of production bundles built on luma.gl that typically do not need debug support.
+[Debugging](#/documentation/get-started/debugging): The Khronos group's `WebGLDeveloperTools` are automatically installed when luma.gl is installed, but are not actually bundled into the application unless explicitly imported. This avoids impacting the size of production bundles built on luma.gl that typically do not need debug support.
 
 To use debug support, first import the debug tools, then call `getDebugContext` to create a debug contexts from a normal WebGL context:
 
@@ -120,9 +120,9 @@ Some previously deprecated classes and functions have been removed in luma.gl v4
 
 | Symbol               | Replacement      | Comment |
 | ---                  | ---              | --- |
-| `Vec3`               | `Vector3`        | [New math library](/#/documentation/api-reference/math) |
-| `Mat4`               | `Matrix4`        | [New math library](/#/documentation/api-reference/math) |
-| `Quat`               | `Quaternion`     | [New math library](/#/documentation/api-reference/math) |
+| `Vec3`               | `Vector3`        | [New math library](#/documentation/api-reference/math) |
+| `Mat4`               | `Matrix4`        | [New math library](#/documentation/api-reference/math) |
+| `Quat`               | `Quaternion`     | [New math library](#/documentation/api-reference/math) |
 
 
 ## Deprecated Features
@@ -132,8 +132,8 @@ Some classes and functions have been deprecated in luma.gl v4. They will continu
 
 | Symbol               | Replacement      | Comment |
 | ---                  | ---              | --- |
-| `withState`          | `withParameters` | [New WebGL state management](/#/documentation/api-reference/with-parameters) |
-| `glContextWithState` | `withParameters` | [New WebGL state management](/#/documentation/api-reference/with-parameters) |
+| `withState`          | `withParameters` | [New WebGL state management](#/documentation/api-reference/with-parameters) |
+| `glContextWithState` | `withParameters` | [New WebGL state management](#/documentation/api-reference/with-parameters) |
 
 
 ## API Change
@@ -165,6 +165,6 @@ V3 was a fairly minor release, a number of deprecations were made.
 
 | Symbol               | Replacement      | Comment |
 | ---                  | ---              | --- |
-| `Vec3`               | `Vector3`        | [New math library](/#/documentation/api-reference/math) |
-| `Mat4`               | `Matrix4`        | [New math library](/#/documentation/api-reference/math) |
-| `Quat`               | `Quaternion`     | [New math library](/#/documentation/api-reference/math) |
+| `Vec3`               | `Vector3`        | [New math library](#/documentation/api-reference/math) |
+| `Mat4`               | `Matrix4`        | [New math library](#/documentation/api-reference/math) |
+| `Quat`               | `Quaternion`     | [New math library](#/documentation/api-reference/math) |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,6 +1,6 @@
 # What's New
 
-In addition to these notes, always check the [Upgrade Guide](/#/documentation/upgrade-guide) when considering adopting a new release.
+In addition to these notes, always check the [Upgrade Guide](#/documentation/upgrade-guide) when considering adopting a new release.
 
 
 ## Version 5.2
@@ -9,27 +9,27 @@ Date: May 24, 2018
 
 ## Transform class (New, WebGL2) (Experimental)
 
-The new experimental [`Transform`](/#/documentation/api-reference/transform) class provides an easy-to-use interface to perform Transform Feedback operations.
+The new experimental [`Transform`](#/documentation/api-reference/transform) class provides an easy-to-use interface to perform Transform Feedback operations.
 
 
 ## Framebuffer Class
 
-**Pixel Readback to GPU Buffers** (WebGL2) - A new method [`Framebuffer.readPixelsToBuffer`](/#/documentation/api-reference/framebuffer) is added to asynchronously read pixel data into a `Buffer` object. This allows  applications to reduce the CPU-GPU sync time by postponing transfer of data or to completely avoid GPU-CPU sync by using the pixel data in the GPU `Buffer` object directly as data source for another GPU draw or transform feedback operation.
+**Pixel Readback to GPU Buffers** (WebGL2) - A new method [`Framebuffer.readPixelsToBuffer`](#/documentation/api-reference/framebuffer) is added to asynchronously read pixel data into a `Buffer` object. This allows  applications to reduce the CPU-GPU sync time by postponing transfer of data or to completely avoid GPU-CPU sync by using the pixel data in the GPU `Buffer` object directly as data source for another GPU draw or transform feedback operation.
 
 
 ## Bundle Size Reduction
 
-The impact of importing luma.gl on production application bundle sizes has been reduced, in particular when using webpack 4 with appropriate configuration. A new article about [bundling and tree shaking](/#/documentation/developer-guide/building-apps]) has been added to the Developer Guide, providing in-depth information and guidance on what numbers to expect.
+The impact of importing luma.gl on production application bundle sizes has been reduced, in particular when using webpack 4 with appropriate configuration. A new article about [bundling and tree shaking](#/documentation/developer-guide/building-apps]) has been added to the Developer Guide, providing in-depth information and guidance on what numbers to expect.
 
 
 ## Running luma.gl in Node.js
 
-Running of luma.gl under Node.js is now easier than ever. luma.gl v5.2 automatically loads headless-gl if installed on the system, avoiding the need for the app to import special files or add other conditional logic. See [Using with Node](/#/documentation/get-started/using-with-node) and the Upgrade Guide.
+Running of luma.gl under Node.js is now easier than ever. luma.gl v5.2 automatically loads headless-gl if installed on the system, avoiding the need for the app to import special files or add other conditional logic. See [Using with Node](#/documentation/get-started/using-with-node) and the Upgrade Guide.
 
 
 ## Debug Mode Changes
 
-To further reduce production application bundle sizes, luma.gl no longer support WebGL debug contexts by default, as this requires including the Khronos [WebGLDeveloperTools](https://github.com/KhronosGroup/WebGLDeveloperTools) into the bundle. WebGL debug contexts are still available, but needs to be explicitly enabled. To understand how to use WebGL debug contexts in v5.2, please refer to the article on [Debugging](/#/documentation/developer-guide/debugging) and the Upgrade Guide.
+To further reduce production application bundle sizes, luma.gl no longer support WebGL debug contexts by default, as this requires including the Khronos [WebGLDeveloperTools](https://github.com/KhronosGroup/WebGLDeveloperTools) into the bundle. WebGL debug contexts are still available, but needs to be explicitly enabled. To understand how to use WebGL debug contexts in v5.2, please refer to the article on [Debugging](#/documentation/developer-guide/debugging) and the Upgrade Guide.
 
 
 ## Examples
@@ -51,7 +51,7 @@ Two improvements Performing Transform Feedback operations has gotten easier, mai
 
 `Program` now build a `varyingMap` on creation depending on `varyings` array and `drawMode`. This `varyingMap` can be passed to `TransformFeedback.bindBuffers()` enabling buffers to be indexed by the name of the "varying" instead of using an index.
 
-For more details check [`TransformFeedback`](/#/documentation/api-reference/transform-feedback) and [`Model`](/#/documentation/api-reference/model) documentation.
+For more details check [`TransformFeedback`](#/documentation/api-reference/transform-feedback) and [`Model`](#/documentation/api-reference/model) documentation.
 
 
 ## Version 5.0
@@ -116,7 +116,7 @@ A major release that brings full WebGL2 support to luma.gl, as well as adding su
 
 luma.gl now exposes the complete WebGL2 APIs:
 
-* New classes expose all the new WebGL2 objects ([`Query`](/#/documentation/api-reference/query), [`Sampler`](/#/documentation/api-reference/sampler), [`Texture2DArray`](/#/documentation/api-reference/texture-2-array), [`Texture3D`](/#/documentation/api-reference/texture-3d), and [`TransformFeedback`](/#/documentation/api-reference/transform-feedback)), together with a new [`UniformBufferLayout`](/#/documentation/api-reference/uniform-buffer-layout) helper class to make uniform buffers easy to use.
+* New classes expose all the new WebGL2 objects ([`Query`](#/documentation/api-reference/query), [`Sampler`](#/documentation/api-reference/sampler), [`Texture2DArray`](#/documentation/api-reference/texture-2-array), [`Texture3D`](#/documentation/api-reference/texture-3d), and [`TransformFeedback`](#/documentation/api-reference/transform-feedback)), together with a new [`UniformBufferLayout`](#/documentation/api-reference/uniform-buffer-layout) helper class to make uniform buffers easy to use.
 * Other existing WebGL classes with new functionalites under WebGL2 have been updated.
 * Add new WebGL2 texture formats and types support, including floating point textures, and multiple render targets.
 


### PR DESCRIPTION
On pages such as http://uber.github.io/luma.gl/#/documentation/developer-guide/api-overview there broken links, for example:
https://uber.github.io/#/documentation/api-reference/model
which should be
http://uber.github.io/luma.gl/#/documentation/api-reference/model

My fix was to remove the first slash, in hopes that the url is resolved after the `#`. Otherwise we'd need to add `/luma.gl/` to each of these.