### PR TITLE
Port fp64 utils from deck.gl

### DIFF
--- a/src/shadertools/modules/fp64/fp64-utils.js
+++ b/src/shadertools/modules/fp64/fp64-utils.js
@@ -1,5 +1,24 @@
-export function fp64ify(a) {
+export function fp64ify(a, array = [], startIndex = 0) {
   const hiPart = Math.fround(a);
-  const loPart = a - hiPart;
-  return [hiPart, loPart];
+  const loPart = a - Math.fround(a);
+  array[startIndex] = hiPart;
+  array[startIndex + 1] = loPart;
+  return array;
+}
+
+export function fp64LowPart(a) {
+  return a - Math.fround(a);
+}
+
+// calculate WebGL 64 bit matrix (transposed "Float64Array")
+export function fp64ifyMatrix4(matrix) {
+  // Transpose the projection matrix to column major for GLSL.
+  const matrixFP64 = new Float32Array(32);
+  for (let i = 0; i < 4; ++i) {
+    for (let j = 0; j < 4; ++j) {
+      const index = i * 4 + j;
+      fp64ify(matrix[j * 4 + i], matrixFP64, index * 2);
+    }
+  }
+  return matrixFP64;
 }

--- a/src/shadertools/modules/fp64/fp64-utils.js
+++ b/src/shadertools/modules/fp64/fp64-utils.js
@@ -1,16 +1,32 @@
-export function fp64ify(a, array = [], startIndex = 0) {
+/**
+ * Calculate WebGL 64 bit float
+ * @param a {number} - the input float number
+ * @param out {array, optional} - the output array. If not supplied, a new array is created.
+ * @param startIndex {integer, optional} - the index in the output array to fill from. Default 0.
+ * @returns {array} - the fp64 representation of the input number
+ */
+export function fp64ify(a, out = [], startIndex = 0) {
   const hiPart = Math.fround(a);
-  const loPart = a - Math.fround(a);
-  array[startIndex] = hiPart;
-  array[startIndex + 1] = loPart;
-  return array;
+  const loPart = a - hiPart;
+  out[startIndex] = hiPart;
+  out[startIndex + 1] = loPart;
+  return out;
 }
 
+/**
+ * Calculate the low part of a WebGL 64 bit float
+ * @param a {number} - the input float number
+ * @returns {number} - the lower 32 bit of the number
+ */
 export function fp64LowPart(a) {
   return a - Math.fround(a);
 }
 
-// calculate WebGL 64 bit matrix (transposed "Float64Array")
+/**
+ * Calculate WebGL 64 bit matrix (transposed "Float64Array")
+ * @param matrix {Matrix4} - the input matrix
+ * @returns {array} - the fp64 representation of the input matrix
+ */
 export function fp64ifyMatrix4(matrix) {
   // Transpose the projection matrix to column major for GLSL.
   const matrixFP64 = new Float32Array(32);

--- a/src/shadertools/modules/fp64/fp64.js
+++ b/src/shadertools/modules/fp64/fp64.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export {fp64ify} from './fp64-utils';
+export {fp64ify, fp64LowPart, fp64ifyMatrix4} from './fp64-utils';
 
 import fp64arithmeticShader from './fp64-arithmetic.glsl';
 import fp64functionShader from './fp64-functions.glsl';


### PR DESCRIPTION
#### Background
The fp64 shader module should be the source of utils that convert a float/matrix4 to compatible 64-bit representations.

#### Change List
- Extend existing `fp64ify` util
- Add `fp64LowPart` and `fp64ifyMatrix4` utils
