### PR TITLE
Allow non-buffer supplied to Transform's sourceBuffers

### DIFF
--- a/docs/api-reference/core/experimental/transform.md
+++ b/docs/api-reference/core/experimental/transform.md
@@ -123,7 +123,7 @@ Constructs a `Transform` object, creates `Model` and `TransformFeedback` instanc
 
 * `gl` (`WebGL2RenderingContext`) gl - context
 * `opts` (`Object`={}) - options
-  * `sourceBuffers` (`Object`) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Buffer` object.
+  * `sourceBuffers` (`Object`) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Attribute`, `Buffer` or attribute descriptor object.
   * `destinationBuffers` (`Object`, Optional) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Buffer` object.
   * `vs` (`String`) - vertex shader string.
   * `varyings` (`Array`) - Array of vertex shader varyings names.
@@ -139,7 +139,7 @@ Deletes all owned resources, `Model`, `TransformFeedback` and any `Buffer` objec
 
 Updates buffer bindings with provided buffer objects for one or more source or destination buffers.
 
-* `sourceBuffers` (`Object`) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Buffer` object.
+* `sourceBuffers` (`Object`) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Attribute`, `Buffer` or attribute descriptor object.
 * `destinationBuffers` (`Object`, Optional) - key and value pairs, where key is the name of vertex shader varying and value is the corresponding `Buffer` object.
 
 ### run
@@ -150,7 +150,7 @@ Performs one transform feedback iteration.
 
 ### swapBuffers
 
-Swaps source and destination buffers.
+Swaps source and destination buffers. If buffer swapping is used, `sourceBuffers` supplied to the constructor and/or the `update` method must be `Buffer` objects.
 
 ### getBuffer
 

--- a/src/core/experimental/transform.js
+++ b/src/core/experimental/transform.js
@@ -87,9 +87,6 @@ export default class Transform {
       return this;
     }
     const {currentIndex, varyingMap, _buffersSwapable, transformFeedbacks} = this;
-    for (const bufferName in sourceBuffers) {
-      assert(sourceBuffers[bufferName] instanceof Buffer);
-    }
     for (const bufferName in destinationBuffers) {
       assert(destinationBuffers[bufferName] instanceof Buffer);
     }
@@ -108,6 +105,8 @@ export default class Transform {
           this.destinationBuffers[currentIndex][destinationBufferName];
         this.destinationBuffers[nextIndex][destinationBufferName] =
           this.sourceBuffers[currentIndex][sourceBufferName];
+        // make sure the new destination buffer is a Buffer object
+        assert(this.destinationBuffers[nextIndex][destinationBufferName] instanceof Buffer);
       }
       transformFeedbacks[nextIndex].bindBuffers(
         this.destinationBuffers[nextIndex], {varyingMap}
@@ -149,9 +148,6 @@ export default class Transform {
     destinationBuffers = null
   }) {
     const {_buffersSwapable} = this;
-    for (const bufferName in sourceBuffers) {
-      assert(sourceBuffers[bufferName] instanceof Buffer);
-    }
     for (const bufferName in destinationBuffers) {
       assert(destinationBuffers[bufferName] instanceof Buffer);
     }
@@ -177,6 +173,8 @@ export default class Transform {
           this.destinationBuffers[0][destinationBufferName];
         this.destinationBuffers[1][destinationBufferName] =
           this.sourceBuffers[0][sourceBufferName];
+        // make sure the new destination buffer is a Buffer object
+        assert(this.destinationBuffers[1][destinationBufferName] instanceof Buffer);
       }
     }
   }

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -523,7 +523,7 @@ count: ${this.stats.profileFrameCount}`
         attribute = attribute || new Attribute(gl, Object.assign({}, descriptor.layout, {
           id: attributeName
         }));
-        attribute.update({buffer: descriptor});
+        attribute.update({isGeneric: false, buffer: descriptor});
       } else if (attribute) {
         attribute.update(descriptor);
       } else {


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/1797 - attribute transition to/from generic values

#### Background
`sourceBuffers` are set as attributes to the model and can be `Buffer`, `Attribute` or a plain descriptor object. `destinationBuffers` are rendered to and must be `Buffer` objects. This PR defers asserting the type of a `sourceBuffer` until it is used as a `destinationBuffer`.

#### Change List
- Relax requirements for `sourceBuffers` in `Transform` class
- Fix bug in `model._createBuffersFromAttributeDescriptors` where `isGeneric` flag is not cleared when applying external buffers
