### PR TITLE
Preparations to make shadertools independently publishable

### DIFF
--- a/src/shadertools/src/lib/assemble-shaders.js
+++ b/src/shadertools/src/lib/assemble-shaders.js
@@ -1,7 +1,7 @@
 import {resolveModules, getShaderModule} from './shader-modules';
 import {getPlatformShaderDefines, getVersionDefines} from './platform-defines';
 import {MODULE_INJECTORS_VS, MODULE_INJECTORS_FS} from '../modules/module-injectors';
-import assert from '../../../utils/assert';
+import assert from '../utils/assert';
 import {log} from '../../../utils';
 
 const VERTEX_SHADER = 'vs';

--- a/src/shadertools/src/lib/shader-cache.js
+++ b/src/shadertools/src/lib/shader-cache.js
@@ -1,6 +1,6 @@
 import {VertexShader, FragmentShader} from '../../../webgl/shader';
 import Program from '../../../webgl/program';
-import assert from '../../../utils/assert';
+import assert from '../utils/assert';
 
 export default class ShaderCache {
 

--- a/src/shadertools/src/lib/shader-modules.js
+++ b/src/shadertools/src/lib/shader-modules.js
@@ -1,4 +1,4 @@
-import assert from '../../../utils/assert';
+import assert from '../utils/assert';
 
 const shaderModules = {};
 let defaultShaderModules = [];

--- a/src/shadertools/src/utils/assert.js
+++ b/src/shadertools/src/utils/assert.js
@@ -1,0 +1,7 @@
+// Recommendation is to ignore message but current test suite checks agains the
+// message so keep it for now.
+export default function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'shadertools: assertion failed.');
+  }
+}

--- a/src/shadertools/src/utils/is-old-ie.js
+++ b/src/shadertools/src/utils/is-old-ie.js
@@ -1,0 +1,11 @@
+/* global window */
+// opts allows user agent to be overridden for testing
+export default function isOldIE(opts = {}) {
+  const navigator = typeof window !== 'undefined' ? window.navigator || {} : {};
+  const userAgent = opts.userAgent || navigator.userAgent;
+  // We only care about older versions of IE (IE 11 and below). Newer versions of IE (Edge)
+  // have much better web standards support.
+  const isMSIE = userAgent.indexOf('MSIE ') !== -1;
+  const isTrident = userAgent.indexOf('Trident/') !== -1;
+  return isMSIE || isTrident;
+}

--- a/src/shadertools/src/utils/webgl-info.js
+++ b/src/shadertools/src/utils/webgl-info.js
@@ -1,0 +1,125 @@
+// Feature detection for WebGL
+//
+// Provides a function that enables simple checking of which WebGL features are
+// available in an WebGL1 or WebGL2 environment.
+
+/* eslint-disable no-inline-comments, max-len */
+/* global WebGL2RenderingContext */
+import isOldIE from './is-old-ie';
+import assert from './assert';
+
+const GL_TEXTURE_BINDING_3D = 0x806A;
+
+const GL_VENDOR = 0x1F00;
+const GL_RENDERER = 0x1F01;
+const GL_VERSION = 0x1F02;
+const GL_SHADING_LANGUAGE_VERSION = 0x8B8C;
+
+// Defines luma.gl "feature" names and semantics
+const WEBGL_FEATURES = {
+  // GLSL extensions
+  GLSL_FRAG_DATA: ['WEBGL_draw_buffers', true], // TODO - name makes no sense in GLSL 3.00
+  GLSL_FRAG_DEPTH: ['EXT_frag_depth', true],
+  GLSL_DERIVATIVES: ['OES_standard_derivatives', true],
+  GLSL_TEXTURE_LOD: ['EXT_shader_texture_lod', true]
+};
+
+// Create a key-mirrored FEATURES array
+const FEATURES = {};
+Object.keys(WEBGL_FEATURES).forEach(key => {
+  FEATURES[key] = key;
+});
+
+export {FEATURES};
+
+function isWebGL2(gl) {
+  return Boolean(gl && (
+    gl instanceof WebGL2RenderingContext ||
+    gl.TEXTURE_BINDING_3D === GL_TEXTURE_BINDING_3D
+  ));
+}
+
+export function getContextInfo(gl) {
+  const info = gl.getExtension('WEBGL_debug_renderer_info');
+  const vendor = gl.getParameter((info && info.UNMASKED_VENDOR_WEBGL) || GL_VENDOR);
+  const renderer = gl.getParameter((info && info.UNMASKED_RENDERER_WEBGL) || GL_RENDERER);
+  const gpuVendor = identifyGPUVendor(vendor, renderer);
+  const gpuInfo = {
+    gpuVendor,
+    vendor,
+    renderer,
+    version: gl.getParameter(GL_VERSION),
+    shadingLanguageVersion: gl.getParameter(GL_SHADING_LANGUAGE_VERSION)
+  };
+  return gpuInfo;
+}
+
+function identifyGPUVendor(vendor, renderer) {
+  if (vendor.match(/NVIDIA/i) || renderer.match(/NVIDIA/i)) {
+    return 'NVIDIA';
+  }
+  if (vendor.match(/INTEL/i) || renderer.match(/INTEL/i)) {
+    return 'INTEL';
+  }
+  if (vendor.match(/AMD/i) || renderer.match(/AMD/i) ||
+    vendor.match(/ATI/i) || renderer.match(/ATI/i)) {
+    return 'AMD';
+  }
+  return 'UNKNOWN GPU';
+}
+
+const compiledGlslExtensions = {};
+
+// Enables feature detection in IE11 due to a bug where gl.getExtension may return true
+// but fail to compile when the extension is enabled in the shader. Specifically,
+// the OES_standard_derivatives extension fails to compile in IE11 even though its included
+// in the list of supported extensions.
+// opts allows user agent to be overridden for testing
+export function canCompileGLGSExtension(gl, cap, opts = {}) {
+  const feature = WEBGL_FEATURES[cap];
+  assert(feature, cap);
+
+  if (!isOldIE(opts)) {
+    return true;
+  }
+
+  if (cap in compiledGlslExtensions) {
+    return compiledGlslExtensions[cap];
+  }
+
+  const extensionName = feature[0];
+  const source = `#extension GL_${extensionName} : enable\nvoid main(void) {}`;
+
+  const shader = gl.createShader(gl.VERTEX_SHADER);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  const canCompile = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+  gl.deleteShader(shader);
+  compiledGlslExtensions[cap] = canCompile;
+  return canCompile;
+}
+
+// TODO - cache the value
+function getFeature(gl, cap) {
+  const feature = WEBGL_FEATURES[cap];
+  assert(feature, cap);
+
+  // Get extension name from table
+  const extensionName = isWebGL2(gl) ?
+    feature[1] || feature[0] :
+    feature[0];
+
+  // Check if the value is dependent on checking an extension
+  const value = typeof extensionName === 'string' ?
+    Boolean(gl.getExtension(extensionName)) :
+    extensionName;
+
+  assert(value === false || value === true);
+
+  return value;
+}
+
+export function hasFeatures(gl, features) {
+  features = Array.isArray(features) ? features : [features];
+  return features.every(feature => getFeature(gl, feature));
+}

--- a/src/shadertools/test/utils/is-old-ie.spec.js
+++ b/src/shadertools/test/utils/is-old-ie.spec.js
@@ -1,0 +1,19 @@
+/* eslint-disable max-len */
+import isOldIE from '../../src/utils/is-old-ie';
+import test from 'tape-catch';
+
+test('isOldIE', t => {
+  t.equal(isOldIE({userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'}),
+    true, 'should return true for IE 10');
+
+  t.equal(isOldIE({userAgent: 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'}),
+      true, 'should return true for IE 11');
+
+  t.equal(isOldIE({userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0'}),
+      false, 'should return false for IE 12');
+
+  t.equal(isOldIE({userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36'}),
+      false, 'should return false for Chrome');
+
+  t.end();
+});

--- a/test/index-webgl-dependent-tests.js
+++ b/test/index-webgl-dependent-tests.js
@@ -1,8 +1,10 @@
 // Imports tests for all modules that depend on webgl
 
+// TODO - move all shadertools test cases into shadertools submodule
+// import '../src/shadertools/test';
+import './src/shadertools';
 import './src/webgl-utils';
 import './src/webgl-context';
-import './src/shadertools';
 import './src/webgl';
 import './src/core';
 import './src/experimental';

--- a/test/src/shadertools/index.js
+++ b/test/src/shadertools/index.js
@@ -1,2 +1,1 @@
-import './lib';
 import './modules';


### PR DESCRIPTION
For #531

#### Background
- Make shadertools independent of luma.gl `assert` and `hasFeatures`
#### Change List
- as above
