### PR TITLE
New RFCs for v6.0

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -26,10 +26,13 @@ These are early ideas not yet associated with any release
 | --- | --- | --- | --- |
 | **WIP/Draft** | | | |
 
+Possible other animation related RFCs:
+- integration with event handling (enter leave triggers for animations)
 
-## v6.0 RFCs
 
-Current direction for luma.gl v6.0 is to focus on:
+## v6.x RFCs
+
+Current direction for luma.gl v6.x is to focus on:
 
 * **GPGPU compute** - rich library for building and testing, WebGL1 fallbacks for transform feedback/floating point
 * **shader modules** - shader module system improvements for GPGPU
@@ -38,21 +41,22 @@ Current direction for luma.gl v6.0 is to focus on:
 * **code size**
 
 
+## v6.0 RFCs
+
 | RFC | Author | Status | Description |
-| --- | --- | --- | --- |
-| [**Dist Size Reduction**](v6.0/reduce-distribution-size-rfc.md) | @ibgreen | **Draft** | Reduce luma.gl impact on app bundle size |
+| --- | ---    | ---    | ---         |
+| [**Off-Thread (aka Off-Screen) Rendering**](v6.0/offscreen-render-rfc.md) | @pessimistress | **Review** | Use the new Off-Screen API to enable WebGL to run in a separate thread. |
+| [**Portable GLSL 3.00 Shader Modules**](v6.0/vertex-array-attributes-rfc.md) | @ibgreen | **Draft** | |
+| [**Centralize Attribute Management in VertexArray**](v6.0/portable-glsl-300-rfc.md) | @ibgreen | **Draft** | |
 | [**Shadertools Improvements**](v6.0/shadertools-improvement-rfc.md) | @ibgreen | **Draft** | |
 | [**Shader Module Injection**](v6.0/shader-module-injection-rfc.md) | @ibgreen | **Draft** | |
-
-Possible other animation related RFCs:
-- integration with event handling (enter leave triggers for animations)
+| [**Dist Size Reduction**](v6.0/reduce-distribution-size-rfc.md) | @ibgreen | **Draft** | Reduce luma.gl impact on app bundle size |
 
 
 ## v5.2 RFCs
 
 | RFC | Author | Status | Description |
-| --- | --- | --- | --- |
-| **General** | | | |
+| --- | ---    | ---    | ---         |
 | [**New Transform Class**](v5.2/enhanced-transform-feedback-api.md) | @1chandu | **Review / Prototyped** | Simpler API for TransformFeedback |
 
 
@@ -61,8 +65,7 @@ Possible other animation related RFCs:
 Release Focus: Address any WebGL2 issues from 4.0.
 
 | RFC | Author | Status | Description |
-| --- | --- | --- | --- |
-| **General** | | | |
+| --- | ---    | ---    | ---         |
 | [**Break out Math Module**](v5.0/break-out-math-module-rfc.md) | @ibgreen | **Implemented** | Break out luma.gl math module |
 
 

--- a/dev-docs/RFCs/v6.0/offscreen-render-rfc.md
+++ b/dev-docs/RFCs/v6.0/offscreen-render-rfc.md
@@ -1,4 +1,4 @@
-# RFC: Offscreen Rendering
+# RFC: Off-Thread (aka Offscreen) Rendering
 
 * **Authors**: Xiaoji
 * **Date**: March 2018

--- a/dev-docs/RFCs/v6.0/portable-glsl-300-rfc.md
+++ b/dev-docs/RFCs/v6.0/portable-glsl-300-rfc.md
@@ -1,0 +1,129 @@
+# RFC: Portable GLSL 3.00 ES shader modules
+
+* **Authors**: Ib Green
+* **Date**: Jun 2018
+* **Status**: Early Draft
+
+
+## Summary
+
+This RFC proposes extending the shadertools shader assembler with code transforms that allow GLSL 3.00 ES shader code to be transformed into WebGL 1.00 ES compatible code.
+
+
+## Motivation
+
+A clean API for attribute management is one of the most important design goals of luma.gl.
+
+
+## Overview
+
+WebGL2 claims to be almost 100% backwards compatible with WebGL1. While this can be true for the JavaScript side of the API (at least assuming one disregards the complications posed by use of WebGL extensions), it is certainly not true for the GLSL shader language.
+
+If one wishes to use GLSL 3.00 features in a shader, one has to make modifications to the shader so that it no longer runs on GLSL 1.00 code.
+
+For a small monolithic shader it may be less of an issue (e.g. if you need WebGL2 features, use GLSL 3.00, otherwise GLSL 1.00) but if the goal is to create reusable shader code that can run under both WebGL1 and WebGL2 and both in GLSL 1.00 and GLSL 3.00 shaders, then there are problems.
+
+
+### Textual replacement
+
+The required modifications are very simple, and can mostly be done by a (fairly) simple series of textual replacements, as detailed in the proposal below.
+
+
+### Fragment Shader Outputs
+
+The major complication is related to fragment shader outputs, that use built-in `gl_fragColor`/`gl_fragData[]` variables in GLSL 1.00, but must be declared as variables in GLSL 3.00. And any variable starting with `gl_` is reserved, so names must be changed.
+
+
+## Proposal
+
+* Shader Assembler knows the target version of GLSL.
+* It applies as series of regular expressions (different between vertex and fragment shader) to replace basic constructs.
+* Users will need to avoid WebGL2 constructs if they wish their shaders to compile
+
+
+### Testing
+
+to make sure shader modules work in both environments an automated testing system should be developed.
+
+A shader module might want to declare minimum supported version, so that the tests can autodiscover what it needs to test.
+
+
+```
+const module = {
+  fs,
+  vs,
+  ...,
+  version: 300 // Needs at least GLSL 3.00 ES.
+}
+
+`version` is assumed to be 100 if not specified.
+
+
+### Table of replacements
+
+#### Converting from GLSL 3.00 to 3.00
+
+To enable portable code to be written, we must allow some non-conformant code in GLSL 3.00.
+
+Most importantly, `texture` in GLSL 3.00 might translate to either `texture2D` or `textureCube` in GLSL 1.00. Therefor we allow `textureCube` to be used in GLSL 3.00 code but automatically change it to `texture`.
+
+
+#### Converting from GLSL 3.00 to 1.00
+
+Vertex Shader
+
+* `in` -> `attribute` - only beginning of line
+* `out` -> `varying` - only beginning of line
+
+Fragment Shader
+
+* `in` -> `varying` - only beginning of line
+* `out` -> `gl_fragColor/gl_fragData[]` - only beginning of line, remove declaration
+
+Common
+
+* `texture` -> `texture2D`
+
+
+### Converting from GLSL 1.00 to 3.00
+
+Vertex Shader
+
+* `attribute` -> `in` - can be done with macro
+* `varying` -> `out` - can be done with macro
+
+Fragment Shader
+
+* `varying` -> `out` - only beginning of line
+* `out` -> `gl_fragColor/gl_fragData[]` - only beginning of line, remove declaration, if multiple `out`s use gl_fragData
+
+Common
+
+* `texture2D` -> `texture`
+* `textureCube` -> `texture`
+
+
+## Alternatives Considered
+
+### Using Macros
+
+An appealing solution could be to simply inject a prologue of macros, like
+
+```glsl
+// Auto-injected VERTEX SHADER prologue with GLSL 3.00 to GLSL 1.00 mappings
+#define in attribute
+#define out varying
+
+// users vertex shader GLSL code
+```
+
+However the keywords in question can arise in other places, which would break compilation:
+
+```glsl
+vec2 project(vec2 p, out float z) { ... }
+```
+
+
+### Full parsing/tokenization of GLSL
+
+Some systems like glslify perform a complete parse of the GLSL code. This is considered unncessarily heavy and fragile at this stage, and will be avoided until stronger reasons make it necessary.

--- a/dev-docs/RFCs/v6.0/vertex-array-attributes-rfc.md
+++ b/dev-docs/RFCs/v6.0/vertex-array-attributes-rfc.md
@@ -1,0 +1,63 @@
+# RFC: Centralize Attribute Management in VertexArray
+
+* **Authors**: Ib Green
+* **Date**: Jun 2018
+* **Status**: Early Draft
+
+
+## Summary
+
+This RFC proposes that attribute management (in the form of e.g `Program.setAttributes`) be moved from `Program` to the `VertexArray` class, allowing applications to manage attributes independently of `Program` instances, and centralizing attribute management code in a dedicated class.
+
+Also proposes to use more information gleaned from shader compilation and linking, to require less layout information to be provided by apps, in many cases requiring NO additional layout information with buffers.
+
+
+## Motivation
+
+A clean API for attribute management is one of the most important design goals of luma.gl. Attribute management is a complicated area and the APIs should be natural and easy-to-understand for users. Having them in a single place, orthogonally defined, with clear API reference and developers docs, is a point of pride for the framework.
+
+The `VertexArray` class is already focused on attribute management and is "the natural place" to put this logic. This provides a nice separation of concerns between programs and attributes, and allows more flexible and performance use of attributes in applications.
+
+In the past we have not been able to fully adopt `VertexArray` since it is not supported on all systems, like headless gl or older WebGL phones etc. The enabler is the Khronos client side `VertexArrayObject` polyfill that allows us to always rely on `VertexArray`s being available.
+
+
+## Proposal
+
+PART I
+
+* Port the Khronos client side `VertexArrayObject` polyfill to luma.gl.
+* Move all attribute management out of `Program`, letting `Program.draw()` accept a `vertexArray`.
+* Consolidate code that queries information from the linked program in `Program` to generate a single configuration object, that contains all information needed by both `VertexArray` and `TransformFeedback`
+* Allow `VertexArray` and `TransformFeedback` constructors to take a `program` parameter that automatically copies the configuration object from that `program`.
+* Standardize on a single `VertexArray.setAttributes` call that handles both buffers, elements and constants.
+
+PART II
+
+* We can extract more information than location from the shaders. We directly get *type* and *size* (components), and we can use simple name comparison heuristics to look for substrings like `instance` and `index` to determine if instance divisors or `ELEMENT_ARRAY_BUFFER` should be considered.
+
+Given this, 90% of all attribute layout specification might be unnecessary and can be autodeduced by luma.gl, letting applications just set arrays and/or buffers with data, leading to a much simpler sample applications.
+
+
+### Program
+
+A range of attribute related Program methods will be deprecated and/or removed.
+
+
+### VertexArray
+
+Will receive a light cleanup, some deprecations. The constructor will now accept an optional `program` parameter from which to copy attribute configuration.
+
+
+### Model
+
+The `Model` class will maintain both a `program` and a `vertexArray` on behalf of the application and should be able to maintain an unchanged API.
+
+
+### Open Issues
+
+* Impact on `Attribute` class.
+
+* Impact on `TransformFeedback` and `Transform` classes.
+
+* Debugging - The current debugging support will almost certainly take a hit in a refactor like this, and needs to be carefully restored. Especially when we use implicitly defined attribute layouts, we should make it very easy to discover what is expected in the debugger.
+


### PR DESCRIPTION
#### Background
- Two new RFC placeholder drafts (portable GLSL 3.00 shader modules, centralize attribute management in VertexArray).
#### Change List
- Also some edits dev-docs/RFC README.
