### PR TITLE
Update Picking Module to use GLSL 300 syntax

### DIFF
--- a/src/shadertools/src/modules/picking/picking.js
+++ b/src/shadertools/src/modules/picking/picking.js
@@ -41,7 +41,7 @@ uniform vec3 picking_uSelectedColor;
 uniform float picking_uThreshold;
 uniform bool picking_uSelectedColorValid;
 
-varying vec4 picking_vRGBcolor_Aselected;
+out vec4 picking_vRGBcolor_Aselected;
 
 const float COLOR_SCALE = 1. / 255.;
 
@@ -68,7 +68,7 @@ uniform bool picking_uActive; // true during rendering to offscreen picking buff
 uniform vec3 picking_uSelectedColor;
 uniform vec4 picking_uHighlightColor;
 
-varying vec4 picking_vRGBcolor_Aselected;
+in vec4 picking_vRGBcolor_Aselected;
 
 const float COLOR_SCALE = 1. / 255.;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #537
<!-- For other PRs without open issue -->
#### Background
Update picking module to use 300 syntax, module source will be converted to 100 or 300 by the tranpiler (#542)

Verified with:
- Instancing demo :  Picking shader code is converted from 300 to 100 syntax.
- Transform demo:   Picking shader code is converted from 300 to 300 syntax.
<!-- For all the PRs -->
#### Change List
- Update picking module to use GLSL 300 syntax
- Enable picking for Transform demo
