### PR TITLE
Move inline GL constants to `luma.gl/constants' (Dist size reduction)

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -14,7 +14,7 @@ luma.gl v6.0 removes a number of previously deprecated symbols. luma.gl will now
 | `deleteGLContest`    | `destroyGLContext`                     | Naming audit, deprecated in v5.3 |
 | `pollContext`        | `pollGLContext`                        | Naming audit, deprecated in v5.3 |
 | Constants            | | |
-| `GL`                 | `import {GL} from 'luma.gl/constants'` | Bundle size reduction, deprecated in v5.3 |
+| `GL`                 | `import GL from 'luma.gl/constants'`   | Bundle size reduction, deprecated in v5.3 |
 | `glGet(name)`        | `glGet(gl, name)`                      | Bundle size reduction, deprecated in v5.3 |
 | `glKey(value)`       | `glKey(gl, value)`                     | Bundle size reduction, deprecated in v5.3 |
 | `glKeyType(value)`   | `glKeyType(gl, value)`                 | Bundle size reduction, deprecated in v5.3 |
@@ -36,7 +36,7 @@ v5.3 deprecates a number of symbols. It is recommended that you replace their us
 
 | Deprecated symbol    | Replacement                            | Reason     |
 | ---                  | ---                                    | --          |
-| `GL`                 | `import {GL} from 'luma.gl/constants'` | Bundle size concerns |
+| `GL`                 | `import GL from 'luma.gl/constants'`   | Bundle size concerns |
 | `deleteGLContest`    | `destroyGLContext`                     | Naming alignment |
 | `pollContext`        | `pollGLContext`                        | Naming alignment |
 

--- a/examples/core/cubemap/app.js
+++ b/examples/core/cubemap/app.js
@@ -1,4 +1,5 @@
-import {AnimationLoop, GL, TextureCube, Cube, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, TextureCube, Cube, setParameters} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, setParameters, pickModels, Cube, picking, dirlight} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, setParameters, pickModels, Cube, picking, dirlight} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/core/picking/app.js
+++ b/examples/core/picking/app.js
@@ -1,6 +1,7 @@
 /* global document */
+import GL from 'luma.gl/constants';
 import {
-  GL, AnimationLoop, setParameters, loadTextures, Buffer,
+  AnimationLoop, setParameters, loadTextures, Buffer,
   Sphere, project, diffuse, picking, pickModels, ShaderCache
 } from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';

--- a/examples/core/shadowmap/app.js
+++ b/examples/core/shadowmap/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, Framebuffer, Cube, setParameters, clear} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Framebuffer, Cube, setParameters, clear} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/03/app.js
+++ b/examples/lessons/03/app.js
@@ -1,5 +1,6 @@
 /* eslint-disable array-bracket-spacing, no-multi-spaces */
-import {GL, AnimationLoop, Program, Model, Geometry, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Program, Model, Geometry, setParameters} from 'luma.gl';
 import {Matrix4} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/04/app.js
+++ b/examples/lessons/04/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, Model, Geometry, Program, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Model, Geometry, Program, setParameters} from 'luma.gl';
 import {Matrix4} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/05/app.js
+++ b/examples/lessons/05/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, loadTextures, Cube, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, loadTextures, Cube, setParameters} from 'luma.gl';
 import {Matrix4} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/06/app.js
+++ b/examples/lessons/06/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, Cube, Texture2D, addEvents, loadImage, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Cube, Texture2D, addEvents, loadImage, setParameters} from 'luma.gl';
 import {Matrix4} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/07/app.js
+++ b/examples/lessons/07/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, Cube, addEvents, loadTextures, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Cube, addEvents, loadTextures, setParameters} from 'luma.gl';
 import {Matrix4} from 'math.gl';
 
 export const INFO_HTML = `

--- a/examples/lessons/08/app.js
+++ b/examples/lessons/08/app.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-statements, array-bracket-spacing, no-multi-spaces */
-import {GL, AnimationLoop, Cube, addEvents, loadTextures, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Cube, addEvents, loadTextures, setParameters} from 'luma.gl';
 import {Matrix4} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/10/app.js
+++ b/examples/lessons/10/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, loadTextures, loadFile, addEvents, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, loadTextures, loadFile, addEvents, setParameters} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 import {loadWorldGeometry, World} from './world';
 

--- a/examples/lessons/11/app.js
+++ b/examples/lessons/11/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, loadTextures, addEvents, setParameters, Sphere} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, loadTextures, addEvents, setParameters, Sphere} from 'luma.gl';
 import {Vector3, Matrix4} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/12/app.js
+++ b/examples/lessons/12/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, loadTextures, setParameters, Sphere, Cube} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, loadTextures, setParameters, Sphere, Cube} from 'luma.gl';
 import {Vector3, Matrix4, radians} from 'math.gl';
 
 const VERTEX_SHADER = `\

--- a/examples/lessons/13/app.js
+++ b/examples/lessons/13/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, loadTextures, setParameters, Sphere, Cube, Program} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, loadTextures, setParameters, Sphere, Cube, Program} from 'luma.gl';
 import {Vector3, Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/14/app.js
+++ b/examples/lessons/14/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, Model, Geometry, loadTextures, loadFiles, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Model, Geometry, loadTextures, loadFiles, setParameters} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/15/app.js
+++ b/examples/lessons/15/app.js
@@ -1,4 +1,5 @@
-import {GL, AnimationLoop, Sphere, loadTextures, setParameters} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Sphere, loadTextures, setParameters} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/lessons/16/app.js
+++ b/examples/lessons/16/app.js
@@ -7,10 +7,11 @@
 // 5. Verify lookAt matrix used. (do we need it?)
 
 /* eslint-disable max-statements, indent, no-multi-spaces */
+import GL from 'luma.gl/constants';
 import {
-  GL, AnimationLoop, Cube, Sphere, Texture2D,
-  loadTextures, Model, loadFiles, parseModel,
-  Program, Renderbuffer, Framebuffer, Geometry, setParameters
+  AnimationLoop, Model, Cube, Sphere, Geometry,
+  Texture2D, Program, Renderbuffer, Framebuffer, setParameters,
+  loadTextures, loadFiles, parseModel
 } from 'luma.gl';
 import {Matrix4} from 'math.gl';
 

--- a/examples/test/tree-shaking/app.js
+++ b/examples/test/tree-shaking/app.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-var, max-statements */
-import {GL, AnimationLoop, createGLContext, Cube} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, createGLContext, Cube} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 
 const SIDE = 256;

--- a/examples/wip/custom-picking/app.js
+++ b/examples/wip/custom-picking/app.js
@@ -1,7 +1,7 @@
 /* global document */
-import {
-  GL, AnimationLoop, setParameters, Matrix4, radians,
-  Model, project, picking, pickModels} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {AnimationLoop, Model, setParameters, project, picking, pickModels} from 'luma.gl';
+import {Matrix4, radians} from 'math.gl';
 import HeightmapGeometry from './heightmap-geometry';
 
 let pickPosition = [0, 0];

--- a/scripts/babel-plugin-tree-shaking.js
+++ b/scripts/babel-plugin-tree-shaking.js
@@ -1,3 +1,4 @@
+// This plugin is not needed for babel 7
 const COLOR_RESET = '\x1b[0m';
 const COLOR_YELLOW = '\x1b[33m';
 

--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,4 @@ export {default as ClipSpaceQuad} from './models/clip-space';
 
 // DEPRECATED EXPORTS IN v5.3
 
-// Due to bundle size impact, should be optional import for application
-export {default as GL} from './constants';
-
 export {glGet, glKey, glKeyType} from './webgl-utils/constants-to-keys';

--- a/src/webgl-context/polyfill-context.js
+++ b/src/webgl-context/polyfill-context.js
@@ -12,6 +12,7 @@ import {getParameterPolyfill} from './polyfill-get-parameter';
 import polyfillVertexArrayObject from './polyfill-vertex-array-object';
 import {WebGLRenderingContext} from '../webgl-utils';
 import assert from '../utils/assert';
+import GL from '../constants';
 
 const OES_vertex_array_object = 'OES_vertex_array_object';
 const ANGLE_instanced_arrays = 'ANGLE_instanced_arrays';
@@ -25,8 +26,7 @@ const ERR_VAO_NOT_SUPPORTED =
 
 // Return true if WebGL2 context
 function isWebGL2(gl) {
-  const GL_TEXTURE_BINDING_3D = 0x806A;
-  return gl && gl.TEXTURE_BINDING_3D === GL_TEXTURE_BINDING_3D;
+  return gl && gl.TEXTURE_BINDING_3D === GL.TEXTURE_BINDING_3D;
 }
 
 // Return object with webgl2 flag and an extension
@@ -108,15 +108,12 @@ const WEBGL_CONTEXT_POLYFILLS = {
       // const gl = this; // eslint-disable-line
       const {webgl2, ext} = getExtensionData(gl, ANGLE_instanced_arrays);
 
-      const GL_VERTEX_ATTRIB_ARRAY_INTEGER = 0x88FD;
-      const GL_VERTEX_ATTRIB_ARRAY_DIVISOR = 0x88FE;
-
       let result;
       switch (pname) {
       // WebGL1 attributes will never be integer
-      case GL_VERTEX_ATTRIB_ARRAY_INTEGER: result = !webgl2 ? false : undefined; break;
+      case GL.VERTEX_ATTRIB_ARRAY_INTEGER: result = !webgl2 ? false : undefined; break;
         // if instancing is not available, return 0 meaning divisor has not been set
-      case GL_VERTEX_ATTRIB_ARRAY_DIVISOR: result = !webgl2 && !ext ? 0 : undefined; break;
+      case GL.VERTEX_ATTRIB_ARRAY_DIVISOR: result = !webgl2 && !ext ? 0 : undefined; break;
       default:
       }
 
@@ -124,26 +121,20 @@ const WEBGL_CONTEXT_POLYFILLS = {
     },
     // Handle transform feedback and uniform block queries in WebGL1
     getProgramParameter: (gl, originalFunc, program, pname) => {
-      const GL_TRANSFORM_FEEDBACK_BUFFER_MODE = 0x8C7F;
-      const GL_TRANSFORM_FEEDBACK_VARYINGS = 0x8C83;
-      const GL_ACTIVE_UNIFORM_BLOCKS = 0x8A36;
-      const GL_SEPARATE_ATTRIBS = 0x8C8D;
-
       if (!isWebGL2(gl)) {
         switch (pname) {
-        case GL_TRANSFORM_FEEDBACK_BUFFER_MODE: return GL_SEPARATE_ATTRIBS;
-        case GL_TRANSFORM_FEEDBACK_VARYINGS: return 0;
-        case GL_ACTIVE_UNIFORM_BLOCKS: return 0;
+        case GL.TRANSFORM_FEEDBACK_BUFFER_MODE: return GL.SEPARATE_ATTRIBS;
+        case GL.TRANSFORM_FEEDBACK_VARYINGS: return 0;
+        case GL.ACTIVE_UNIFORM_BLOCKS: return 0;
         default:
         }
       }
       return originalFunc(program, pname);
     },
     getInternalformatParameter: (gl, originalFunc, target, format, pname) => {
-      const GL_SAMPLES = 0x80A9;
       if (!isWebGL2(gl)) {
         switch (pname) {
-        case GL_SAMPLES:
+        case GL.SAMPLES:
           return new Int32Array([0]);
         default:
         }
@@ -151,12 +142,11 @@ const WEBGL_CONTEXT_POLYFILLS = {
       return gl.getInternalformatParameter(target, format, pname);
     },
     getTexParameter(gl, originalFunc, target, pname) {
-      const GL_TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE;
       switch (pname) {
-      case GL_TEXTURE_MAX_ANISOTROPY_EXT:
+      case GL.TEXTURE_MAX_ANISOTROPY_EXT:
         const {extensions} = gl.luma;
         const ext = extensions[EXT_texture_filter_anisotropic];
-        pname = (ext && ext.TEXTURE_MAX_ANISOTROPY_EXT) || GL_TEXTURE_MAX_ANISOTROPY_EXT;
+        pname = (ext && ext.TEXTURE_MAX_ANISOTROPY_EXT) || GL.TEXTURE_MAX_ANISOTROPY_EXT;
         break;
       default:
       }

--- a/src/webgl-utils/typed-array-utils.js
+++ b/src/webgl-utils/typed-array-utils.js
@@ -1,14 +1,4 @@
-// GL Constants
-const GL_BYTE = 0x1400;
-const GL_UNSIGNED_BYTE = 0x1401;
-const GL_SHORT = 0x1402;
-const GL_UNSIGNED_SHORT = 0x1403;
-const GL_INT = 0x1404;
-const GL_UNSIGNED_INT = 0x1405;
-const GL_FLOAT = 0x1406;
-const GL_UNSIGNED_SHORT_4_4_4_4 = 0x8033;
-const GL_UNSIGNED_SHORT_5_5_5_1 = 0x8034;
-const GL_UNSIGNED_SHORT_5_6_5 = 0x8363;
+import GL from '../constants';
 
 const ERR_TYPE_DEDUCTION = 'Failed to deduce GL constant from typed array';
 
@@ -18,14 +8,14 @@ export function getGLTypeFromTypedArray(arrayOrType) {
   // If typed array, look up constructor
   const type = ArrayBuffer.isView(arrayOrType) ? arrayOrType.constructor : arrayOrType;
   switch (type) {
-  case Float32Array: return GL_FLOAT;
-  case Uint16Array: return GL_UNSIGNED_SHORT;
-  case Uint32Array: return GL_UNSIGNED_INT;
-  case Uint8Array: return GL_UNSIGNED_BYTE;
-  case Uint8ClampedArray: return GL_UNSIGNED_BYTE;
-  case Int8Array: return GL_BYTE;
-  case Int16Array: return GL_SHORT;
-  case Int32Array: return GL_INT;
+  case Float32Array: return GL.FLOAT;
+  case Uint16Array: return GL.UNSIGNED_SHORT;
+  case Uint32Array: return GL.UNSIGNED_INT;
+  case Uint8Array: return GL.UNSIGNED_BYTE;
+  case Uint8ClampedArray: return GL.UNSIGNED_BYTE;
+  case Int8Array: return GL.BYTE;
+  case Int16Array: return GL.SHORT;
+  case Int32Array: return GL.INT;
   default:
     throw new Error(ERR_TYPE_DEDUCTION);
   }
@@ -38,22 +28,22 @@ export function getGLTypeFromTypedArray(arrayOrType) {
 export function getTypedArrayFromGLType(glType, {clamped = true} = {}) {
   // Sorted in some order of likelihood to reduce amount of comparisons
   switch (glType) {
-  case GL_FLOAT:
+  case GL.FLOAT:
     return Float32Array;
-  case GL_UNSIGNED_SHORT:
-  case GL_UNSIGNED_SHORT_5_6_5:
-  case GL_UNSIGNED_SHORT_4_4_4_4:
-  case GL_UNSIGNED_SHORT_5_5_5_1:
+  case GL.UNSIGNED_SHORT:
+  case GL.UNSIGNED_SHORT_5_6_5:
+  case GL.UNSIGNED_SHORT_4_4_4_4:
+  case GL.UNSIGNED_SHORT_5_5_5_1:
     return Uint16Array;
-  case GL_UNSIGNED_INT:
+  case GL.UNSIGNED_INT:
     return Uint32Array;
-  case GL_UNSIGNED_BYTE:
+  case GL.UNSIGNED_BYTE:
     return clamped ? Uint8ClampedArray : Uint8Array;
-  case GL_BYTE:
+  case GL.BYTE:
     return Int8Array;
-  case GL_SHORT:
+  case GL.SHORT:
     return Int16Array;
-  case GL_INT:
+  case GL.INT:
     return Int32Array;
   default:
     throw new Error('Failed to deduce typed array type from GL constant');

--- a/src/webgl/framebuffer.js
+++ b/src/webgl/framebuffer.js
@@ -1,5 +1,3 @@
-import GL from '../constants';
-
 import Resource from './resource';
 import Texture2D from './texture-2d';
 import Renderbuffer from './renderbuffer';
@@ -17,28 +15,7 @@ import {flipRows, scalePixels} from '../webgl-utils';
 import {log} from '../utils';
 import assert from '../utils/assert';
 
-// Local constants - will collapse during minification
-const GL_FRAMEBUFFER = 0x8D40;
-const GL_DRAW_FRAMEBUFFER = 0x8CA8;
-const GL_READ_FRAMEBUFFER = 0x8CA9;
-
-const GL_COLOR_ATTACHMENT0 = 0x8CE0;
-const GL_DEPTH_ATTACHMENT = 0x8D00;
-const GL_STENCIL_ATTACHMENT = 0x8D20;
-// const GL_DEPTH_STENCIL_ATTACHMENT = 0x821A;
-
-const GL_RENDERBUFFER = 0x8D41;
-
-const GL_TEXTURE_3D = 0x806F;
-const GL_TEXTURE_2D_ARRAY = 0x8C1A;
-const GL_TEXTURE_2D = 0x0DE1;
-const GL_TEXTURE_CUBE_MAP = 0x8513;
-
-const GL_TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515;
-
-const GL_DEPTH_BUFFER_BIT = 0x00000100;
-const GL_STENCIL_BUFFER_BIT = 0x00000400;
-const GL_COLOR_BUFFER_BIT = 0x00004000;
+import GL from '../constants';
 
 const ERR_MULTIPLE_RENDERTARGETS = 'Multiple render targets not supported';
 
@@ -50,7 +27,7 @@ export default class Framebuffer extends Resource {
   } = {}) {
     let supported = true;
     supported = colorBufferFloat &&
-      gl.getExtension(isWebGL2(gl) ? 'EXT_color_buffer_float' : 'WEBGL_color_buffer_float');
+      gl.getExtension(isWebGL2(gl) ? 'EXT_color_buffer_float' : 'WEBGL.color_buffer_float');
     supported = colorBufferHalfFloat &&
       gl.getExtension(isWebGL2(gl) ? 'EXT_color_buffer_float' : 'EXT_color_buffer_half_float');
     return supported;
@@ -81,27 +58,27 @@ export default class Framebuffer extends Resource {
     this.width = null;
     this.height = null;
     this.attachments = {};
-    this.readBuffer = GL_COLOR_ATTACHMENT0;
-    this.drawBuffers = [GL_COLOR_ATTACHMENT0];
+    this.readBuffer = GL.COLOR_ATTACHMENT0;
+    this.drawBuffers = [GL.COLOR_ATTACHMENT0];
     this.initialize(opts);
 
     Object.seal(this);
   }
 
   get color() {
-    return this.attachments[GL_COLOR_ATTACHMENT0] || null;
+    return this.attachments[GL.COLOR_ATTACHMENT0] || null;
   }
 
   get texture() {
-    return this.attachments[GL_COLOR_ATTACHMENT0] || null;
+    return this.attachments[GL.COLOR_ATTACHMENT0] || null;
   }
 
   get depth() {
-    return this.attachments[GL_DEPTH_ATTACHMENT] || null;
+    return this.attachments[GL.DEPTH_ATTACHMENT] || null;
   }
 
   get stencil() {
-    return this.attachments[GL_STENCIL_ATTACHMENT] || null;
+    return this.attachments[GL.STENCIL_ATTACHMENT] || null;
   }
 
   initialize({
@@ -152,14 +129,14 @@ export default class Framebuffer extends Resource {
 
     const {gl} = this;
     // Multiple render target support, set read buffer and draw buffers
-    const prevHandle = gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = gl.bindFramebuffer(GL.FRAMEBUFFER, this.handle);
     if (readBuffer) {
       this._setReadBuffer(readBuffer);
     }
     if (drawBuffers) {
       this._setDrawBuffers(drawBuffers);
     }
-    gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle || null);
+    gl.bindFramebuffer(GL.FRAMEBUFFER, prevHandle || null);
 
     return this;
   }
@@ -208,7 +185,7 @@ export default class Framebuffer extends Resource {
     // Overlay the new attachments
     Object.assign(newAttachments, attachments);
 
-    const prevHandle = this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = this.gl.bindFramebuffer(GL.FRAMEBUFFER, this.handle);
 
     // Walk the attachments
     for (const attachment in newAttachments) {
@@ -235,7 +212,7 @@ export default class Framebuffer extends Resource {
       }
     }
 
-    this.gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle || null);
+    this.gl.bindFramebuffer(GL.FRAMEBUFFER, prevHandle || null);
 
     // Assign to attachments and remove any nulls to get a clean attachment map
     Object.assign(this.attachments, attachments);
@@ -246,9 +223,9 @@ export default class Framebuffer extends Resource {
 
   checkStatus() {
     const {gl} = this;
-    const prevHandle = gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
-    const status = gl.checkFramebufferStatus(GL_FRAMEBUFFER);
-    gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle || null);
+    const prevHandle = gl.bindFramebuffer(GL.FRAMEBUFFER, this.handle);
+    const status = gl.checkFramebufferStatus(GL.FRAMEBUFFER);
+    gl.bindFramebuffer(GL.FRAMEBUFFER, prevHandle || null);
     if (status !== gl.FRAMEBUFFER_COMPLETE) {
       throw new Error(_getFrameBufferStatus(status));
     }
@@ -262,7 +239,7 @@ export default class Framebuffer extends Resource {
     drawBuffers = []
   } = {}) {
     // Bind framebuffer and delegate to global clear functions
-    const prevHandle = this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = this.gl.bindFramebuffer(GL.FRAMEBUFFER, this.handle);
 
     if (color || depth || stencil) {
       clear(this.gl, {color, depth, stencil});
@@ -272,7 +249,7 @@ export default class Framebuffer extends Resource {
       clearBuffer({drawBuffer, value});
     });
 
-    this.gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle || null);
+    this.gl.bindFramebuffer(GL.FRAMEBUFFER, prevHandle || null);
 
     return this;
   }
@@ -289,7 +266,7 @@ export default class Framebuffer extends Resource {
     format = GL.RGBA,
     type, // Auto deduced from pixelArray or gl.UNSIGNED_BYTE
     pixelArray = null,
-    attachment = GL_COLOR_ATTACHMENT0 // TODO - support gl.readBuffer
+    attachment = GL.COLOR_ATTACHMENT0 // TODO - support gl.readBuffer
   }) {
     const {gl} = this;
 
@@ -311,9 +288,9 @@ export default class Framebuffer extends Resource {
     // Pixel array available, if necessary, deduce type from it.
     type = type || getGLTypeFromTypedArray(pixelArray);
 
-    const prevHandle = this.gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = this.gl.bindFramebuffer(GL.FRAMEBUFFER, this.handle);
     this.gl.readPixels(x, y, width, height, format, type, pixelArray);
-    this.gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle || null);
+    this.gl.bindFramebuffer(GL.FRAMEBUFFER, prevHandle || null);
 
     return pixelArray;
   }
@@ -361,7 +338,7 @@ export default class Framebuffer extends Resource {
 
   // Reads pixels as a dataUrl
   copyToDataUrl({
-    attachment = GL_COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
+    attachment = GL.COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
     maxHeight = Number.MAX_SAFE_INTEGER
   } = {}) {
     let data = this.readPixels({attachment});
@@ -392,7 +369,7 @@ export default class Framebuffer extends Resource {
   // Reads pixels into an HTML Image
   copyToImage({
     image = null,
-    attachment = GL_COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
+    attachment = GL.COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
     maxHeight = Number.MAX_SAFE_INTEGER
   } = {}) {
     /* global Image */
@@ -423,14 +400,14 @@ export default class Framebuffer extends Resource {
     mipmapLevel = 0,
 
     // Source
-    attachment = GL_COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
+    attachment = GL.COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
     x = 0,
     y = 0,
     width, // defaults to texture width
     height // defaults to texture height
   }) {
     const {gl} = this;
-    const prevHandle = gl.bindFramebuffer(GL_FRAMEBUFFER, this.handle);
+    const prevHandle = gl.bindFramebuffer(GL.FRAMEBUFFER, this.handle);
     const prevBuffer = gl.readBuffer(attachment);
 
     width = Number.isFinite(width) ? width : texture.width;
@@ -438,8 +415,8 @@ export default class Framebuffer extends Resource {
 
     // target
     switch (texture.target) {
-    case GL_TEXTURE_2D:
-    case GL_TEXTURE_CUBE_MAP:
+    case GL.TEXTURE_2D:
+    case GL.TEXTURE_CUBE_MAP:
       gl.copyTexSubImage2D(
         target || texture.target,
         mipmapLevel,
@@ -451,8 +428,8 @@ export default class Framebuffer extends Resource {
         height
       );
       break;
-    case GL_TEXTURE_2D_ARRAY:
-    case GL_TEXTURE_3D:
+    case GL.TEXTURE_2D_ARRAY:
+    case GL.TEXTURE_3D:
       gl.copyTexSubImage3D(
         target || texture.target,
         mipmapLevel,
@@ -469,7 +446,7 @@ export default class Framebuffer extends Resource {
     }
 
     gl.readBuffer(prevBuffer);
-    gl.bindFramebuffer(GL_FRAMEBUFFER, prevHandle || null);
+    gl.bindFramebuffer(GL.FRAMEBUFFER, prevHandle || null);
     return texture;
   }
 
@@ -478,7 +455,7 @@ export default class Framebuffer extends Resource {
   // Copies a rectangle of pixels between framebuffers
   blit({
     srcFramebuffer,
-    attachment = GL_COLOR_ATTACHMENT0,
+    attachment = GL.COLOR_ATTACHMENT0,
     srcX0 = 0, srcY0 = 0, srcX1, srcY1,
     dstX0 = 0, dstY0 = 0, dstX1, dstY1,
     color = true,
@@ -490,18 +467,18 @@ export default class Framebuffer extends Resource {
     const {gl} = this;
     assertWebGL2Context(gl);
 
-    if (!srcFramebuffer.handle && attachment === GL_COLOR_ATTACHMENT0) {
+    if (!srcFramebuffer.handle && attachment === GL.COLOR_ATTACHMENT0) {
       attachment = GL.FRONT;
     }
 
     if (color) {
-      mask |= GL_COLOR_BUFFER_BIT;
+      mask |= GL.COLOR_BUFFER_BIT;
     }
     if (depth) {
-      mask |= GL_DEPTH_BUFFER_BIT;
+      mask |= GL.DEPTH_BUFFER_BIT;
     }
     if (stencil) {
-      mask |= GL_STENCIL_BUFFER_BIT;
+      mask |= GL.STENCIL_BUFFER_BIT;
     }
     assert(mask);
 
@@ -510,13 +487,13 @@ export default class Framebuffer extends Resource {
     dstX1 = dstX1 === undefined ? this.width : dstX1;
     dstY1 = dstY1 === undefined ? this.height : dstY1;
 
-    const prevDrawHandle = gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, this.handle);
-    const prevReadHandle = gl.bindFramebuffer(GL_READ_FRAMEBUFFER, srcFramebuffer.handle);
+    const prevDrawHandle = gl.bindFramebuffer(GL.DRAW_FRAMEBUFFER, this.handle);
+    const prevReadHandle = gl.bindFramebuffer(GL.READ_FRAMEBUFFER, srcFramebuffer.handle);
     gl.readBuffer(attachment);
     gl.blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
     gl.readBuffer(this.readBuffer);
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, prevReadHandle || null);
-    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, prevDrawHandle || null);
+    gl.bindFramebuffer(GL.READ_FRAMEBUFFER, prevReadHandle || null);
+    gl.bindFramebuffer(GL.DRAW_FRAMEBUFFER, prevDrawHandle || null);
 
     return this;
   }
@@ -532,34 +509,34 @@ export default class Framebuffer extends Resource {
   }) {
     const {gl} = this;
     assertWebGL2Context(gl);
-    const prevHandle = gl.bindFramebuffer(GL_READ_FRAMEBUFFER, this.handle);
+    const prevHandle = gl.bindFramebuffer(GL.READ_FRAMEBUFFER, this.handle);
     const invalidateAll = x === 0 && y === 0 && width === undefined && height === undefined;
     if (invalidateAll) {
-      gl.invalidateFramebuffer(GL_READ_FRAMEBUFFER, attachments);
+      gl.invalidateFramebuffer(GL.READ_FRAMEBUFFER, attachments);
     } else {
-      gl.invalidateFramebuffer(GL_READ_FRAMEBUFFER, attachments, x, y, width, height);
+      gl.invalidateFramebuffer(GL.READ_FRAMEBUFFER, attachments, x, y, width, height);
     }
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, prevHandle);
+    gl.bindFramebuffer(GL.READ_FRAMEBUFFER, prevHandle);
     return this;
   }
 
   // Return the value for `pname` of the specified attachment.
   // The type returned is the type of the requested pname
   getAttachmentParameter({
-    attachment = GL_COLOR_ATTACHMENT0,
+    attachment = GL.COLOR_ATTACHMENT0,
     pname
   } = {}) {
     let value = this._getAttachmentParameterFallback(pname);
     if (value === null) {
-      this.gl.bindTexture(GL_FRAMEBUFFER, this.handle);
-      value = this.gl.getFramebufferAttachmentParameter(GL_FRAMEBUFFER, attachment, pname);
-      this.gl.bindTexture(GL_FRAMEBUFFER, null);
+      this.gl.bindTexture(GL.FRAMEBUFFER, this.handle);
+      value = this.gl.getFramebufferAttachmentParameter(GL.FRAMEBUFFER, attachment, pname);
+      this.gl.bindTexture(GL.FRAMEBUFFER, null);
     }
     return value;
   }
 
   getAttachmentParameters(
-    attachment = GL_COLOR_ATTACHMENT0,
+    attachment = GL.COLOR_ATTACHMENT0,
     parameters = this.constructor.ATTACHMENT_PARAMETERS || {}
   ) {
     const values = {};
@@ -591,12 +568,12 @@ export default class Framebuffer extends Resource {
   }
 
   // WEBGL INTERFACE
-  bind({target = GL_FRAMEBUFFER} = {}) {
+  bind({target = GL.FRAMEBUFFER} = {}) {
     this.gl.bindFramebuffer(target, this.handle);
     return this;
   }
 
-  unbind({target = GL_FRAMEBUFFER} = {}) {
+  unbind({target = GL.FRAMEBUFFER} = {}) {
     this.gl.bindFramebuffer(target, null);
     return this;
   }
@@ -609,7 +586,7 @@ export default class Framebuffer extends Resource {
     // Add a color buffer if requested and not supplied
     if (color) {
       defaultAttachments = defaultAttachments || {};
-      defaultAttachments[GL_COLOR_ATTACHMENT0] = new Texture2D(this.gl, {
+      defaultAttachments[GL.COLOR_ATTACHMENT0] = new Texture2D(this.gl, {
         pixels: null, // reserves texture memory, but texels are undefined
         format: GL.RGBA,
         type: GL.UNSIGNED_BYTE,
@@ -633,7 +610,7 @@ export default class Framebuffer extends Resource {
     // Add a depth buffer if requested and not supplied
     if (depth) {
       defaultAttachments = defaultAttachments || {};
-      defaultAttachments[GL_DEPTH_ATTACHMENT] =
+      defaultAttachments[GL.DEPTH_ATTACHMENT] =
         new Renderbuffer(this.gl, {format: GL.DEPTH_COMPONENT16, width, height});
     }
 
@@ -643,42 +620,42 @@ export default class Framebuffer extends Resource {
   }
 
   _unattach({attachment}) {
-    this.gl.bindRenderbuffer(GL_RENDERBUFFER, this.handle);
-    this.gl.framebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, null);
+    this.gl.bindRenderbuffer(GL.RENDERBUFFER, this.handle);
+    this.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, attachment, GL.RENDERBUFFER, null);
     delete this.attachments[attachment];
   }
 
-  _attachRenderbuffer({attachment = GL_COLOR_ATTACHMENT0, renderbuffer}) {
+  _attachRenderbuffer({attachment = GL.COLOR_ATTACHMENT0, renderbuffer}) {
     const {gl} = this;
     // TODO - is the bind needed?
-    // gl.bindRenderbuffer(GL_RENDERBUFFER, renderbuffer.handle);
-    gl.framebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, renderbuffer.handle);
+    // gl.bindRenderbuffer(GL.RENDERBUFFER, renderbuffer.handle);
+    gl.framebufferRenderbuffer(GL.FRAMEBUFFER, attachment, GL.RENDERBUFFER, renderbuffer.handle);
     // TODO - is the unbind needed?
-    // gl.bindRenderbuffer(GL_RENDERBUFFER, null);
+    // gl.bindRenderbuffer(GL.RENDERBUFFER, null);
 
     this.attachments[attachment] = renderbuffer;
   }
 
   // layer = 0 - index into Texture2DArray and Texture3D or face for `TextureCubeMap`
   // level = 0 - mipmapLevel (must be 0 in WebGL1)
-  _attachTexture({attachment = GL_COLOR_ATTACHMENT0, texture, layer, level}) {
+  _attachTexture({attachment = GL.COLOR_ATTACHMENT0, texture, layer, level}) {
     const {gl} = this;
     gl.bindTexture(texture.target, texture.handle);
 
     switch (texture.target) {
-    case GL_TEXTURE_2D_ARRAY:
-    case GL_TEXTURE_3D:
-      gl.framebufferTextureLayer(GL_FRAMEBUFFER, attachment, texture.target, level, layer);
+    case GL.TEXTURE_2D_ARRAY:
+    case GL.TEXTURE_3D:
+      gl.framebufferTextureLayer(GL.FRAMEBUFFER, attachment, texture.target, level, layer);
       break;
 
-    case GL_TEXTURE_CUBE_MAP:
+    case GL.TEXTURE_CUBE_MAP:
       // layer must be a cubemap face (or if index, converted to cube map face)
       const face = mapIndexToCubeMapFace(layer);
-      gl.framebufferTexture2D(GL_FRAMEBUFFER, attachment, face, texture.handle, level);
+      gl.framebufferTexture2D(GL.FRAMEBUFFER, attachment, face, texture.handle, level);
       break;
 
-    case GL_TEXTURE_2D:
-      gl.framebufferTexture2D(GL_FRAMEBUFFER, attachment, GL_TEXTURE_2D, texture.handle, level);
+    case GL.TEXTURE_2D:
+      gl.framebufferTexture2D(GL.FRAMEBUFFER, attachment, GL.TEXTURE_2D, texture.handle, level);
       break;
 
     default:
@@ -695,7 +672,7 @@ export default class Framebuffer extends Resource {
       gl.readBuffer(readBuffer);
     } else {
       // Setting to color attachment 0 is a noop, so allow it in WebGL1
-      assert(readBuffer === GL_COLOR_ATTACHMENT0 || readBuffer === GL.BACK,
+      assert(readBuffer === GL.COLOR_ATTACHMENT0 || readBuffer === GL.BACK,
         ERR_MULTIPLE_RENDERTARGETS);
     }
     this.readBuffer = readBuffer;
@@ -706,13 +683,13 @@ export default class Framebuffer extends Resource {
     if (isWebGL2(gl)) {
       gl.drawBuffers(drawBuffers);
     } else {
-      const ext = gl.getExtension('WEBGL_draw_buffers');
+      const ext = gl.getExtension('WEBGL.draw_buffers');
       if (ext) {
         ext.drawBuffersWEBGL(drawBuffers);
       } else {
         // Setting a single draw buffer to color attachment 0 is a noop, allow in WebGL1
         assert(drawBuffers.length === 1 &&
-          (drawBuffers[0] === GL_COLOR_ATTACHMENT0 || drawBuffers[0] === GL.BACK),
+          (drawBuffers[0] === GL.COLOR_ATTACHMENT0 || drawBuffers[0] === GL.BACK),
           ERR_MULTIPLE_RENDERTARGETS);
       }
     }
@@ -762,8 +739,8 @@ export default class Framebuffer extends Resource {
 function mapIndexToCubeMapFace(layer) {
   // TEXTURE_CUBE_MAP_POSITIVE_X is a big value (0x8515)
   // if smaller assume layer is index, otherwise assume it is already a cube map face constant
-  return layer < GL_TEXTURE_CUBE_MAP_POSITIVE_X ?
-    layer + GL_TEXTURE_CUBE_MAP_POSITIVE_X :
+  return layer < GL.TEXTURE_CUBE_MAP_POSITIVE_X ?
+    layer + GL.TEXTURE_CUBE_MAP_POSITIVE_X :
     layer;
 }
 

--- a/src/webgl/uniforms.js
+++ b/src/webgl/uniforms.js
@@ -3,118 +3,64 @@ import Texture from './texture';
 import Sampler from './sampler';
 import {formatValue, log} from '../utils';
 import assert from '../utils/assert';
-
-// Local constants, will be "collapsed" during minification
-
-// WebGL1
-
-const GL_FLOAT = 0x1406;
-const GL_FLOAT_VEC2 = 0x8B50;
-const GL_FLOAT_VEC3 = 0x8B51;
-const GL_FLOAT_VEC4 = 0x8B52;
-
-const GL_INT = 0x1404;
-const GL_INT_VEC2 = 0x8B53;
-const GL_INT_VEC3 = 0x8B54;
-const GL_INT_VEC4 = 0x8B55;
-
-const GL_BOOL = 0x8B56;
-const GL_BOOL_VEC2 = 0x8B57;
-const GL_BOOL_VEC3 = 0x8B58;
-const GL_BOOL_VEC4 = 0x8B59;
-
-const GL_FLOAT_MAT2 = 0x8B5A;
-const GL_FLOAT_MAT3 = 0x8B5B;
-const GL_FLOAT_MAT4 = 0x8B5C;
-
-const GL_SAMPLER_2D = 0x8B5E;
-const GL_SAMPLER_CUBE = 0x8B60;
-
-// WebGL2
-
-const GL_UNSIGNED_INT = 0x1405;
-const GL_UNSIGNED_INT_VEC2 = 0x8DC6;
-const GL_UNSIGNED_INT_VEC3 = 0x8DC7;
-const GL_UNSIGNED_INT_VEC4 = 0x8DC8;
-
-/* eslint-disable camelcase */
-const GL_FLOAT_MAT2x3 = 0x8B65;
-const GL_FLOAT_MAT2x4 = 0x8B66;
-const GL_FLOAT_MAT3x2 = 0x8B67;
-const GL_FLOAT_MAT3x4 = 0x8B68;
-const GL_FLOAT_MAT4x2 = 0x8B69;
-const GL_FLOAT_MAT4x3 = 0x8B6A;
-
-const GL_SAMPLER_3D = 0x8B5F;
-const GL_SAMPLER_2D_SHADOW = 0x8B62;
-const GL_SAMPLER_2D_ARRAY = 0x8DC1;
-const GL_SAMPLER_2D_ARRAY_SHADOW = 0x8DC4;
-const GL_SAMPLER_CUBE_SHADOW = 0x8DC5;
-const GL_INT_SAMPLER_2D = 0x8DCA;
-const GL_INT_SAMPLER_3D = 0x8DCB;
-const GL_INT_SAMPLER_CUBE = 0x8DCC;
-const GL_INT_SAMPLER_2D_ARRAY = 0x8DCF;
-const GL_UNSIGNED_INT_SAMPLER_2D = 0x8DD2;
-const GL_UNSIGNED_INT_SAMPLER_3D = 0x8DD3;
-const GL_UNSIGNED_INT_SAMPLER_CUBE = 0x8DD4;
-const GL_UNSIGNED_INT_SAMPLER_2D_ARRAY = 0x8DD7;
+import GL from '../constants';
 
 const UNIFORM_SETTERS = {
 
   // WEBGL1
 
   /* eslint-disable max-len */
-  [GL_FLOAT]: (gl, location, value) => gl.uniform1f(location, value),
-  [GL_FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, toFloatArray(value, 2)),
-  [GL_FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, toFloatArray(value, 3)),
-  [GL_FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, toFloatArray(value, 4)),
+  [GL.FLOAT]: (gl, location, value) => gl.uniform1f(location, value),
+  [GL.FLOAT_VEC2]: (gl, location, value) => gl.uniform2fv(location, toFloatArray(value, 2)),
+  [GL.FLOAT_VEC3]: (gl, location, value) => gl.uniform3fv(location, toFloatArray(value, 3)),
+  [GL.FLOAT_VEC4]: (gl, location, value) => gl.uniform4fv(location, toFloatArray(value, 4)),
 
-  [GL_INT]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_INT_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value, 2)),
-  [GL_INT_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value, 3)),
-  [GL_INT_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value, 4)),
+  [GL.INT]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.INT_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value, 2)),
+  [GL.INT_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value, 3)),
+  [GL.INT_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value, 4)),
 
-  [GL_BOOL]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_BOOL_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value, 2)),
-  [GL_BOOL_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value, 3)),
-  [GL_BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value, 4)),
+  [GL.BOOL]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.BOOL_VEC2]: (gl, location, value) => gl.uniform2iv(location, toIntArray(value, 2)),
+  [GL.BOOL_VEC3]: (gl, location, value) => gl.uniform3iv(location, toIntArray(value, 3)),
+  [GL.BOOL_VEC4]: (gl, location, value) => gl.uniform4iv(location, toIntArray(value, 4)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, toFloatArray(value, 4)),
-  [GL_FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, toFloatArray(value, 9)),
-  [GL_FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, toFloatArray(value, 16)),
+  [GL.FLOAT_MAT2]: (gl, location, value) => gl.uniformMatrix2fv(location, false, toFloatArray(value, 4)),
+  [GL.FLOAT_MAT3]: (gl, location, value) => gl.uniformMatrix3fv(location, false, toFloatArray(value, 9)),
+  [GL.FLOAT_MAT4]: (gl, location, value) => gl.uniformMatrix4fv(location, false, toFloatArray(value, 16)),
 
-  [GL_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
 
   // WEBGL2 - unsigned integers, irregular matrices, additional texture samplers
 
-  [GL_UNSIGNED_INT]: (gl, location, value) => gl.uniform1ui(location, value),
-  [GL_UNSIGNED_INT_VEC2]: (gl, location, value) => gl.uniform2uiv(location, toUIntArray(value, 2)),
-  [GL_UNSIGNED_INT_VEC3]: (gl, location, value) => gl.uniform3uiv(location, toUIntArray(value, 3)),
-  [GL_UNSIGNED_INT_VEC4]: (gl, location, value) => gl.uniform4uiv(location, toUIntArray(value, 4)),
+  [GL.UNSIGNED_INT]: (gl, location, value) => gl.uniform1ui(location, value),
+  [GL.UNSIGNED_INT_VEC2]: (gl, location, value) => gl.uniform2uiv(location, toUIntArray(value, 2)),
+  [GL.UNSIGNED_INT_VEC3]: (gl, location, value) => gl.uniform3uiv(location, toUIntArray(value, 3)),
+  [GL.UNSIGNED_INT_VEC4]: (gl, location, value) => gl.uniform4uiv(location, toUIntArray(value, 4)),
 
   // uniformMatrix(false): don't transpose the matrix
-  [GL_FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, toFloatArray(value, 6)),
-  [GL_FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, toFloatArray(value, 8)),
-  [GL_FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, toFloatArray(value, 6)),
-  [GL_FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, toFloatArray(value, 12)),
-  [GL_FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, toFloatArray(value, 8)),
-  [GL_FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, toFloatArray(value, 12)),
+  [GL.FLOAT_MAT2x3]: (gl, location, value) => gl.uniformMatrix2x3fv(location, false, toFloatArray(value, 6)),
+  [GL.FLOAT_MAT2x4]: (gl, location, value) => gl.uniformMatrix2x4fv(location, false, toFloatArray(value, 8)),
+  [GL.FLOAT_MAT3x2]: (gl, location, value) => gl.uniformMatrix3x2fv(location, false, toFloatArray(value, 6)),
+  [GL.FLOAT_MAT3x4]: (gl, location, value) => gl.uniformMatrix3x4fv(location, false, toFloatArray(value, 12)),
+  [GL.FLOAT_MAT4x2]: (gl, location, value) => gl.uniformMatrix4x2fv(location, false, toFloatArray(value, 8)),
+  [GL.FLOAT_MAT4x3]: (gl, location, value) => gl.uniformMatrix4x3fv(location, false, toFloatArray(value, 12)),
 
-  [GL_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_SAMPLER_2D_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_SAMPLER_2D_ARRAY]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_SAMPLER_2D_ARRAY_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_SAMPLER_CUBE_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_INT_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_INT_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_INT_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_INT_SAMPLER_2D_ARRAY]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_UNSIGNED_INT_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_UNSIGNED_INT_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_UNSIGNED_INT_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
-  [GL_UNSIGNED_INT_SAMPLER_2D_ARRAY]: (gl, location, value) => gl.uniform1i(location, value)
+  [GL.SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.SAMPLER_2D_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.SAMPLER_2D_ARRAY]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.SAMPLER_2D_ARRAY_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.SAMPLER_CUBE_SHADOW]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.INT_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.INT_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.INT_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.INT_SAMPLER_2D_ARRAY]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.UNSIGNED_INT_SAMPLER_2D]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.UNSIGNED_INT_SAMPLER_3D]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.UNSIGNED_INT_SAMPLER_CUBE]: (gl, location, value) => gl.uniform1i(location, value),
+  [GL.UNSIGNED_INT_SAMPLER_2D_ARRAY]: (gl, location, value) => gl.uniform1i(location, value)
   /* eslint-enable max-len */
 };
 

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -2,36 +2,22 @@
 import Resource from './resource';
 import {isWebGL2, getKey} from '../webgl-utils';
 import {log, assert} from '../utils';
+import GL from '../constants';
 
 /* eslint-disable camelcase */
 const OES_vertex_array_object = 'OES_vertex_array_object';
 
-const GL_ELEMENT_ARRAY_BUFFER = 0x8893;
-
-// const GL_CURRENT_VERTEX_ATTRIB = 0x8626;
-
-const GL_VERTEX_ATTRIB_ARRAY_ENABLED = 0x8622;
-const GL_VERTEX_ATTRIB_ARRAY_SIZE = 0x8623;
-const GL_VERTEX_ATTRIB_ARRAY_STRIDE = 0x8624;
-const GL_VERTEX_ATTRIB_ARRAY_TYPE = 0x8625;
-const GL_VERTEX_ATTRIB_ARRAY_NORMALIZED = 0x886A;
-const GL_VERTEX_ATTRIB_ARRAY_POINTER = 0x8645;
-const GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING = 0x889F;
-
-const GL_VERTEX_ATTRIB_ARRAY_INTEGER = 0x88FD;
-const GL_VERTEX_ATTRIB_ARRAY_DIVISOR = 0x88FE;
-
 const PARAMETERS = [
-  GL_VERTEX_ATTRIB_ARRAY_ENABLED,
-  GL_VERTEX_ATTRIB_ARRAY_SIZE,
-  GL_VERTEX_ATTRIB_ARRAY_STRIDE,
-  GL_VERTEX_ATTRIB_ARRAY_TYPE,
-  GL_VERTEX_ATTRIB_ARRAY_NORMALIZED,
-  GL_VERTEX_ATTRIB_ARRAY_POINTER,
-  GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING,
+  GL.VERTEX_ATTRIB_ARRAY_ENABLED,
+  GL.VERTEX_ATTRIB_ARRAY_SIZE,
+  GL.VERTEX_ATTRIB_ARRAY_STRIDE,
+  GL.VERTEX_ATTRIB_ARRAY_TYPE,
+  GL.VERTEX_ATTRIB_ARRAY_NORMALIZED,
+  GL.VERTEX_ATTRIB_ARRAY_POINTER,
+  GL.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING,
 
-  GL_VERTEX_ATTRIB_ARRAY_INTEGER,
-  GL_VERTEX_ATTRIB_ARRAY_DIVISOR
+  GL.VERTEX_ATTRIB_ARRAY_INTEGER,
+  GL.VERTEX_ATTRIB_ARRAY_DIVISOR
 ];
 
 const ERR_ELEMENTS = 'elements must be GL.ELEMENT_ARRAY_BUFFER';
@@ -106,7 +92,7 @@ export default class VertexArray extends Resource {
     this._filledLocations[location] = true;
 
     this.bind(() => {
-      // a non-zero named buffer object must be bound to the GL_ARRAY_BUFFER target
+      // a non-zero named buffer object must be bound to the GL.ARRAY_BUFFER target
       buffer.bind({target: gl.ARRAY_BUFFER});
 
       const {size, type, normalized, stride, offset} = layout;
@@ -166,10 +152,10 @@ export default class VertexArray extends Resource {
 
   // Set (bind) an elements buffer, for indexed rendering. Must be GL.ELEMENT_ARRAY_BUFFER
   setElements(elements) {
-    assert(!elements || elements.target === GL_ELEMENT_ARRAY_BUFFER, ERR_ELEMENTS);
+    assert(!elements || elements.target === GL.ELEMENT_ARRAY_BUFFER, ERR_ELEMENTS);
 
     this.gl.bindVertexArray(this.handle);
-    this.gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, elements && elements.handle);
+    this.gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, elements && elements.handle);
     this.gl.bindVertexArray(null);
 
     this.elements = elements;
@@ -307,7 +293,7 @@ export default class VertexArray extends Resource {
       const buffer = buffers[bufferName];
 
       // Check if this is an elements array
-      if (buffer && buffer.target === GL_ELEMENT_ARRAY_BUFFER) {
+      if (buffer && buffer.target === GL.ELEMENT_ARRAY_BUFFER) {
         assert(!elements, 'Duplicate GL.ELEMENT_ARRAY_BUFFER');
         // assert(location === undefined, 'GL.ELEMENT_ARRAY_BUFFER assigned to location');
         elements = buffer;
@@ -337,7 +323,7 @@ export default class VertexArray extends Resource {
       const buffer = buffers[bufferName];
 
       // Check if this is an elements arrau
-      if (buffer.target === GL_ELEMENT_ARRAY_BUFFER) {
+      if (buffer.target === GL.ELEMENT_ARRAY_BUFFER) {
         assert(!elements, 'Duplicate GL.ELEMENT_ARRAY_BUFFER');
         // assert(location === undefined, 'GL.ELEMENT_ARRAY_BUFFER assigned to location');
         elements = buffer;
@@ -434,7 +420,7 @@ export default class VertexArray extends Resource {
     // Let the polyfill intercept the query
     let result;
     switch (pname) {
-    case GL_VERTEX_ATTRIB_ARRAY_POINTER:
+    case GL.VERTEX_ATTRIB_ARRAY_POINTER:
       result = this.gl.getVertexAttribOffset(location, pname);
       break;
     default:

--- a/test/src/core/attribute.spec.js
+++ b/test/src/core/attribute.spec.js
@@ -1,4 +1,5 @@
-import {experimental, Buffer, GL} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {experimental, Buffer} from 'luma.gl';
 const {Attribute} = experimental;
 import test from 'tape-catch';
 import {fixture} from 'luma.gl/test/setup';

--- a/test/src/webgl-context/context-state.spec.js
+++ b/test/src/webgl-context/context-state.spec.js
@@ -2,7 +2,7 @@
 
 import test from 'tape-catch';
 
-import {GL} from 'luma.gl';
+import GL from 'luma.gl/constants';
 import {getParameter, getParameters, setParameters, withParameters, resetParameters, Framebuffer} from 'luma.gl';
 import {getKey} from 'luma.gl/webgl-utils/constants-to-keys';
 

--- a/test/src/webgl-context/data/sample-enum-settings.js
+++ b/test/src/webgl-context/data/sample-enum-settings.js
@@ -1,4 +1,4 @@
-import {GL} from 'luma.gl';
+import GL from 'luma.gl/constants';
 
 // eslint-disable-next-line
 // NOTE: These settings should be in sync with FUNCTION_STYLE_SETTINGS_SET1

--- a/test/src/webgl-context/data/sample-function-settings.js
+++ b/test/src/webgl-context/data/sample-function-settings.js
@@ -1,4 +1,4 @@
-import {GL} from 'luma.gl';
+import GL from 'luma.gl/constants';
 
 // NOTE: These settings are same as ENUM_STYLE_SETTINGS_SET1
 // In unit tests for bellow settings, we use ENUM_STYLE_SETTINGS_SET1

--- a/test/src/webgl/buffer.spec.js
+++ b/test/src/webgl/buffer.spec.js
@@ -1,4 +1,5 @@
-import {GL, Buffer, isWebGL} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {Buffer, isWebGL} from 'luma.gl';
 import test from 'tape-catch';
 
 import {fixture} from 'luma.gl/test/setup';

--- a/test/src/webgl/framebuffer.spec.js
+++ b/test/src/webgl/framebuffer.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import test from 'tape-catch';
-import {GL, Framebuffer, Renderbuffer, Texture2D, Buffer} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {Framebuffer, Renderbuffer, Texture2D, Buffer} from 'luma.gl';
 import {fixture} from 'luma.gl/test/setup';
 const EPSILON = 0.0000001;
 const TEST_CASES = [

--- a/test/src/webgl/program.spec.js
+++ b/test/src/webgl/program.spec.js
@@ -1,5 +1,6 @@
 import test from 'tape-catch';
-import {GL, Program, Buffer} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {Program, Buffer} from 'luma.gl';
 
 import {fixture} from 'luma.gl/test/setup';
 

--- a/test/src/webgl/renderbuffer.spec.js
+++ b/test/src/webgl/renderbuffer.spec.js
@@ -1,5 +1,6 @@
 import test from 'tape-catch';
-import {GL, Renderbuffer, glKey} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {Renderbuffer, glKey} from 'luma.gl';
 
 import {RENDERBUFFER_FORMATS} from 'luma.gl/webgl/renderbuffer';
 

--- a/test/src/webgl/sampler.utils.js
+++ b/test/src/webgl/sampler.utils.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
-import {GL, glKey} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {getKey} from 'luma.gl';
 
 // Sampler Parameters
 
@@ -11,7 +12,7 @@ import {GL, glKey} from 'luma.gl';
   [GL.TEXTURE_WRAP_S]                  | `GL.REPEAT`    | texture wrapping function for texture coordinate `s` |
   [GL.TEXTURE_WRAP_T]                  | `GL.REPEAT`    | texture wrapping function for texture coordinate `t` |
   [GL.TEXTURE_WRAP_R] **WebGL2**       | `GL.REPEAT`    | texture wrapping function for texture coordinate `r` |
-| `GL_TEXTURE_MAX_ANISOTROPY           | fLargest
+| GL.TEXTURE_MAX_ANISOTROPY           | fLargest
   [GL.TEXTURE_BASE_LEVEL] **WebGL2**   | `0`            | Texture mipmap level |
   [GL.TEXTURE_MAX_LEVEL] **WebGL2**    | `1000`         | Maximum texture mipmap array level |
   [GL.TEXTURE_COMPARE_FUNC] **WebGL2** | `GL.LEQUAL`    | texture comparison function |
@@ -92,7 +93,7 @@ export function testSamplerParameters({t, texture, parameters}) {
       const name = texture.constructor.name;
       const newValue = texture.getParameter(parameter);
       t.equals(newValue, value,
-        `${name}.setParameters({[${glKey(parameter)}]: ${glKey(value)}}) read back OK`);
+        `${name}.setParameters({[${getKey(GL, parameter)}]: ${getKey(GL, value)}}) read back OK`);
     }
   }
 }

--- a/test/src/webgl/texture.spec.js
+++ b/test/src/webgl/texture.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import test from 'tape-catch';
-import {GL, Texture2D, glKey} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {Texture2D, getKey} from 'luma.gl';
 
 import {TEXTURE_FORMATS} from 'luma.gl/webgl/texture';
 import {
@@ -63,7 +64,7 @@ test('WebGL#Texture2D format creation', t => {
       // const opts = Object.assign({format}, textureFormat);
       // const texture = new Texture2D(gl, opts);
       // t.equals(texture.format, format,
-      //   `Texture2D(${glKey(format)}) created with correct format`);
+      //   `Texture2D(${getKey(GL, format)}) created with correct format`);
 
       // texture.delete();
     }
@@ -115,17 +116,17 @@ test('WebGL2#Texture2D format creation', t => {
       for (const type of types) {
         // texture = new Texture2D(gl2, Object.assign({format, dataFormat, type}));
         // t.equals(texture.format, format,
-        //   `Texture2D({format: ${glKey(format)}, type: ${glKey(type)}, dataFormat: ${glKey(dataFormat)}) created`);
+        //   `Texture2D({format: ${getKey(GL, format)}, type: ${getKey(GL, type)}, dataFormat: ${getKey(GL, dataFormat)}) created`);
         // texture.delete()
         const data = TEXTURE_DATA[type] || DEFAULT_TEXTURE_DATA;
         if (data) { // eslint-disable-line
           texture = new Texture2D(gl2, {format, dataFormat, type, data, width: 1, height: 1});
           t.equals(texture.format, format,
-            `Texture2D({format: ${glKey(format)}, type: ${glKey(type)}, dataFormat: ${glKey(dataFormat)}) created`);
+            `Texture2D({format: ${getKey(GL, format)}, type: ${getKey(GL, type)}, dataFormat: ${getKey(GL, dataFormat)}) created`);
           texture.delete();
         } else {
           t.equals(texture.format, format,
-            `Texture2D({format: ${glKey(format)}, type: ${glKey(type)}, dataFormat: ${glKey(dataFormat)}) skipped`);
+            `Texture2D({format: ${getKey(GL, format)}, type: ${getKey(GL, type)}, dataFormat: ${getKey(GL, dataFormat)}) skipped`);
         }
       }
     }
@@ -184,7 +185,7 @@ test('WebGL#Texture2D setParameters', t => {
   });
   const newValue = texture.getParameter(GL.TEXTURE_MAG_FILTER);
   t.equals(newValue, value,
-    `Texture2D.setParameters({[${glKey(parameter)}]: ${glKey(value)}})`);
+    `Texture2D.setParameters({[${getKey(GL, parameter)}]: ${getKey(GL, value)}})`);
   */
 
   texture = texture.delete();

--- a/test/src/webgl/uniform-buffer-layout.spec.js
+++ b/test/src/webgl/uniform-buffer-layout.spec.js
@@ -1,5 +1,6 @@
 import test from 'tape-catch';
-import {GL, UniformBufferLayout, experimental, Buffer, Program} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {UniformBufferLayout, experimental, Buffer, Program} from 'luma.gl';
 const {Transform} = experimental;
 import {fixture} from 'luma.gl/test/setup';
 

--- a/test/src/webgl/uniforms.spec.js
+++ b/test/src/webgl/uniforms.spec.js
@@ -120,9 +120,7 @@ const ARRAY_UNIFORM_SIZE = {
 };
 
 // const WEBGL1_ARRAYS_FRAGMENT_SHADER = `
-// #ifdef GL_ES
 // precision highp float;
-// #endif
 
 // uniform float f[3];
 // uniform int i[3];
@@ -167,9 +165,7 @@ const ARRAY_UNIFORM_SIZE = {
 // };
 
 // const WEBGL2_FRAGMENT_SHADER = `
-// #ifdef GL_ES
 // precision highp float;
-// #endif
 // uniform sampler1D;
 // uniform sampler3D;
 

--- a/test/src/webgl/vertex-array.spec.js
+++ b/test/src/webgl/vertex-array.spec.js
@@ -1,5 +1,6 @@
 import test from 'tape-catch';
-import {GL, createGLContext} from 'luma.gl';
+import GL from 'luma.gl/constants';
+import {createGLContext} from 'luma.gl';
 import {VertexArray} from 'luma.gl';
 
 const fixture = {

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -131,8 +131,16 @@ const CONFIGS = {
         })
       }
     });
-    if (dist === 'es6') {
-      resolve.mainFields = ['esnext', 'browser', 'module', 'main'];
+
+    switch (dist) {
+    case 'es6':
+      config.resolve.mainFields = ['esnext', 'browser', 'module', 'main'];
+      break;
+    case 'es5':
+      config.resolve.mainFields = ['main'];
+      break;
+    case 'esm':
+    default:
     }
     return config;
   },


### PR DESCRIPTION
For #555 
#### Background
- See Issue
#### Change List
- new custom babel plugin to strip `import GL` and replace `GL.<xyz>` and `gl.<xyz>` with actual values.
- Move away from duplicated constants to `GL.`
