### PR TITLE
VertexArray #3: Refactor Transform and TransformFeedback, assuming Chrome bug is fixed.

### DIFF
--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -1,4 +1,5 @@
 /* global window */
+import 'luma.gl/debug';
 import {AnimationLoop, Buffer, setParameters, Model, pickModels, picking} from 'luma.gl';
 import {_Transform as Transform} from 'luma.gl';
 
@@ -132,7 +133,7 @@ function mouseleave(e) {
 }
 
 const animationLoop = new AnimationLoop({
-  glOptions: {webgl2: true},
+  glOptions: {webgl2: true, debug: true},
   createFramebuffer: true,
   /* eslint-disable max-statements */
   onInitialize({canvas, gl}) {

--- a/src/webgl/program-configuration.js
+++ b/src/webgl/program-configuration.js
@@ -39,7 +39,7 @@ export default class ProgramConfiguration {
   }
 
   getVaryingIndex(locationOrName) {
-    const varying = this.getVaryingInfo();
+    const varying = this.getVaryingInfo(locationOrName);
     return varying ? varying.location : -1;
   }
 

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -61,7 +61,6 @@ export default class TransformFeedback extends Resource {
   }
 
   pause() {
-    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
     this.gl.pauseTransformFeedback();
     this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
@@ -76,7 +75,6 @@ export default class TransformFeedback extends Resource {
   }
 
   end() {
-    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
     this.gl.endTransformFeedback();
     this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
@@ -144,21 +142,18 @@ export default class TransformFeedback extends Resource {
   // You'd always use the default because you'd always have to bind and
   // unbind all the buffers.
   _bindBuffers() {
-    this.bind(() => {
-      for (const bufferIndex in this.buffers) {
-        console.warn('binding buffer');
-        this.bindBuffer(Number(bufferIndex), this.buffers[bufferIndex]);
-      }
-    });
+    // Can't bind here, supposed to be called on active feedback
+    for (const bufferIndex in this.buffers) {
+      this.bindBuffer(Number(bufferIndex), this.buffers[bufferIndex]);
+    }
   }
 
   _unbindBuffers() {
-    this.bind(() => {
-      for (const bufferIndex in this.buffers) {
-        // this.bindBuffer(Number(bufferIndex), null);
-        this.gl.bindBufferBase(GL.TRANSFORM_FEEDBACK_BUFFER, Number(bufferIndex), null);
-      }
-    });
+    // Can't bind here, supposed to be called on active feedback
+    for (const bufferIndex in this.buffers) {
+      // this.bindBuffer(Number(bufferIndex), null);
+      this.gl.bindBufferBase(GL.TRANSFORM_FEEDBACK_BUFFER, Number(bufferIndex), null);
+    }
   }
 
   // Resolve a varying name or number to a location index

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -1,43 +1,47 @@
+import GL from '../constants';
 import Resource from './resource';
 import {isWebGL2, assertWebGL2Context} from '../webgl-utils';
+import {log} from '../utils';
 import assert from '../utils/assert';
 
-const GL_TRANSFORM_FEEDBACK_BUFFER = 0x8C8E;
-const GL_TRANSFORM_FEEDBACK = 0x8E22;
-
-export default class TranformFeedback extends Resource {
+export default class TransformFeedback extends Resource {
 
   static isSupported(gl) {
     return isWebGL2(gl);
   }
 
-  static isHandle(handle) {
-    return this.gl.isTransformFeedback(this.handle);
-  }
-
-  /**
-   * @class
-   * @param {WebGL2RenderingContext} gl - context
-   * @param {Object} opts - options
-   */
   constructor(gl, opts = {}) {
     assertWebGL2Context(gl);
     super(gl, opts);
-    this.buffers = {};
-    Object.seal(this);
+
+    this._bound = false;
 
     this.initialize(opts);
+
+    Object.seal(this);
   }
 
-  initialize({buffers = {}, varyingMap = {}}) {
-    this.bindBuffers(buffers, {clear: true, varyingMap});
-  }
-
-  bindBuffers(buffers = {}, {clear = false, varyingMap = {}} = {}) {
-    if (clear) {
-      this._unbindBuffers();
-      this.buffers = {};
+  setProps(props) {
+    if ('buffers' in props) {
+      this.setBuffers(props.buffers);
     }
+  }
+
+  initialize(props) {
+    this.configuration = props.configuration || (props.program && props.program.getConfiguration());
+    this.reset();
+    this.setProps(props);
+  }
+
+  reset() {
+    this._unbindBuffers();
+    this.buffers = {};
+    this.unused = [];
+    return this;
+  }
+
+  setBuffers(buffers = {}) {
+    const varyingMap = this.configuration ? this.configuration.varyingMap : {};
     for (const bufferName in buffers) {
       const buffer = buffers[bufferName];
       const index = Number.isFinite(Number(bufferName)) ?
@@ -51,51 +55,77 @@ export default class TranformFeedback extends Resource {
   // program.use, should we move these methods (begin/pause/resume/end) to the Program?
   begin(primitiveMode) {
     this._bindBuffers();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
     this.gl.beginTransformFeedback(primitiveMode);
     return this;
   }
 
   pause() {
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
     this.gl.pauseTransformFeedback();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
     return this;
   }
 
   resume() {
     this._bindBuffers();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
     this.gl.resumeTransformFeedback();
     return this;
   }
 
   end() {
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
     this.gl.endTransformFeedback();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
     this._unbindBuffers();
     return this;
   }
 
-  bindBuffer({index, buffer, offset = 0, size}) {
-    // Need to avoid chrome bug where buffer that is already bound to a different target
-    // cannot be bound to 'TRANSFORM_FEEDBACK_BUFFER' target.
-    buffer.unbind();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    if (size === undefined) {
-      this.gl.bindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer.handle);
-    } else {
-      this.gl.bindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer.handle, offset, size);
+  bindBuffer(locationOrName, buffer, size, offset = 0) {
+    const location = this._getVaryingIndex(locationOrName);
+    if (location < 0) {
+      this.unused[locationOrName] = buffer;
+      log.warn(() => `${this.id} unused varying buffer ${locationOrName}`)();
+      return this;
     }
+
+    this.buffers[location] = buffer;
+    const handle = buffer && buffer.handle;
+
+    this.bind(() => {
+      if (size === undefined) {
+        this.gl.bindBufferBase(GL.TRANSFORM_FEEDBACK_BUFFER, location, handle);
+      } else {
+        this.gl.bindBufferRange(GL.TRANSFORM_FEEDBACK_BUFFER, location, handle, offset, size);
+      }
+    });
+
     return this;
   }
 
-  unbindBuffer({index}) {
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    this.gl.bindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, index, null);
-    return this;
+  bind(funcOrHandle = this.handle) {
+    if (typeof funcOrHandle !== 'function') {
+      this.bindTransformFeedback(funcOrHandle);
+      return this;
+    }
+
+    let value;
+
+    if (!this._bound) {
+      this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
+      this._bound = true;
+
+      value = funcOrHandle();
+
+      this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
+      this._bound = false;
+    } else {
+      value = funcOrHandle();
+    }
+
+    return value;
   }
 
   // PRIVATE METHODS
@@ -114,15 +144,29 @@ export default class TranformFeedback extends Resource {
   // You'd always use the default because you'd always have to bind and
   // unbind all the buffers.
   _bindBuffers() {
-    for (const bufferIndex in this.buffers) {
-      this.bindBuffer({buffer: this.buffers[bufferIndex], index: Number(bufferIndex)});
-    }
+    this.bind(() => {
+      for (const bufferIndex in this.buffers) {
+        console.warn('binding buffer');
+        this.bindBuffer(Number(bufferIndex), this.buffers[bufferIndex]);
+      }
+    });
   }
 
   _unbindBuffers() {
-    for (const bufferIndex in this.buffers) {
-      this.unbindBuffer({buffer: this.buffers[bufferIndex], index: Number(bufferIndex)});
+    this.bind(() => {
+      for (const bufferIndex in this.buffers) {
+        // this.bindBuffer(Number(bufferIndex), null);
+        this.gl.bindBufferBase(GL.TRANSFORM_FEEDBACK_BUFFER, Number(bufferIndex), null);
+      }
+    });
+  }
+
+  // Resolve a varying name or number to a location index
+  _getVaryingIndex(locationOrName) {
+    if (this.configuration) {
+      return this.configuration.getVaryingIndex(locationOrName);
     }
+    return -1;
   }
 
   // RESOURCE METHODS
@@ -133,5 +177,11 @@ export default class TranformFeedback extends Resource {
 
   _deleteHandle() {
     this.gl.deleteTransformFeedback(this.handle);
+  }
+
+  // DEPRECATED / REMOVED
+
+  bindBuffers() {
+    log.removed('TransformFeedback.bindBuffers', 'TransformFeedback.setBuffers');
   }
 }


### PR DESCRIPTION
# For #535
#### Background
- Chrome bug appears to be fixed. Use TransformFeedback as it was originally intended to.
#### Change List
- `TransformFeedback` class no longer needs to cache, bind and unbind buffers
- `Transform` class, light cleanup and alignment with API in other places / PRs.
