### PR TITLE
Additional Transform and TransformFeedback cleanup

### DIFF
--- a/dev-docs/RFCs/v5.2/enhanced-transform-feedback-api-rfc.md
+++ b/dev-docs/RFCs/v5.2/enhanced-transform-feedback-api-rfc.md
@@ -51,14 +51,14 @@ Swap source destination buffers.
 
 ## Usage:
 
-Create `Transform` object with sourceBuffers, sourceDestinationMap and number of elements to process.
+Create `Transform` object with sourceBuffers, feedbackMap and number of elements to process.
 
 ```js
 const bufferMap = new Transform(gl2, {
   sourceBuffers: {
     inValue: sourceBuffer
   },
-  sourceDestinationMap: {
+  feedbackMap: {
     inValue: 'outValue'
   },
   vs: VS,

--- a/docs/api-reference/core/transform.md
+++ b/docs/api-reference/core/transform.md
@@ -58,14 +58,14 @@ transform.run();
 
 ### Use case : Create destination buffers automatically.
 
-`Transform` can internally create destination buffers (i.e. feedback buffers), when `sourceDestinationMap` is provided. Each destination buffer is created with same settings and layout as corresponding source buffer as per `sourceDestinationMap`.
+`Transform` can internally create destination buffers (i.e. feedback buffers), when `feedbackMap` is provided. Each destination buffer is created with same settings and layout as corresponding source buffer as per `feedbackMap`.
 
 ```js
 const transform = new Transform(gl2, {
   sourceBuffers: {
     inValue: sourceBuffer
   },
-  sourceDestinationMap: {
+  feedbackMap: {
     inValue: 'outValue'
   },
   vs: VS,
@@ -76,7 +76,7 @@ const transform = new Transform(gl2, {
 ```
 ### Use case : Multiple iterations using swapBuffers().
 
-When `sourceDestinationMap` is specified buffers can be swapped using a single call to `swapBuffers()`, this is useful for cases like particle simulation, where output of one transform feedback iteration is piped as input to the next iteration.
+When `feedbackMap` is specified buffers can be swapped using a single call to `swapBuffers()`, this is useful for cases like particle simulation, where output of one transform feedback iteration is piped as input to the next iteration.
 
 ```js
 
@@ -130,7 +130,7 @@ Constructs a `Transform` object, creates `Model` and `TransformFeedback` instanc
   * `feedbackBuffers` (`Object`, Optional) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Buffer` object.
   * `vs` (`String`) - vertex shader string.
   * `varyings` (`Array`) - Array of vertex shader varyings names.
-  * `sourceDestinationMap` (`Object`, Optional) - key and value pairs, where key is a vertex shader attribute name and value is a vertex shader varying name.
+  * `feedbackMap` (`Object`, Optional) - key and value pairs, where key is a vertex shader attribute name and value is a vertex shader varying name.
   * `drawMode` (`GLEnum` = gl.POINTS, Optional) - Draw mode to be set on `Model` and `TransformFeedback` objects during draw/render time.
   * `elementCount` (`Integer`) - Number set to vertex count when rendering the model.
 

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -220,7 +220,7 @@ const animationLoop = new AnimationLoop({
       },
       vs: EMIT_VS,
       varyings: ['v_offset', 'v_rotation'],
-      sourceDestinationMap: {
+      feedbackMap: {
         a_offset: 'v_offset',
         a_rotation: 'v_rotation'
       },

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -1,18 +1,13 @@
+import GL from '../constants';
 import Resource from './resource';
 import {isWebGL2, assertWebGL2Context} from '../webgl-utils';
+import {log} from '../utils';
 import assert from '../utils/assert';
-
-const GL_TRANSFORM_FEEDBACK_BUFFER = 0x8C8E;
-const GL_TRANSFORM_FEEDBACK = 0x8E22;
 
 export default class TranformFeedback extends Resource {
 
   static isSupported(gl) {
     return isWebGL2(gl);
-  }
-
-  static isHandle(handle) {
-    return this.gl.isTransformFeedback(this.handle);
   }
 
   /**
@@ -23,82 +18,50 @@ export default class TranformFeedback extends Resource {
   constructor(gl, opts = {}) {
     assertWebGL2Context(gl);
     super(gl, opts);
+
+    this.configuration = null;
     this.buffers = {};
+    this.unused = {};
+    this._bound = false;
+
     Object.seal(this);
 
     this.initialize(opts);
   }
 
-  initialize({buffers = {}, varyingMap = {}}) {
-    this.bindBuffers(buffers, {clear: true, varyingMap});
+  initialize(props) {
+    this.configuration = props.configuration || (props.program && props.program.getConfiguration());
+    this.reset();
+    this.setProps(props);
   }
 
-  bindBuffers(buffers = {}, {clear = false, varyingMap = {}} = {}) {
-    if (clear) {
-      this._unbindBuffers();
-      this.buffers = {};
-    }
-    for (const bufferName in buffers) {
-      const buffer = buffers[bufferName];
-      const index = Number.isFinite(Number(bufferName)) ?
-        Number(bufferName) : varyingMap[bufferName];
-      assert(Number.isFinite(index));
-      this.buffers[index] = buffer;
+  setProps(props) {
+    if ('buffers' in props) {
+      this.setBuffers(props.buffers);
     }
   }
 
-  // TODO: Activation is tightly coupled to the current program. Since we try to encapsulate
-  // program.use, should we move these methods (begin/pause/resume/end) to the Program?
-  begin(primitiveMode) {
-    this._bindBuffers();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    this.gl.beginTransformFeedback(primitiveMode);
+  reset() {
+    this.buffers = {};
+    this.unused = [];
+
+    // Unbind any currently bound buffers
+    this.bind(() => {
+      for (const bufferIndex in this.buffers) {
+        this.gl.bindBufferBase(GL.TRANSFORM_FEEDBACK_BUFFER, Number(bufferIndex), null);
+      }
+    });
     return this;
   }
 
-  pause() {
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    this.gl.pauseTransformFeedback();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
-    this._unbindBuffers();
+  setBuffers(buffers = {}) {
+    this.bind(() => {
+      for (const bufferName in buffers) {
+        this.setBuffer(bufferName, buffers[bufferName]);
+      }
+    });
     return this;
   }
-
-  resume() {
-    this._bindBuffers();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    this.gl.resumeTransformFeedback();
-    return this;
-  }
-
-  end() {
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    this.gl.endTransformFeedback();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, null);
-    this._unbindBuffers();
-    return this;
-  }
-
-  bindBuffer({index, buffer, offset = 0, size}) {
-    // Need to avoid chrome bug where buffer that is already bound to a different target
-    // cannot be bound to 'TRANSFORM_FEEDBACK_BUFFER' target.
-    buffer.unbind();
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    if (size === undefined) {
-      this.gl.bindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer.handle);
-    } else {
-      this.gl.bindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer.handle, offset, size);
-    }
-    return this;
-  }
-
-  unbindBuffer({index}) {
-    this.gl.bindTransformFeedback(GL_TRANSFORM_FEEDBACK, this.handle);
-    this.gl.bindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, index, null);
-    return this;
-  }
-
-  // PRIVATE METHODS
 
   // See https://github.com/KhronosGroup/WebGL/issues/2346
   // If it was true that having a buffer on an unused TF was a problem
@@ -113,16 +76,124 @@ export default class TranformFeedback extends Resource {
   // there would be no reason to setup transform feedback objects ever.
   // You'd always use the default because you'd always have to bind and
   // unbind all the buffers.
+
+  setBuffer(locationOrName, buffer, size, offset = 0) {
+    const location = this._getVaryingIndex(locationOrName);
+    if (location < 0) {
+      this.unused[locationOrName] = buffer;
+      log.warn(() => `${this.id} unused varying buffer ${locationOrName}`)();
+      return this;
+    }
+
+    this.buffers[location] = buffer;
+
+    // Can't bind the buffer now
+    // const handle = buffer && buffer.handle;
+    // this.bind(() => {
+    //   if (!handle || size === undefined) {
+    //     this.gl.bindBufferBase(GL.TRANSFORM_FEEDBACK_BUFFER, location, handle);
+    //   } else {
+    //     this.gl.bindBufferRange(GL.TRANSFORM_FEEDBACK_BUFFER, location, handle, offset, size);
+    //   }
+    // });
+
+    return this;
+  }
+
+  // TODO: Activation is tightly coupled to the current program. Since we try to encapsulate
+  // program.use, should we move these methods (begin/pause/resume/end) to the Program?
+  begin(primitiveMode) {
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
+    // Need to avoid chrome bug where buffer that is already bound to a different target
+    // cannot be bound to 'TRANSFORM_FEEDBACK_BUFFER' target.
+    this._bindBuffers();
+    this.gl.beginTransformFeedback(primitiveMode);
+    return this;
+  }
+
+  pause() {
+    this.gl.pauseTransformFeedback();
+    this._unbindBuffers();
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
+    return this;
+  }
+
+  resume() {
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
+    this._bindBuffers();
+    this.gl.resumeTransformFeedback();
+    return this;
+  }
+
+  end() {
+    this.gl.endTransformFeedback();
+    // Need to avoid chrome bug where buffer that is already bound to a different target
+    // cannot be bound to 'TRANSFORM_FEEDBACK_BUFFER' target.
+    this._unbindBuffers();
+    this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
+    return this;
+  }
+
+  bind(funcOrHandle = this.handle) {
+    if (typeof funcOrHandle !== 'function') {
+      this.bindTransformFeedback(funcOrHandle);
+      return this;
+    }
+
+    let value;
+
+    if (!this._bound) {
+      this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, this.handle);
+      this._bound = true;
+
+      value = funcOrHandle();
+
+      this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);
+      this._bound = false;
+    } else {
+      value = funcOrHandle();
+    }
+
+    return value;
+  }
+
+  // PRIVATE METHODS
+
+  _getVaryingInfo(locationOrName) {
+    return this.configuration && this.configuration.getVaryingInfo(locationOrName);
+  }
+
+  _getVaryingIndex(locationOrName) {
+    if (this.configuration) {
+      return this.configuration.getVaryingInfo(locationOrName).location;
+    }
+    const location = Number(locationOrName);
+    if (Number.isFinite(location)) {
+      return location;
+    }
+    return -1;
+  }
+
   _bindBuffers() {
     for (const bufferIndex in this.buffers) {
-      this.bindBuffer({buffer: this.buffers[bufferIndex], index: Number(bufferIndex)});
+      this._bindBuffer(bufferIndex, this.buffers[bufferIndex]);
     }
   }
 
   _unbindBuffers() {
     for (const bufferIndex in this.buffers) {
-      this.unbindBuffer({buffer: this.buffers[bufferIndex], index: Number(bufferIndex)});
+      this._bindBuffer(bufferIndex, null);
     }
+  }
+
+  _bindBuffer(index, buffer, offset = 0, size) {
+    const handle = buffer && buffer.handle;
+    if (!handle || size === undefined) {
+      this.gl.bindBufferBase(GL.TRANSFORM_FEEDBACK_BUFFER, index, handle);
+    } else {
+      this.gl.bindBufferRange(GL.TRANSFORM_FEEDBACK_BUFFER, index, handle, offset, size);
+    }
+    return this;
   }
 
   // RESOURCE METHODS

--- a/src/webgl/transform-feedback.js
+++ b/src/webgl/transform-feedback.js
@@ -2,9 +2,8 @@ import GL from '../constants';
 import Resource from './resource';
 import {isWebGL2, assertWebGL2Context} from '../webgl-utils';
 import {log} from '../utils';
-import assert from '../utils/assert';
 
-export default class TranformFeedback extends Resource {
+export default class TransformFeedback extends Resource {
 
   static isSupported(gl) {
     return isWebGL2(gl);

--- a/test/index-webgl-dependent-tests.js
+++ b/test/index-webgl-dependent-tests.js
@@ -1,7 +1,6 @@
 // Imports tests for all modules that depend on webgl
 
-import '../src/shadertools/test';
-import './src/shadertools';
+import '../src/shadertools/test'; // Shadertool tests are placed within submodule
 import './src/webgl1';
 import './src/webgl-utils';
 import './src/webgl-context';

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -4,6 +4,7 @@ import tapePromise from 'tape-promise';
 export default tapePromise(test_);
 
 // Avoid generating a lot of big context divs
+import 'luma.gl/debug';
 import {setContextDefaults} from 'luma.gl';
 setContextDefaults({width: 1, height: 1, debug: true, throwOnFailure: false, throwOnError: false});
 

--- a/test/src/core/transform.spec.js
+++ b/test/src/core/transform.spec.js
@@ -40,7 +40,7 @@ test('WebGL#Transform constructor/delete', t => {
       inValue: sourceBuffer
     },
     vs: VS,
-    sourceDestinationMap: {
+    feedbackMap: {
       inValue: 'outValue'
     },
     varyings: ['outValue'],
@@ -75,7 +75,7 @@ test('WebGL#Transform run', t => {
       inValue: sourceBuffer
     },
     vs: VS,
-    sourceDestinationMap: {
+    feedbackMap: {
       inValue: 'outValue'
     },
     varyings: ['outValue'],
@@ -109,7 +109,7 @@ test('WebGL#Transform swapBuffers', t => {
       inValue: sourceBuffer
     },
     vs: VS,
-    sourceDestinationMap: {
+    feedbackMap: {
       inValue: 'outValue'
     },
     varyings: ['outValue'],
@@ -149,7 +149,7 @@ test('WebGL#Transform update', t => {
       inValue: sourceBuffer
     },
     vs: VS,
-    sourceDestinationMap: {
+    feedbackMap: {
       inValue: 'outValue'
     },
     varyings: ['outValue'],

--- a/test/src/io/read-texture.js
+++ b/test/src/io/read-texture.js
@@ -1,6 +1,7 @@
 import test from 'blue-tape';
 import {createGLContext, Program, Texture2D, Buffer} from 'luma.gl';
 import {loadImage} from 'luma.gl/io';
+import {fixture} from 'luma.gl/test/setup';
 
 const DATA_URL = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAA
 Bytg0kAAAAFElEQVQIW2P8z/D/PwMDAwMjjAEAQOwF/W1Dp54AAAAASUVORK5CYII=`;
@@ -10,7 +11,7 @@ test('WebGL#load-file', t => {
 });
 
 test('WebGL#read-texture', t => {
-  const gl = createGLContext({width: 2, height: 2, debug: true});
+  const {gl} = fixture;
 
   const program = new Program(gl, {
     vs: `

--- a/test/src/io/read-texture.js
+++ b/test/src/io/read-texture.js
@@ -1,5 +1,5 @@
 import test from 'blue-tape';
-import {createGLContext, Program, Texture2D, Buffer} from 'luma.gl';
+import {Program, Texture2D, Buffer} from 'luma.gl';
 import {loadImage} from 'luma.gl/io';
 import {fixture} from 'luma.gl/test/setup';
 

--- a/test/src/shadertools/index.js
+++ b/test/src/shadertools/index.js
@@ -1,1 +1,0 @@
-import './modules';

--- a/test/src/webgl/draw.spec.js
+++ b/test/src/webgl/draw.spec.js
@@ -1,5 +1,6 @@
 import test from 'tape-catch';
 import {createGLContext, Program} from 'luma.gl';
+import {fixture} from 'luma.gl/test/setup';
 
 const vs = `
 attribute vec3 positions;
@@ -17,7 +18,7 @@ void main(void) {
 `;
 
 test('WebGL#draw', t => {
-  const gl = createGLContext();
+  const {gl} = fixture;
   t.ok(gl, 'Created gl context');
 
   const program = new Program(gl, {vs, fs});

--- a/test/src/webgl/draw.spec.js
+++ b/test/src/webgl/draw.spec.js
@@ -1,5 +1,5 @@
 import test from 'tape-catch';
-import {createGLContext, Program} from 'luma.gl';
+import {Program} from 'luma.gl';
 import {fixture} from 'luma.gl/test/setup';
 
 const vs = `

--- a/test/src/webgl/framebuffer.spec.js
+++ b/test/src/webgl/framebuffer.spec.js
@@ -3,7 +3,9 @@ import test from 'tape-catch';
 import GL from 'luma.gl/constants';
 import {Framebuffer, Renderbuffer, Texture2D, Buffer} from 'luma.gl';
 import {fixture} from 'luma.gl/test/setup';
+
 const EPSILON = 0.0000001;
+
 const TEST_CASES = [
   {
     title: 'Default attachments',

--- a/test/src/webgl/sampler.spec.js
+++ b/test/src/webgl/sampler.spec.js
@@ -1,24 +1,22 @@
 import test from 'tape-catch';
-import {createGLContext, Sampler} from 'luma.gl';
+import {Sampler} from 'luma.gl';
+
+import {fixture} from 'luma.gl/test/setup';
 
 import {
   testSamplerParameters, SAMPLER_PARAMETERS, SAMPLER_PARAMETERS_WEBGL2
 } from './sampler.utils';
 
-const fixture = {
-  gl: createGLContext({webgl2: true})
-};
-
 test('WebGL2#Sampler setParameters', t => {
-  const {gl} = fixture;
+  const {gl2} = fixture;
 
-  if (!Sampler.isSupported(gl)) {
+  if (!Sampler.isSupported(gl2)) {
     t.comment('Sampler not available, skipping tests');
     t.end();
     return;
   }
 
-  let sampler = new Sampler(gl, {});
+  let sampler = new Sampler(gl2, {});
   t.ok(sampler instanceof Sampler, 'Sampler construction successful');
 
   testSamplerParameters({t, texture: sampler, parameters: SAMPLER_PARAMETERS});

--- a/test/src/webgl/texture-2d-array.spec.js
+++ b/test/src/webgl/texture-2d-array.spec.js
@@ -1,10 +1,7 @@
 import test from 'tape-catch';
-import {createGLContext} from '../../utils/test-tools';
-import {Texture2DArray} from 'luma.gl';
+import {Texture2DArray} from 'luma.gl2';
 
-const fixture = {
-  gl: createGLContext()
-};
+import {fixture} from 'luma.gl/test/setup';
 
 test('WebGL#Texture2DArray', tt => {
 
@@ -15,14 +12,14 @@ test('WebGL#Texture2DArray', tt => {
   }
 
   test('WebGL#Texture2DArray construct/delete', t => {
-    const {gl} = fixture;
+    const {gl2} = fixture;
 
     t.throws(
       () => new Texture2DArray(),
       /.*WebGLRenderingContext.*/,
       'Texture2DArray throws on missing gl context');
 
-    const texture = new Texture2DArray(gl);
+    const texture = new Texture2DArray(gl2);
     t.ok(texture instanceof Texture2DArray, 'Texture2DArray construction successful');
 
     texture.delete();
@@ -35,9 +32,9 @@ test('WebGL#Texture2DArray', tt => {
   });
 
   test('WebGL#Texture2DArray parameters', t => {
-    const {gl} = fixture;
+    const {gl2} = fixture;
 
-    const texture = new Texture2DArray(gl);
+    const texture = new Texture2DArray(gl2);
     t.ok(texture instanceof Texture2DArray, 'Texture2DArray construction successful');
 
     const params = texture.getParameters({keys: true});

--- a/test/src/webgl/transform-feedback.spec.js
+++ b/test/src/webgl/transform-feedback.spec.js
@@ -49,28 +49,24 @@ test('WebGL#TransformFeedback bindBuffers', t => {
   const buffer1 = new Buffer(gl2);
   const buffer2 = new Buffer(gl2);
 
-  tf.bindBuffers({
+  tf.setBuffers({
     0: buffer1,
     1: buffer2
   });
   t.ok(tf instanceof TransformFeedback, 'TransformFeedback bindBuffers successful');
 
-  tf.bindBuffers({
+  tf.setBuffers({
     0: buffer1,
     1: buffer2
-  }, {clear: true});
+  });
   t.ok(tf instanceof TransformFeedback, 'TransformFeedback bindBuffers with clear is successful');
 
-  const varyingMap = {
-    varying1: 0,
-    varying2: 1
-  };
-  tf.bindBuffers({
-    varying2: buffer2,
-    varying1: buffer1
-  }, {clear: true, varyingMap});
+  // tf.setBuffers({
+  //   varying2: buffer2,
+  //   varying1: buffer1
+  // }, {clear: true, varyingMap});
 
-  t.ok(tf instanceof TransformFeedback, 'TransformFeedback bindBuffers with clear is successful');
+  // t.ok(tf instanceof TransformFeedback, 'TransformFeedback bindBuffers with clear is successful');
 
   t.end();
 });


### PR DESCRIPTION
# For #535 

#### Change List

- Replace `varyingMap` with program configuration
- Rename `sourceDestinationMap` to `feedbackMap`
- TransformFeedback setBuffer / bindBuffer distinction.
- Create less contexts during testing