### PR TITLE
Model, AnimationLoop - Code reorganization

### DIFF
--- a/examples/core/cubemap/app.js
+++ b/examples/core/cubemap/app.js
@@ -33,51 +33,6 @@ function readHTMLControls() {
   return {uReflect, uRefract};
 }
 
-const animationLoop = new AnimationLoop({
-
-  onInitialize: ({gl, canvas}) => {
-    setParameters(gl, {
-      clearColor: [0, 0, 0, 1],
-      clearDepth: 1,
-      depthTest: true,
-      depthFunc: GL.LEQUAL
-    });
-
-    return {
-      cube: getCube(gl),
-      prism: getPrism(gl),
-      cubemap: new TextureCube(gl, {data: getFaceTextures({size: 512})})
-    };
-  },
-
-  onRender: ({gl, tick, aspect, cube, prism, cubemap}) => {
-    const view = new Matrix4().lookAt({eye: [0, 0, -1]}).translate([0, 0, 4]);
-    const projection = new Matrix4().perspective({fov: radians(75), aspect});
-
-    const {uReflect, uRefract} = readHTMLControls();
-
-    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
-
-    cube.render({
-      uTextureCube: cubemap,
-      uModel: new Matrix4().scale([5, 5, 5]),
-      uView: view,
-      uProjection: projection
-    });
-
-    prism.render({
-      uTextureCube: cubemap,
-      uReflect,
-      uRefract,
-      uModel: new Matrix4().rotateX(tick * 0.01).rotateY(tick * 0.013),
-      uView: view,
-      uProjection: projection
-    });
-  }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
-
 function getCube(gl) {
   return new Cube(gl, {
     vs: `\
@@ -156,6 +111,51 @@ void main(void) {
 `
   });
 }
+
+const animationLoop = new AnimationLoop({
+
+  onInitialize: ({gl, canvas}) => {
+    setParameters(gl, {
+      clearColor: [0, 0, 0, 1],
+      clearDepth: 1,
+      depthTest: true,
+      depthFunc: GL.LEQUAL
+    });
+
+    return {
+      cube: getCube(gl),
+      prism: getPrism(gl),
+      cubemap: new TextureCube(gl, {data: getFaceTextures({size: 512})})
+    };
+  },
+
+  onRender: ({gl, tick, aspect, cube, prism, cubemap}) => {
+    const view = new Matrix4().lookAt({eye: [0, 0, -1]}).translate([0, 0, 4]);
+    const projection = new Matrix4().perspective({fov: radians(75), aspect});
+
+    const {uReflect, uRefract} = readHTMLControls();
+
+    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
+
+    cube.render({
+      uTextureCube: cubemap,
+      uModel: new Matrix4().scale([5, 5, 5]),
+      uView: view,
+      uProjection: projection
+    });
+
+    prism.render({
+      uTextureCube: cubemap,
+      uReflect,
+      uRefract,
+      uModel: new Matrix4().rotateX(tick * 0.01).rotateY(tick * 0.013),
+      uView: view,
+      uProjection: projection
+    });
+  }
+});
+
+animationLoop.getInfo = () => INFO_HTML;
 
 // Create six textures for the cube map sides
 function getFaceTextures({size}) {

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -13,71 +13,6 @@ single GPU draw call using instanced vertex attributes.
 
 const SIDE = 256;
 
-let pickPosition = [0, 0];
-function mousemove(e) {
-  pickPosition = [e.offsetX, e.offsetY];
-}
-function mouseleave(e) {
-  pickPosition = null;
-}
-
-const animationLoop = new AnimationLoop({
-  createFramebuffer: true,
-  onInitialize({gl}) {
-    setParameters(gl, {
-      clearColor: [0, 0, 0, 1],
-      clearDepth: 1,
-      depthTest: true,
-      depthFunc: GL.LEQUAL
-    });
-
-    gl.canvas.addEventListener('mousemove', mousemove);
-    gl.canvas.addEventListener('mouseleave', mouseleave);
-
-    return {
-      cube: makeInstancedCube(gl)
-    };
-  },
-  onFinalize({gl, cube}) {
-    gl.canvas.removeEventListener('mousemove', mousemove);
-    cube.delete();
-  },
-  onRender({gl, tick, aspect, cube, framebuffer, useDevicePixels}) {
-    cube.setUniforms({
-      uTime: tick * 0.1,
-      // Basic projection matrix
-      uProjection: new Matrix4().perspective({fov: radians(60), aspect, near: 1, far: 2048.0}),
-      // Move the eye around the plane
-      uView: new Matrix4().lookAt({
-        center: [0, 0, 0],
-        eye: [
-          Math.cos(tick * 0.005) * SIDE / 2,
-          Math.sin(tick * 0.006) * SIDE / 2,
-          (Math.sin(tick * 0.0035) + 1) * SIDE / 4 + 32
-        ]
-      }),
-      // Rotate all the individual cubes
-      uModel: new Matrix4().rotateX(tick * 0.01).rotateY(tick * 0.013)
-    });
-
-    const pickInfo = pickPosition && pickModels(gl, {
-      models: [cube],
-      position: pickPosition,
-      useDevicePixels,
-      framebuffer
-    });
-
-    const pickingSelectedColor = (pickInfo && pickInfo.color) || null;
-
-    cube.updateModuleSettings({
-      pickingSelectedColor
-    });
-
-    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
-    cube.draw();
-  }
-});
-
 // Make a cube with 65K instances and attributes to control offset and color of each instance
 function makeInstancedCube(gl) {
   let offsets = [];
@@ -157,6 +92,71 @@ void main(void) {
     }
   });
 }
+
+let pickPosition = [0, 0];
+function mousemove(e) {
+  pickPosition = [e.offsetX, e.offsetY];
+}
+function mouseleave(e) {
+  pickPosition = null;
+}
+
+const animationLoop = new AnimationLoop({
+  createFramebuffer: true,
+  onInitialize({gl}) {
+    setParameters(gl, {
+      clearColor: [0, 0, 0, 1],
+      clearDepth: 1,
+      depthTest: true,
+      depthFunc: GL.LEQUAL
+    });
+
+    gl.canvas.addEventListener('mousemove', mousemove);
+    gl.canvas.addEventListener('mouseleave', mouseleave);
+
+    return {
+      cube: makeInstancedCube(gl)
+    };
+  },
+  onFinalize({gl, cube}) {
+    gl.canvas.removeEventListener('mousemove', mousemove);
+    cube.delete();
+  },
+  onRender({gl, tick, aspect, cube, framebuffer, useDevicePixels}) {
+    cube.setUniforms({
+      uTime: tick * 0.1,
+      // Basic projection matrix
+      uProjection: new Matrix4().perspective({fov: radians(60), aspect, near: 1, far: 2048.0}),
+      // Move the eye around the plane
+      uView: new Matrix4().lookAt({
+        center: [0, 0, 0],
+        eye: [
+          Math.cos(tick * 0.005) * SIDE / 2,
+          Math.sin(tick * 0.006) * SIDE / 2,
+          (Math.sin(tick * 0.0035) + 1) * SIDE / 4 + 32
+        ]
+      }),
+      // Rotate all the individual cubes
+      uModel: new Matrix4().rotateX(tick * 0.01).rotateY(tick * 0.013)
+    });
+
+    const pickInfo = pickPosition && pickModels(gl, {
+      models: [cube],
+      position: pickPosition,
+      useDevicePixels,
+      framebuffer
+    });
+
+    const pickingSelectedColor = (pickInfo && pickInfo.color) || null;
+
+    cube.updateModuleSettings({
+      pickingSelectedColor
+    });
+
+    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
+    cube.draw();
+  }
+});
 
 animationLoop.getInfo = () => INFO_HTML;
 

--- a/src/core/pick-models.js
+++ b/src/core/pick-models.js
@@ -48,7 +48,7 @@ export default function pickModels(gl, {
   const group = new Group({children: models});
   return group.traverseReverse(model => {
 
-    if (model.isPickable !== false) {
+    if (model.pickable !== false) {
       // Clear the frame buffer
       clear(gl, {framebuffer, color: true, depth: true});
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,13 +62,14 @@ export {default as TransformFeedback} from './webgl/transform-feedback';
 export {default as VertexArray} from './webgl/vertex-array';
 export {default as UniformBufferLayout} from './webgl/uniform-buffer-layout';
 
-// Core
-export {default as Model} from './core/model';
-export {default as AnimationLoop} from './core/animation-loop';
-export {default as AnimationLoopProxy} from './core/animation-loop-proxy';
+// experimental WebGL exports
+export {clearBuffer as _clearBuffer} from './webgl/clear';
 
+// CORE
 // export {default as Object3D} from './core/object-3d';
 // export {default as Group} from './core/group';
+export {default as Model} from './core/model';
+export {default as AnimationLoop} from './core/animation-loop';
 export {default as pickModels} from './core/pick-models';
 export {
   encodePickingColor,
@@ -76,7 +77,10 @@ export {
   getNullPickingColor} from './core/picking-colors';
 
 // Experimental core exports
+export {default as _Transform} from './core/transform';
 export {default as _Attribute} from './core/attribute';
+export {default as _ShaderCache} from './core/shader-cache';
+export {default as _AnimationLoopProxy} from './core/animation-loop-proxy';
 
 // Geometry
 export {default as Geometry} from './geometry/geometry';
@@ -127,12 +131,6 @@ export {default as lighting} from './shadertools/src/modules/lighting/lighting';
 export {default as dirlight} from './shadertools/src/modules/dirlight/dirlight';
 export {default as picking} from './shadertools/src/modules/picking/picking';
 export {default as diffuse} from './shadertools/src/modules/diffuse/diffuse';
-
-// EXPERIMENTAL EXPORTS
-
-export {clearBuffer as _clearBuffer} from './webgl/clear';
-export {default as _Transform} from './core/transform';
-export {default as _ShaderCache} from './core/shader-cache';
 
 // DEPRECATED EXPORTS IN v6.0
 


### PR DESCRIPTION
# For #573

#### Change List
- Reorganize/Clean up `model.js`
- Rename and make `AnimationLoop.animationProps` available to `Model`
- Move around code in two examples to reduce diff size in coming PR.
- Make `AnimationLoopProxy` into experimental export.