### PR TITLE
Fix buffer reuse

### DIFF
--- a/docs/api-reference/webgl/vertex-array.md
+++ b/docs/api-reference/webgl/vertex-array.md
@@ -123,12 +123,21 @@ Reinitializes a `VertexArray`.
 Sets named uniforms from a map.
 
 ```js
-program.setAttributes({nameOrLocation: value, ....});
+program.setAttributes(attributes : Object);
 ```
 
 * `attributes` - (*object*) An object with key value pairs matching a buffer name and its value respectively.
+
+Attributes is an object with key-value pairs: `{nameOrLocation: value, ....}`.
+
 * `nameOrLocation` - (*string|number*) The name of the attribute as declared in the shader, or the location specified by a layout qualifier in the shader.
-* `value` - (*Buffer|typed array*) An attribute value must be a `Buffer` or a typed array.
+* `value` - (*Buffer|Array|typed array*) An attribute value must be a `Buffer` or a typed array.
+
+Each value can be an a `Buffer`, an `Array` starting with a `Buffer` or a typed array.
+
+* Typed Array - Sets a constant value as if `.setConstant(value)`  was called.
+* `Buffer` - Binds the atttribute to a buffer, using buffer's accessor data as if `.setBuffer(value)` was called.
+* `Array` - Binds the atttribute to a buffer, with extra accessor data overrides. Expects a two element array with `[buffer : Buffer, accessor : Object]`. Binds the attribute to the buffer as if ` .setBuffer(buffer, accessor)` was called.
 
 
 ### setConstant(values : Array) : VertexArray

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -7,13 +7,15 @@ Date: In development, target late June 2018
 A major release that focuses on WebGL performance and code size optimizations, API cleanup, better support for shader/GLSL programming and improved documentation.
 
 
-### WebGL Optimizations
+### WebGL Improvements
 
 * **WebGL1 Browser Support Optimizations** - luma.gl focuses on providing a WebGL2 based API, and internally "translates" WebGL2-style API calls to WebGL1 calls when WebGL2 is not available. While this WebGL1 backwards compatibility is convenient, it is not completely free. Therefore, to optimize the bundle size of WebGL2-only applications, WebGL1 "polyfills" are no longer included by default. If you still want your app to support WebGL1 browsers, just import 'luma.gl/webgl1' before creating any luma.gl contexts. Also note that WebGL portability, including WebGL1 browser support, is still a core feature of luma.gl, and the WebGL1 polyfills will continue to be used and supported.
 
 * **Attribute Management Optimizations** - `VertexArray` objects are now used for all attribute management in luma.gl, resulting in improved performance and a simpler, more consistent API. The `Program` and `Model` class APIs have been updated to use `VertexArray`.
 
 * **Buffer Memory Optimizations** - The `Buffer` class no longer holds on to the complete JavaScript typed arrays used during initialization. This can lead to significant memory savings in apps that use multiple large GPU buffers initialized from typed arrays.
+
+* **Transform Feedback Improvements** - A new method `Model.transform` makes it easier to run basic transform feedback operations.
 
 
 ### API Cleanup

--- a/src/core/attribute.js
+++ b/src/core/attribute.js
@@ -98,8 +98,7 @@ export default class Attribute {
   getValue() {
     const buffer = this.externalBuffer || this.buffer;
     if (buffer) {
-      buffer.accessor.update(this);
-      return buffer;
+      return [buffer, this];
     }
     if (this.isGeneric) {
       return this.value;

--- a/src/webgl/vertex-array.js
+++ b/src/webgl/vertex-array.js
@@ -145,7 +145,11 @@ export default class VertexArray extends Resource {
     this.bind(() => {
       for (const locationOrName in attributes) {
         const value = attributes[locationOrName];
-        if (value instanceof Buffer) {
+        if (Array.isArray(value) && value.length && value[0] instanceof Buffer) {
+          const buffer = value[0];
+          const accessor = value[1];
+          this.setBuffer(locationOrName, buffer, accessor);
+        } else if (value instanceof Buffer) {
           this.setBuffer(locationOrName, value);
         } else if (ArrayBuffer.isView(value) || Array.isArray(value)) {
           this.setConstant(locationOrName, value);

--- a/website-ocular/TODO.md
+++ b/website-ocular/TODO.md
@@ -1,7 +1,10 @@
-P0 - Make sure luma.gl can lint website folder using its own linter rules (not oculars) without crashing on missing dependency @ljharb/eslint-config
-P0 - Fix urls - Old website has static urls, ocular generates url based on headers, this will cause massive url breakage.
+
 P0 - Fix links between pages
 P0 - Fix links to subheaders
 P0 - Framework drop down menu broken
 P0 - Restore Example Text and Controls
 P1 - Flash of unstyled HTML (P0 if it affects production)
+
+P1 - Fix urls - Old website has static urls, ocular generates url based on headers, this will cause massive link/url breakage?
+
+P2 - Make sure luma.gl can lint website folder using its own linter rules (not oculars) without crashing on missing dependency @ljharb/eslint-config


### PR DESCRIPTION
For #
#### Change List
- Support specifying separate accessor info in `VertexArray.setAttributes({name: [buffer, accessor]})`
- `Attribute`: Ensure that the original attribute settings are used when setting shared buffers.
