### PR TITLE
Fix generic attribute bug

### DIFF
--- a/docs/api-reference/core/attribute.md
+++ b/docs/api-reference/core/attribute.md
@@ -37,13 +37,15 @@ The constructor for the Attribute class. Use this to create a new Attribute.
 * `id` (*string*, optional) - Identifier of the attribute. Cannot be updated.
 * `type` (*GLenum*, optional) - Type of the attribute. If not supplied will be inferred from `value`. Cannot be updated.
 * `isIndexed` (*bool*, optional) - If the attribute is element index. Default `false`. Cannot be updated.
-* `isGeneric` (*bool*, optional) - If the attribute is generic. Default `false`.
+* `constant` (*bool*, optional) - If the attribute is a constant. Default `false`.
 * `isInstanced` (*bool*, optional) - Whether buffer contains instance data. Default `false`.
 * `normalized` (*boolean*, optional) - Default `false`
 * `integer` (*boolean*, optional) - Default `false`
 * `offset` (*number*, optional) - where the data starts in the buffer. Default `0`.
 * `stride` (*number*, optional) - an additional offset between each element in the buffer. Default `0`.
 * `value` (*TypedArray*) - value of the attribute.
+    - If `constant` is `true`, the length of `value` should match `size`
+    - If `constant` is `false`, the length of `value` should be `size` multiplies the number of vertices.
 * `buffer` (*Buffer*) - an external buffer for the attribute.
 
 

--- a/src/core/attribute.js
+++ b/src/core/attribute.js
@@ -51,7 +51,7 @@ export default class Attribute {
       integer = this.integer || false,
       instanced = this.instanced || 0,
 
-      isGeneric = this.isGeneric || false,
+      constant = this.constant || false,
       isInstanced
     } = opts;
 
@@ -60,7 +60,7 @@ export default class Attribute {
     this.stride = stride;
     this.normalized = normalized;
     this.integer = integer;
-    this.isGeneric = isGeneric;
+    this.constant = constant;
 
     if (isInstanced !== undefined) {
       this.instanced = isInstanced ? 1 : 0;
@@ -70,6 +70,8 @@ export default class Attribute {
 
     if (buffer) {
       this.externalBuffer = buffer;
+      this.constant = false;
+
       this.type = buffer.accessor.type;
       if (buffer.accessor.divisor !== undefined) {
         this.instanced = buffer.accessor.divisor > 0;
@@ -78,7 +80,7 @@ export default class Attribute {
       this.externalBuffer = null;
       this.value = value;
 
-      if (!isGeneric) {
+      if (!constant) {
         // Create buffer if needed
         this.buffer = this.buffer ||
           new Buffer(this.gl, Object.assign({}, opts, {target: this.target, type: this.type}));
@@ -89,14 +91,14 @@ export default class Attribute {
   }
 
   getBuffer() {
-    if (this.isGeneric) {
+    if (this.constant) {
       return null;
     }
     return this.externalBuffer || this.buffer;
   }
 
   getValue() {
-    if (this.isGeneric) {
+    if (this.constant) {
       return this.value;
     }
     const buffer = this.externalBuffer || this.buffer;

--- a/src/core/attribute.js
+++ b/src/core/attribute.js
@@ -96,12 +96,12 @@ export default class Attribute {
   }
 
   getValue() {
+    if (this.isGeneric) {
+      return this.value;
+    }
     const buffer = this.externalBuffer || this.buffer;
     if (buffer) {
       return [buffer, this];
-    }
-    if (this.isGeneric) {
-      return this.value;
     }
     return null;
   }

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -586,7 +586,7 @@ count: ${this.stats.profileFrameCount}`
         attribute = attribute || new Attribute(gl, Object.assign({}, descriptor.layout, {
           id: attributeName
         }));
-        attribute.update({isGeneric: false, buffer: descriptor});
+        attribute.update({buffer: descriptor});
       } else if (attribute) {
         attribute.update(descriptor);
       } else {

--- a/test/src/core/attribute.spec.js
+++ b/test/src/core/attribute.spec.js
@@ -72,8 +72,11 @@ test('WebGL#Attribute getBuffer', t => {
   attribute.update({value: value2});
   t.is(attribute.getBuffer(), attribute.buffer, 'getBuffer returns own buffer');
 
-  attribute.update({isGeneric: true, value: [0, 0, 0, 0]});
+  attribute.update({constant: true, value: [0, 0, 0, 0]});
   t.is(attribute.getBuffer(), null, 'getBuffer returns null for generic attributes');
+
+  attribute.update({buffer});
+  t.is(attribute.getBuffer(), buffer, 'getBuffer returns user supplied buffer');
 
   attribute.delete();
 
@@ -93,8 +96,11 @@ test('WebGL#Attribute getValue', t => {
   attribute.update({value: value2});
   t.is(attribute.getValue()[0], attribute.buffer, 'getValue returns own buffer');
 
-  attribute.update({isGeneric: true, value: value1});
+  attribute.update({constant: true, value: value1});
   t.is(attribute.getValue(), value1, 'getValue returns generic value');
+
+  attribute.update({buffer});
+  t.is(attribute.getValue()[0], buffer, 'getValue returns user supplied buffer');
 
   attribute.delete();
 

--- a/test/src/core/attribute.spec.js
+++ b/test/src/core/attribute.spec.js
@@ -79,3 +79,24 @@ test('WebGL#Attribute getBuffer', t => {
 
   t.end();
 });
+
+test('WebGL#Attribute getValue', t => {
+  const {gl} = fixture;
+
+  const attribute = new Attribute(gl, {size: 4, value: value1});
+  t.is(attribute.getValue()[0], attribute.buffer, 'getValue returns own buffer');
+
+  const buffer = new Buffer(gl, {data: value1});
+  attribute.update({buffer});
+  t.is(attribute.getValue()[0], buffer, 'getValue returns user supplied buffer');
+
+  attribute.update({value: value2});
+  t.is(attribute.getValue()[0], attribute.buffer, 'getValue returns own buffer');
+
+  attribute.update({isGeneric: true, value: value1});
+  t.is(attribute.getValue(), value1, 'getValue returns generic value');
+
+  attribute.delete();
+
+  t.end();
+});

--- a/test/src/core/model.spec.js
+++ b/test/src/core/model.spec.js
@@ -42,7 +42,7 @@ test('Model#setAttribute', t => {
   model.setAttributes({
     instanceSizes: new Attribute(gl, {size: 1, buffer: buffer1}),
     instancePositions: buffer2,
-    instanceWeight: {size: 1, isGeneric: true, value: new Float32Array([10])}
+    instanceWeight: {size: 1, constant: true, value: new Float32Array([10])}
   });
 
   t.is(stats.resourceMap.Buffer.active - initialActiveBuffers, 4, 'Did not create new buffers');


### PR DESCRIPTION
#### Background
Once `attribute.buffer` is created, `getValue()` never returns the generic value even if `isGeneric` is updated to `true`.

#### Change List
- Fix `attribute.getValue`
- Add tests
