### PR TITLE
Transfrom: swap buffers cleanup

### DIFF
--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -74,6 +74,7 @@ export default class Transform {
       return this;
     }
 
+
     this.model.setVertexCount(elementCount);
 
     for (const bufferName in feedbackBuffers) {
@@ -147,10 +148,8 @@ export default class Transform {
       varyingsArray = Object.values(feedbackMap);
     }
 
-    if (feedbackMap) {
-      this.feedbackMap = feedbackMap;
-      this._swapBuffers = true;
-    }
+    this.feedbackMap = feedbackMap;
+    this._swapBuffers = this._canSwapBuffers({feedbackMap, sourceBuffers});
 
     this._setupBuffers({sourceBuffers, feedbackBuffers});
     this._buildModel({id, vs, varyings: varyingsArray, drawMode, elementCount});
@@ -215,4 +214,14 @@ export default class Transform {
       });
     }
   }
+
+  _canSwapBuffers({feedbackMap, sourceBuffers}) {
+    const buffers = Object.values(sourceBuffers);
+    if (buffers.some(buffer => !(buffer instanceof Buffer))) {
+      return false;
+    }
+    if (!feedbackMap) {
+      return false;
+    }
+    return true;
 }

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -215,6 +215,7 @@ export default class Transform {
     }
   }
 
+  // Returns true if buffers can be swappable, false otherwise.
   _canSwapBuffers({feedbackMap, sourceBuffers}) {
     const buffers = Object.values(sourceBuffers);
     if (buffers.some(buffer => !(buffer instanceof Buffer))) {
@@ -224,4 +225,5 @@ export default class Transform {
       return false;
     }
     return true;
+  }
 }

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -138,7 +138,6 @@ export default class Transform {
 
     this.feedbackMap = feedbackMap;
     this._swapBuffers = this._canSwapBuffers({feedbackMap, sourceBuffers});
-    this._autoCreatedBuffers = {};
 
     this._setupBuffers({sourceBuffers, feedbackBuffers});
     this._buildModel({id, vs, varyings: varyingsArray, drawMode, elementCount});

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -26,7 +26,7 @@ export default class Transform {
     this.sourceBuffers = new Array(2);
     this.feedbackBuffers = new Array(2);
     this.transformFeedbacks = new Array(2);
-    this._buffersToDelete = [];
+    this._buffersCreated = {};
 
     this._initialize(opts);
     Object.seal(this);
@@ -34,9 +34,7 @@ export default class Transform {
 
   // Delete owned resources.
   delete() {
-    for (const buffer of this._buffersToDelete) {
-      buffer.delete();
-    }
+    Object.values(this._buffersCreated).map(buffer => buffer.delete());
     this.model.delete();
   }
 
@@ -74,7 +72,6 @@ export default class Transform {
       return this;
     }
 
-
     this.model.setVertexCount(elementCount);
 
     for (const bufferName in feedbackBuffers) {
@@ -84,24 +81,10 @@ export default class Transform {
     const {currentIndex} = this;
     Object.assign(this.sourceBuffers[currentIndex], sourceBuffers);
     Object.assign(this.feedbackBuffers[currentIndex], feedbackBuffers);
+    this._createFeedbackBuffers({feedbackBuffers});
     this.transformFeedbacks[currentIndex].setBuffers(this.feedbackBuffers[currentIndex]);
 
-    if (this._swapBuffers) {
-      const nextIndex = (currentIndex + 1) % 2;
-
-      for (const sourceBufferName in this.feedbackMap) {
-        const feedbackBufferName = this.feedbackMap[sourceBufferName];
-
-        this.sourceBuffers[nextIndex][sourceBufferName] =
-          this.feedbackBuffers[currentIndex][feedbackBufferName];
-        this.feedbackBuffers[nextIndex][feedbackBufferName] =
-          this.sourceBuffers[currentIndex][sourceBufferName];
-        // make sure the new destination buffer is a Buffer object
-        assert(this.feedbackBuffers[nextIndex][feedbackBufferName] instanceof Buffer);
-      }
-
-      this.transformFeedbacks[nextIndex].setBuffers(this.feedbackBuffers[nextIndex]);
-    }
+    this._setupSwapBuffers({feedbackBuffers});
     return this;
   }
 
@@ -150,6 +133,7 @@ export default class Transform {
 
     this.feedbackMap = feedbackMap;
     this._swapBuffers = this._canSwapBuffers({feedbackMap, sourceBuffers});
+    this._autoCreatedBuffers = {};
 
     this._setupBuffers({sourceBuffers, feedbackBuffers});
     this._buildModel({id, vs, varyings: varyingsArray, drawMode, elementCount});
@@ -160,31 +144,62 @@ export default class Transform {
 
     this.sourceBuffers[0] = Object.assign({}, sourceBuffers);
     this.feedbackBuffers[0] = Object.assign({}, feedbackBuffers);
+    this._createFeedbackBuffers({feedbackBuffers});
+    this.sourceBuffers[1] = {};
+    this.feedbackBuffers[1] = {};
 
-    if (this._swapBuffers) {
-      this.sourceBuffers[1] = {};
-      this.feedbackBuffers[1] = {};
+    this._setupSwapBuffers({feedbackBuffers});
+  }
 
-      for (const sourceBufferName in this.feedbackMap) {
-        const feedbackBufferName = this.feedbackMap[sourceBufferName];
+  // auto create any feedback buffers
+  _createFeedbackBuffers({feedbackBuffers}) {
+    if (!this.feedbackMap) {
+      // feedbackMap required to auto create buffers.
+      return;
+    }
+    const current = this.currentIndex;
+    for (const sourceBufferName in this.feedbackMap) {
+      const feedbackBufferName = this.feedbackMap[sourceBufferName];
+      if (!feedbackBuffers || !feedbackBuffers[feedbackBufferName]) {
+        // Create new buffer with same layout and settings as source buffer
+        const sourceBuffer = this.sourceBuffers[current][sourceBufferName];
+        const {bytes, type, usage, layout} = sourceBuffer;
+        const buffer = new Buffer(this.gl, {bytes, type, usage, layout});
 
-        if (!this.feedbackBuffers[0][feedbackBufferName]) {
-
-          // Create new buffer with same layout and settings as source buffer
-          const sourceBuffer = this.sourceBuffers[0][sourceBufferName];
-          const {bytes, type, usage, layout} = sourceBuffer;
-          const buffer = new Buffer(this.gl, {bytes, type, usage, layout});
-
-          this.feedbackBuffers[0][feedbackBufferName] = buffer;
-          this._buffersToDelete.push(this.feedbackBuffers[0][feedbackBufferName]);
+        if (this._buffersCreated[feedbackBufferName]) {
+          this._buffersCreated[feedbackBufferName].delete();
+          this._buffersCreated[feedbackBufferName] = buffer;
         }
-
-        this.sourceBuffers[1][sourceBufferName] = this.feedbackBuffers[0][feedbackBufferName];
-        this.feedbackBuffers[1][feedbackBufferName] = this.sourceBuffers[0][sourceBufferName];
-
-        // make sure the new destination buffer is a Buffer object
-        assert(this.feedbackBuffers[1][feedbackBufferName] instanceof Buffer);
+        this.feedbackBuffers[current][feedbackBufferName] = buffer;
       }
+    }
+  }
+
+  // setup buffers for swapping.
+  _setupSwapBuffers({feedbackBuffers}) {
+    if (!this.feedbackMap) {
+      // feedbackMap required set up swap buffers.
+      return;
+    }
+    const current = this.currentIndex;
+    const next = (current + 1) % 2;
+
+    for (const sourceBufferName in this.feedbackMap) {
+      const feedbackBufferName = this.feedbackMap[sourceBufferName];
+
+      this.sourceBuffers[next][sourceBufferName] =
+        this.feedbackBuffers[current][feedbackBufferName];
+      this.feedbackBuffers[next][feedbackBufferName] =
+        this.sourceBuffers[current][sourceBufferName];
+
+      // make sure the new destination buffer is a Buffer object
+      assert(this.feedbackBuffers[next][feedbackBufferName] instanceof Buffer);
+    }
+
+    // When triggered by `update()` TranformFeedback objects are already set up,
+    // if so update buffers
+    if (this.transformFeedbacks[next]) {
+      this.transformFeedbacks[next].setBuffers(this.feedbackBuffers[next]);
     }
   }
 
@@ -217,11 +232,11 @@ export default class Transform {
 
   // Returns true if buffers can be swappable, false otherwise.
   _canSwapBuffers({feedbackMap, sourceBuffers}) {
-    const buffers = Object.values(sourceBuffers);
-    if (buffers.some(buffer => !(buffer instanceof Buffer))) {
+    if (!feedbackMap) {
       return false;
     }
-    if (!feedbackMap) {
+    const sourceBufferNames = Object.keys(feedbackMap);
+    if (sourceBufferNames.some(name => !(sourceBuffers[name] instanceof Buffer))) {
       return false;
     }
     return true;

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -4,7 +4,7 @@ import Buffer from '../webgl/buffer';
 import TransformFeedback from '../webgl/transform-feedback';
 import {isWebGL2, assertWebGL2Context, getShaderVersion} from '../webgl-utils';
 import assert from '../utils/assert';
-import {log} from '../utils';
+import {log, isObjectEmpty} from '../utils';
 
 const FS100 = 'void main() {}';
 const FS300 = `#version 300 es\n${FS100}`;
@@ -62,7 +62,12 @@ export default class Transform {
   // Swap source and destination buffers.
   swapBuffers() {
     assert(this._swapBuffers);
-    this.currentIndex = (this.currentIndex + 1) % 2;
+    const nextIndex = (this.currentIndex + 1) % 2;
+    // Setup swapbuffers first time swapBuffers are called.
+    if (isObjectEmpty(this.sourceBuffers[nextIndex])) {
+      this._setupSwapBuffers();
+    }
+    this.currentIndex = nextIndex;
   }
 
   // Update some or all buffer bindings.
@@ -84,7 +89,7 @@ export default class Transform {
     this._createFeedbackBuffers({feedbackBuffers});
     this.transformFeedbacks[currentIndex].setBuffers(this.feedbackBuffers[currentIndex]);
 
-    this._setupSwapBuffers({feedbackBuffers});
+    // this._setupSwapBuffers();
     return this;
   }
 
@@ -148,7 +153,7 @@ export default class Transform {
     this.sourceBuffers[1] = {};
     this.feedbackBuffers[1] = {};
 
-    this._setupSwapBuffers({feedbackBuffers});
+    // this._setupSwapBuffers();
   }
 
   // auto create any feedback buffers
@@ -176,7 +181,7 @@ export default class Transform {
   }
 
   // setup buffers for swapping.
-  _setupSwapBuffers({feedbackBuffers}) {
+  _setupSwapBuffers() {
     if (!this.feedbackMap) {
       // feedbackMap required set up swap buffers.
       return;

--- a/test/src/core/transform.spec.js
+++ b/test/src/core/transform.spec.js
@@ -253,14 +253,7 @@ test('WebGL#Transform swapBuffers + update', t => {
   });
 
   transform.run();
-
   transform.swapBuffers();
-  transform.run();
-
-  let expectedData = sourceData.map(x => x * 4);
-  let outData = transform.getBuffer('outValue').getData();
-
-  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
 
   // Increase the buffer size
   sourceData = new Float32Array([1, 2, 3, 4, 5, 6, 7]);
@@ -275,7 +268,13 @@ test('WebGL#Transform swapBuffers + update', t => {
 
   transform.run();
 
-  expectedData = sourceData.map(x => x * 2);
+  let expectedData = sourceData.map(x => x * 2);
+  let outData = transform.getBuffer('outValue').getData();
+
+  transform.swapBuffers();
+  transform.run();
+
+  expectedData = sourceData.map(x => x * 4);
   outData = transform.getBuffer('outValue').getData();
 
   t.deepEqual(outData, expectedData, 'Transform.getData: is successful');

--- a/test/src/core/transform.spec.js
+++ b/test/src/core/transform.spec.js
@@ -228,6 +228,61 @@ test('WebGL#Transform swapBuffers', t => {
   t.end();
 });
 
+test('WebGL#Transform swapBuffers + update', t => {
+  const {gl2} = fixture;
+
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  let sourceData = new Float32Array([10, 20, 31, 0, -57]);
+  let sourceBuffer = new Buffer(gl2, {data: sourceData});
+
+  const transform = new Transform(gl2, {
+    sourceBuffers: {
+      inValue: sourceBuffer
+    },
+    vs: VS,
+    feedbackMap: {
+      inValue: 'outValue'
+    },
+    varyings: ['outValue'],
+    elementCount: 5
+  });
+
+  transform.run();
+
+  transform.swapBuffers();
+  transform.run();
+
+  let expectedData = sourceData.map(x => x * 4);
+  let outData = transform.getBuffer('outValue').getData();
+
+  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
+
+  // Increase the buffer size
+  sourceData = new Float32Array([1, 2, 3, 4, 5, 6, 7]);
+  sourceBuffer = new Buffer(gl2, {data: sourceData});
+
+  transform.update({
+    sourceBuffers: {
+      inValue: sourceBuffer
+    },
+    elementCount: 7
+  });
+
+  transform.run();
+
+  expectedData = sourceData.map(x => x * 2);
+  outData = transform.getBuffer('outValue').getData();
+
+  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
+
+  t.end();
+});
+
 test('WebGL#Transform swapBuffers without varyings', t => {
   const {gl2} = fixture;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #576 
<!-- For other PRs without open issue -->
#### Background
- Separate out auto feedback buffer creation.
- Seperate out swap buffers setup.
- Initiate swap buffers code on first usage.
- Disable swap buffers when any of the source buffers is not a `Buffer` type.
- Delete auto created buffer when new one is created, instead of accumulating.
- Add more tests cases to cover `Attribute` usage.
<!-- For all the PRs -->
#### Change List
- Cleanup swap buffers code, fix swapBuffers flag.
