### PR TITLE
Buffer: add getElementCount method.

### DIFF
--- a/docs/api-reference/webgl/buffer.md
+++ b/docs/api-reference/webgl/buffer.md
@@ -200,6 +200,10 @@ Reads data from buffer into an `ArrayBufferView` or `SharedArrayBuffer`.
 
 Returns a typed array containing the data from the buffer (if `dstData` was supplied it will be returned, otherwise this will be a freshly allocated array).
 
+### getElementCount() : Int
+
+Returns number of elements in the buffer. In a buffer created with Float32Array typed array, each float is an element and takes 4 bytes (or 32 bits).
+
 
 ## Types
 

--- a/src/core/transform.js
+++ b/src/core/transform.js
@@ -161,8 +161,8 @@ export default class Transform {
       if (!feedbackBuffers || !feedbackBuffers[feedbackBufferName]) {
         // Create new buffer with same layout and settings as source buffer
         const sourceBuffer = this.sourceBuffers[current][sourceBufferName];
-        const {bytes, type, usage, layout} = sourceBuffer;
-        const buffer = new Buffer(this.gl, {bytes, type, usage, layout});
+        const {bytes, type, usage, accessor} = sourceBuffer;
+        const buffer = new Buffer(this.gl, {bytes, type, usage, accessor});
 
         if (this._buffersCreated[feedbackBufferName]) {
           this._buffersCreated[feedbackBufferName].delete();

--- a/src/webgl/buffer.js
+++ b/src/webgl/buffer.js
@@ -77,7 +77,7 @@ export default class Buffer extends Resource {
     this.debugData = data ? data.slice(0, DEBUG_DATA_LENGTH) : null;
 
     // Call after type is determined
-    this.setAccessor(new Accessor(type ? {type} : {}, props));
+    this.setAccessor(new Accessor(type ? {type} : {}, props, props.accessor));
 
     // Create the buffer - binding it here for the first time locks the type
     // In WebGL2, use GL.COPY_WRITE_BUFFER to avoid locking the type
@@ -222,6 +222,12 @@ export default class Buffer extends Resource {
     return this;
   }
 
+  // returns number of elements in the buffer
+  getElementCount() {
+    const ArrayType = getTypedArrayFromGLType(this.accessor.type || GL.FLOAT, {clamped: false});
+    return this.bytes / ArrayType.BYTES_PER_ELEMENT;
+  }
+
   unbind({target = this.target, index = this.accessor && this.accessor.index} = {}) {
     const isIndexedBuffer = target === GL.UNIFORM_BUFFER || target === GL.TRANSFORM_FEEDBACK_BUFFER;
     if (isIndexedBuffer) {
@@ -249,9 +255,8 @@ export default class Buffer extends Resource {
 
   _getAvailableElementCount(srcByteOffset) {
     const ArrayType = getTypedArrayFromGLType(this.accessor.type || GL.FLOAT, {clamped: false});
-    const sourceElementCount = this.bytes / ArrayType.BYTES_PER_ELEMENT;
     const sourceElementOffset = srcByteOffset / ArrayType.BYTES_PER_ELEMENT;
-    return sourceElementCount - sourceElementOffset;
+    return this.getElementCount() - sourceElementOffset;
   }
 
   // RESOURCE METHODS

--- a/test/src/webgl/buffer.spec.js
+++ b/test/src/webgl/buffer.spec.js
@@ -195,3 +195,24 @@ test('WebGL#Buffer getData', t => {
 
   t.end();
 });
+
+test('WebGL#Buffer getElementCount', t => {
+  const {gl} = fixture;
+
+  let vertexCount;
+
+  const buffer1 = new Buffer(gl, {data: new Float32Array([1, 2, 3])});
+  vertexCount = buffer1.getElementCount();
+  t.equal(vertexCount, 3, 'Vertex count should match');
+
+  let buffer2 = new Buffer(gl, {data: new Int32Array([1, 2, 3, 4]), instanced: true});
+  vertexCount = buffer2.getElementCount();
+  t.equal(vertexCount, 4, 'Vertex count should match');
+
+  const {bytes, usage, type, accessor} = buffer1;
+  buffer2 = new Buffer(gl, {bytes, usage, type, accessor});
+  vertexCount = buffer2.getElementCount();
+  t.equal(vertexCount, 3, 'Vertex count should match');
+
+  t.end();
+});


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #591 
<!-- For other PRs without open issue -->
#### Background
- Add `getElementCount` method to Buffer class. Element count is determined by `bytes` and `type`.
- Fix an issue where `type` needs to be deduced from `accessor`.
- Update `Transform` to use `accessor` instead of  removed `layout` object.
<!-- For all the PRs -->
#### Change List
- Buffer: add getElementCount method.
