### PR TITLE
Fix multi-model render bug

### DIFF
--- a/src/core/model.js
+++ b/src/core/model.js
@@ -322,7 +322,7 @@ export default class Model extends Object3D {
     this.onBeforeRender();
     this._timerQueryStart();
 
-    this.program.draw(Object.assign(opts, {
+    this.program.draw(Object.assign({}, opts, {
       logPriority,
       framebuffer,
       parameters,


### PR DESCRIPTION
#### Background
Breaks deck.gl's `layer.draw` when multiple models share the same draw options.

#### Change List
- Avoid mutating draw options with model specific data
