### PR TITLE
Shader Module fp64: add const uniforms used in shader WAs

### DIFF
--- a/src/shadertools/src/modules/fp64/fp64.js
+++ b/src/shadertools/src/modules/fp64/fp64.js
@@ -24,8 +24,15 @@ import fp64arithmeticShader from './fp64-arithmetic.glsl';
 import fp64functionShader from './fp64-functions.glsl';
 
 const fp64shader = `${fp64arithmeticShader}\n${fp64functionShader}`;
-
+const CONST_UNIFORMS = {
+  // Used in LUMA_FP64_CODE_ELIMINATION_WORKAROUND
+  ONE: 1.0
+};
 export {fp64ify, fp64LowPart, fp64ifyMatrix4};
+
+function getUniforms() {
+  return Object.assign({}, CONST_UNIFORMS);
+}
 
 export default {
   name: 'fp64',
@@ -33,7 +40,8 @@ export default {
   fs: null,
   fp64ify,
   fp64LowPart,
-  fp64ifyMatrix4
+  fp64ifyMatrix4,
+  getUniforms
 };
 
 // Arithmetic only


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #621 
<!-- For other PRs without open issue -->
#### Background
`fp64` shader module uses `ONE` uniform for implementing `LUMA_FP64_CODE_ELIMINATION_WORKAROUND` that is applied to specific Intel and Nvidia GPUs. Move the uniform generation code to module, so users (layers/demos) using this module doesn't have to set it explicitly.
<!-- For all the PRs -->
#### Change List
- Shader Module fp64: add const uniforms used in shader WAs
