### PR TITLE
v6.0 Mark gl import as "server only" using package.json "browser" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "headless.js",
     "webgl1.js"
   ],
+  "browser": {
+    "gl": false,
+    "gl/wrap": false
+  },
   "scripts": {
     "start": "echo 'Please see luma.gl website for how to run examples' && open http://uber.github.io/luma.gl/#/documentation/getting-started/examples",
     "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5/packages dist/esm/packages dist/es6/packages",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "math.gl": "^2.0.0",
-    "probe.gl": "^1.0.0",
+    "probe.gl": "^1.0.4",
     "seer": "^0.2.4",
     "webgl-debug": "^2.0.0"
   },

--- a/src/webgl-context/create-headless-context.js
+++ b/src/webgl-context/create-headless-context.js
@@ -1,7 +1,4 @@
-/* eslint-disable quotes, no-console */
-import isBrowser from '../utils/is-browser';
-
-import {ERR_HEADLESSGL_LOAD} from '../webgl-utils/webgl-types';
+import {headlessGL} from '../webgl-utils/webgl-types';
 
 const ERR_HEADLESSGL_NOT_AVAILABLE =
 'Failed to create WebGL context in Node.js, headless gl not available';
@@ -11,15 +8,6 @@ const ERR_HEADLESSGL_FAILED =
 
 // Create headless gl context (for running under Node.js)
 export function createHeadlessContext({width, height, opts, onError}) {
-  let headlessGL;
-  if (!isBrowser) {
-    try {
-      headlessGL = module.require('gl');
-    } catch (error) {
-      return onError(`${ERR_HEADLESSGL_LOAD}\n${error}`);
-    }
-  }
-
   const {webgl1, webgl2} = opts;
   if (webgl2 && !webgl1) {
     return onError('headless-gl does not support WebGL2');

--- a/src/webgl-utils/webgl-types.js
+++ b/src/webgl-utils/webgl-types.js
@@ -17,9 +17,13 @@ If this is desired, install headless gl using "npm install gl --save-dev" or "ya
 
 // Load headless gl dynamically, if available
 export let headlessTypes = null;
+export let headlessGL = () => {
+  throw new Error(ERR_HEADLESSGL_LOAD);
+};
 
-if (!isBrowser) {
+if (!isBrowser && module.require) {
   try {
+    headlessGL = module.require('gl');
     headlessTypes = module.require('gl/wrap');
   } catch (error) {
     console.info(ERR_HEADLESSGL_LOAD);


### PR DESCRIPTION
Fixes #620 

#### Change List
- List "gl" as `"browser": false` in `package.json` to prevent it being bundled by latest webpack version that implements `module.require`.
- Consolidate "gl" loading into a single file.
