### PR TITLE
v6.0: More comprehensive metrics collection

### DIFF
--- a/scripts/collect-metrics.sh
+++ b/scripts/collect-metrics.sh
@@ -11,28 +11,35 @@ version=$(jq '.version' ./package.json | awk '{ gsub(/"/,"",$1); printf "%-14s",
 # Helper functions
 
 print_size_header() {
-  echo "| Version        | Dist | Bundle Size        | Compressed     |"
-  echo "| ---            | ---  | ---                | ---            |"
+  echo "| Version        | Dist           | Bundle (Compr) | Bytes (Compressed)   |"
+  echo "| ---            | ---            | ---            | ---                  |"
 }
 
 print_size() {
   DIST=$1
+  BUILD=$2
+
   # Size it
-  size=$(wc -c /tmp/bundle.js | awk '{ print int($1 / 1024) "KB (" $1 ")" }')
-  # Zip it
+  BYTES_UNCOMPRESSED=$(wc -c /tmp/bundle.js)
+
+  # Zip and size it
   gzip -9f /tmp/bundle.js
-  # Size it again
-  zipsize=$(wc -c /tmp/bundle.js.gz | awk '{ print int($1 / 1024) "KB (" $1 ")" }')  # Size it
-  # Remove our copy
+  BYTES_COMPRESSED=$(wc -c /tmp/bundle.js.gz)
   rm /tmp/bundle.js.gz
+
+  size=$(echo $BYTES_UNCOMPRESSED $BYTES_COMPRESSED | awk '{ print int($1 / 1024) "KB / " int($3/ 1024K) "KB" }')
+  zipsize=$(echo $BYTES_UNCOMPRESSED $BYTES_COMPRESSED | awk '{ print $1 " / " $3 " bytes" }')  # Size it
   # Print version, size, compressed size with markdown
 
-  echo "| $version | $DIST  | $size KB  | $zipsize KB     |"
+  echo "| $version | $DIST-$BUILD | $size   | $zipsize |"
 }
 
 build_bundle() {
   ENV=$1
-  NODE_ENV=production webpack --config test/webpack.config.js --hide-modules --env.import-nothing --env.bundle --env.$ENV > /dev/null
+  DEVELOPMENT=$2
+  NODE_ENV=production webpack --config test/webpack.config.js --hide-modules --env.import-nothing --env.bundle --env.$ENV --env.$DEVELOPMENT> /dev/null
+
+  print_size $ENV $DEVELOPMENT
 }
 
 # Main Script
@@ -43,14 +50,13 @@ echo
 
 print_size_header
 
-build_bundle es6
-print_size ES6
+build_bundle es6 production
+build_bundle esm production
+build_bundle es5 production
 
-build_bundle esm
-print_size ESM
-
-build_bundle es5
-print_size ES5
+build_bundle es6 development
+build_bundle esm development
+build_bundle es5 development
 
 # Disable bold terminal font
 echo "\033[0m"

--- a/test/size/import-nothing.js
+++ b/test/size/import-nothing.js
@@ -1,3 +1,3 @@
-import {Program} from 'luma.gl';
+import {Model, AnimationLoop} from 'luma.gl';
 
-console.log(Program); // eslint-disable-line
+console.log(Model, AnimationLoop); // eslint-disable-line

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -152,7 +152,7 @@ const CONFIGS = {
     const config = CONFIGS.size(env);
 
     Object.assign(config, {
-      mode: 'production',
+      mode: env.development ? 'development' : 'production',
 
       // Replace the entry point for webpack-dev-server
       entry: {


### PR DESCRIPTION
#### Background
- Backport of #627 to 6.0-release so that we can make apples-to-apples comparisons.
#### Change List
- collect-metrics script.
- increase the amount of code bundled by size test app by importing `Model` and `AnimationLoop`, to give more representative bundle sizes.
