### PR TITLE
Bump math.gl to 2.1.0-alpha

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -75,7 +75,7 @@
     "collect-metrics": "./scripts/collect-metrics.sh"
   },
   "dependencies": {
-    "math.gl": "^2.0.0",
+    "math.gl": "^2.1.0-alpha",
     "probe.gl": "^1.0.0",
     "seer": "^0.2.4",
     "webgl-debug": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,9 +5299,9 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
 
-math.gl@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-2.0.0.tgz#c41cf8f5cfce820161511c435d3f706eebd7deb0"
+math.gl@^2.1.0-alpha:
+  version "2.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-2.1.0-alpha.1.tgz#80866ac74ae3ffadca23a47aec926c9336d4dace"
   dependencies:
     gl-mat3 "^1.0.0"
     gl-mat4 "^1.1.4"


### PR DESCRIPTION
#### Background
- Take advantage of new math.gl library that has been tuned for tree-shaking and size reductions.

#### Change List
- Bump version

Before
<img width="586" alt="screen shot 2018-07-29 at 7 00 40 pm" src="https://user-images.githubusercontent.com/7025232/43373941-d59225f2-9361-11e8-8a2e-b88542917cb8.png">

After
<img width="575" alt="screen shot 2018-07-29 at 7 00 47 pm" src="https://user-images.githubusercontent.com/7025232/43373946-da71a55c-9361-11e8-82e1-e3686b256197.png">

