### PR TITLE
FP64: Unit tests using `Transform`

### DIFF
--- a/docs/api-reference/core/transform.md
+++ b/docs/api-reference/core/transform.md
@@ -118,6 +118,7 @@ Constructs a `Transform` object. It then creates destination buffers if needed a
   * `sourceBuffers` (`Object`) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Attribute`, `Buffer` or attribute descriptor object.
   * `feedbackBuffers` (`Object`, Optional) - key and value pairs, where key is the name of vertex shader attribute and value is the corresponding `Buffer` object.
   * `vs` (`String`) - vertex shader string.
+  * `modules` - shader modules to be applied.
   * `varyings` (`Array`) - Array of vertex shader varyings names. When not provided this can be deduced from `feedbackMap`. Either `varyings` or `feedbackMap` must be provided.
   * `feedbackMap` (`Object`, Optional) - key and value pairs, where key is a vertex shader attribute name and value is a vertex shader varying name.
   * `drawMode` (`GLEnum` = gl.POINTS, Optional) - Draw mode to be set on `Model` and `TransformFeedback` objects during draw/render time.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -15,6 +15,9 @@ luma.gl now provides a multipass rendering framework, based on a `MultiPassRende
 
 A number of classic WebGL/OpenGL post processing effects have been ported to luma.gl and packaged as composable render passes. In many cases, the underlying shaders have also been exposed as shader modules, providing additional composability options for advanced apps.
 
+### Transform class supports shader module assembly
+
+`Transform` constructor can now accept `modules` parameter, when used corresponding shader modules will be applied on vertex and fragment shaders.
 
 
 ## Version 6.0

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -17,7 +17,7 @@ A number of classic WebGL/OpenGL post processing effects have been ported to lum
 
 ### Transform class supports shader module assembly
 
-`Transform` constructor can now accept `modules` parameter, when used corresponding shader modules will be applied on vertex and fragment shaders.
+`Transform` constructor now accepts all shader module parameters such as `modules`, `dependencies` and `inject` (see [assembleShaders](/docs/api-reference/shadertools/assemble-shaders.md)).
 
 
 ## Version 6.0

--- a/modules/core/src/core/transform.js
+++ b/modules/core/src/core/transform.js
@@ -93,9 +93,10 @@ export default class Transform {
   // Private
 
   _initialize({
-    // Program parameters
+    // Model parameters
     id = 'transform',
     vs,
+    modules = null,
     varyings,
     drawMode = GL.POINTS,
     elementCount,
@@ -137,7 +138,7 @@ export default class Transform {
 
     this._setupBuffers({sourceBuffers, feedbackBuffers});
     this._setupSwapBuffers();
-    this._buildModel({id, vs, varyings: varyingsArray, drawMode, elementCount});
+    this._buildModel({id, vs, modules, varyings: varyingsArray, drawMode, elementCount});
   }
 
   // setup source and destination buffers
@@ -204,7 +205,7 @@ export default class Transform {
   }
 
   // build Model and TransformFeedback objects
-  _buildModel({id, vs, varyings, drawMode, elementCount}) {
+  _buildModel({id, vs, modules, varyings, drawMode, elementCount}) {
     // use a minimal fragment shader with matching version of vertex shader.
     const fs = getShaderVersion(vs) === 300 ? FS300 : FS100;
 
@@ -212,6 +213,7 @@ export default class Transform {
       id,
       vs,
       fs,
+      modules,
       varyings,
       drawMode,
       vertexCount: elementCount

--- a/modules/core/src/shadertools/src/modules/fp64/fp64-test-utils.js
+++ b/modules/core/src/shadertools/src/modules/fp64/fp64-test-utils.js
@@ -41,6 +41,10 @@ function getFloat64(upper = 256) {
 export function getRelativeError64(result, reference) {
   const reference64 = reference[0] + reference[1];
   const result64 = result[0] + result[1];
+  // When refrence valu is < 1, dividing with it increases total value of difference.
+  if (reference64 < 1) {
+    return Math.abs(reference64 - result64);
+  }
   return Math.abs((reference64 - result64) / reference64);
 }
 

--- a/modules/core/src/shadertools/test/index.js
+++ b/modules/core/src/shadertools/test/index.js
@@ -7,5 +7,6 @@ import './lib/resolve-modules.spec';
 
 import './modules';
 
-// TODO - The fp64 shader tests are still too flaky
+// TODO - Remove once WebGL1 support added to Transfrom
+// so `fp64-arithmetic-transform.spec` can test under WebGL1 and WebGL2
 // import '../src/modules/fp64/fp64-arithmetic.spec';

--- a/test/index-webgl-dependent-tests.js
+++ b/test/index-webgl-dependent-tests.js
@@ -1,9 +1,10 @@
 // Imports tests for all modules that depend on webgl
 
 import 'luma.gl/debug';
-import '../modules/core/src/shadertools/test';
+import '../modules/core/src/shadertools/test'; // TODO: move these tests into modules/core/shadertools
 import './modules/core/webgl1';
 import './modules/core/webgl-utils';
 import './modules/core/webgl-context';
 import './modules/core/webgl';
 import './modules/core/core';
+import './modules/core/shadertools';

--- a/test/modules/core/shadertools/fp64/fp64-arithmetic-transform.spec.js
+++ b/test/modules/core/shadertools/fp64/fp64-arithmetic-transform.spec.js
@@ -1,0 +1,122 @@
+// Copyright (c) 2015 - 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import test from 'tape-catch';
+import {runTests} from './fp64-test-utils-transform';
+import {glGetDebugInfo} from 'luma.gl';
+import {fixture} from 'luma.gl/test/setup';
+const gl = fixture.gl2;
+
+ // Failing tests cases are ignred based ib cyrrebt gpu and glslFunc, using ignoreFor field
+ // ignoreFor: [{gpu: ['glslFun']}] => ignores glslFun when running `gpu`
+const commonTestCases = [
+  {a: 3.0e-19, b: 3.3e+13},
+  {a: 9.9e-40, b: 1.7e+3},
+  {a: 1.5e-36, b: 1.7e-16},
+  {a: 9.4e-26, b: 51},
+  {a: 6.7e-20, b: 0.93},
+
+  // mul_fp64: Large numbers once multipled, can't be represented by 32 bit precision and Math.fround() returns NAN
+  // sqrt_fp64: Fail on INTEL with margin 3.906051071870294e-12
+  {a: 2.4e+3, b: 5.9e+31, ignoreFor: {all: ['mul_fp64'], Intel: ['sqrt_fp64']}},
+
+   // div_fp64 fail on INTEL with margin 1.7318642528355118e-12
+   // sqrt_fp64 fails on INTEL with margin 1.5518878351528786e-12
+  {a: 1.4e+9, b: 6.3e+5, ignoreFor: {Intel: ['div_fp64', 'sqrt_fp64']}},
+
+  // div fails on INTEL with margin 1.7886288892678105e-14
+  // sqrt fails on INTEL with margin 2.5362810256331708e-12
+  {a: 3.0e+9, b: 4.3e-23, ignoreFor: {Intel: ['div_fp64', 'sqrt_fp64']}},
+
+  // div fail on INTEL with margin 1.137354350370519e-12
+  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {Intel: ['div_fp64']}},
+
+  // div_fp64 fails on INTEL with margin 2.7291999999999997e-12
+  // sqrt_fp64 fails on INTEL with margin 3.501857471494295e-12
+  {a: 0.3, b: 3.2e-16, ignoreFor: {Intel: ['div_fp64', 'sqrt_fp64']}},
+
+  // mul_fp64 : fails since result can't be represented by 32 bit floats
+  // div_fp64 : fails on INTEL with margin 1.9999999999999994e-15
+  // sqrt_fp64 : fails on INTEL with margin 1.832115697751484e-12
+  {a: 4.1e+30, b: 8.2e+15, ignoreFor: {all: ['mul_fp64'], Intel: ['div_fp64', 'sqrt_fp64']}},
+
+  // Fails on INTEL, margin 3.752606081210107e-12
+  {a: 6.2e+3, b: 6.3e+10, ignoreFor: {Intel: ['sqrt_fp64']}},
+  // Fails on INTEL, margin 3.872578286363912e-13
+  {a: 2.5e+2, b: 5.1e-21, ignoreFor: {Intel: ['sqrt_fp64']}},
+  // Fails on INTEL, margin 1.5332142001740705e-12
+  {a: 96, b: 1.7e+4, ignoreFor: {Intel: ['sqrt_fp64']}},
+  // // Fail on INTEL, margin 1.593162047558726e-12
+  {a: 0.27, b: 2.3e+16, ignoreFor: {Intel: ['sqrt_fp64']}},
+  // // Fails on INTEL, margin 1.014956357028767e-12
+  {a: 18, b: 9.1e-9, ignoreFor: {Intel: ['sqrt_fp64']}}
+];
+
+// Filter all tests cases based on current gpu and glsFunc
+function getTestCasesFor(glslFunc) {
+  // Under node gl2 is not available
+  if (!gl) {
+    return [];
+  }
+  const debugInfo = glGetDebugInfo(gl);
+  const testCases = commonTestCases.filter(testCase => {
+    if (testCase.ignoreFor) {
+      for (const gpu in testCase.ignoreFor) {
+        if (
+            (gpu === 'all' || debugInfo.vendor.indexOf(gpu) >= 0) &&
+            testCase.ignoreFor[gpu].includes(glslFunc)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  });
+  return testCases;
+}
+
+test('fp64#sum_fp64', t => {
+  const glslFunc = 'sum_fp64';
+  const testCases = getTestCasesFor(glslFunc);
+  runTests(gl, {glslFunc, binary: true, op: (a, b) => a + b, testCases, t});
+});
+
+test('fp64#sub_fp64', t => {
+  const glslFunc = 'sub_fp64';
+  const testCases = getTestCasesFor(glslFunc);
+  runTests(gl, {glslFunc, binary: true, op: (a, b) => a - b, testCases, t});
+});
+
+test('fp64#mul_fp64', t => {
+  const glslFunc = 'mul_fp64';
+  const testCases = getTestCasesFor(glslFunc);
+  runTests(gl, {glslFunc, binary: true, op: (a, b) => a * b, limit: 128, testCases, t});
+});
+
+test('fp64#div_fp64', t => {
+  const glslFunc = 'div_fp64';
+  const testCases = getTestCasesFor(glslFunc);
+  runTests(gl, {glslFunc, binary: true, op: (a, b) => a / b, limit: 128, testCases, t});
+});
+
+test('fp64#sqrt_fp64', t => {
+  const glslFunc = 'sqrt_fp64';
+  const testCases = getTestCasesFor(glslFunc);
+  runTests(gl, {glslFunc, op: (a) => Math.sqrt(a), limit: 128, testCases, t});
+});

--- a/test/modules/core/shadertools/fp64/fp64-arithmetic-transform.spec.js
+++ b/test/modules/core/shadertools/fp64/fp64-arithmetic-transform.spec.js
@@ -24,8 +24,8 @@ import {glGetDebugInfo} from 'luma.gl';
 import {fixture} from 'luma.gl/test/setup';
 const gl = fixture.gl2;
 
- // Failing tests cases are ignred based ib cyrrebt gpu and glslFunc, using ignoreFor field
- // ignoreFor: [{gpu: ['glslFun']}] => ignores glslFun when running `gpu`
+ // Failing test cases are ignored based on gpu and glslFunc, using ignoreFor field
+ // ignoreFor: [{gpu: ['glslFunc-1', 'glslFunc-2']}] => ignores for `'glslFunc-1' and 'glslFunc-2` when running on `gpu`
 const commonTestCases = [
   {a: 3.0e-19, b: 3.3e+13},
   {a: 9.9e-40, b: 1.7e+3},
@@ -35,38 +35,38 @@ const commonTestCases = [
 
   // mul_fp64: Large numbers once multipled, can't be represented by 32 bit precision and Math.fround() returns NAN
   // sqrt_fp64: Fail on INTEL with margin 3.906051071870294e-12
-  {a: 2.4e+3, b: 5.9e+31, ignoreFor: {all: ['mul_fp64'], Intel: ['sqrt_fp64']}},
+  {a: 2.4e+3, b: 5.9e+31, ignoreFor: {all: ['mul_fp64'], intel: ['sqrt_fp64']}},
 
-   // div_fp64 fail on INTEL with margin 1.7318642528355118e-12
+   // div_fp64 fails on INTEL with margin 1.7318642528355118e-12
    // sqrt_fp64 fails on INTEL with margin 1.5518878351528786e-12
-  {a: 1.4e+9, b: 6.3e+5, ignoreFor: {Intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 1.4e+9, b: 6.3e+5, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
 
   // div fails on INTEL with margin 1.7886288892678105e-14
   // sqrt fails on INTEL with margin 2.5362810256331708e-12
-  {a: 3.0e+9, b: 4.3e-23, ignoreFor: {Intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 3.0e+9, b: 4.3e-23, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
 
   // div fail on INTEL with margin 1.137354350370519e-12
-  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {Intel: ['div_fp64']}},
+  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {intel: ['div_fp64']}},
 
   // div_fp64 fails on INTEL with margin 2.7291999999999997e-12
   // sqrt_fp64 fails on INTEL with margin 3.501857471494295e-12
-  {a: 0.3, b: 3.2e-16, ignoreFor: {Intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 0.3, b: 3.2e-16, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
 
   // mul_fp64 : fails since result can't be represented by 32 bit floats
   // div_fp64 : fails on INTEL with margin 1.9999999999999994e-15
   // sqrt_fp64 : fails on INTEL with margin 1.832115697751484e-12
-  {a: 4.1e+30, b: 8.2e+15, ignoreFor: {all: ['mul_fp64'], Intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 4.1e+30, b: 8.2e+15, ignoreFor: {all: ['mul_fp64'], intel: ['div_fp64', 'sqrt_fp64']}},
 
   // Fails on INTEL, margin 3.752606081210107e-12
-  {a: 6.2e+3, b: 6.3e+10, ignoreFor: {Intel: ['sqrt_fp64']}},
+  {a: 6.2e+3, b: 6.3e+10, ignoreFor: {intel: ['sqrt_fp64']}},
   // Fails on INTEL, margin 3.872578286363912e-13
-  {a: 2.5e+2, b: 5.1e-21, ignoreFor: {Intel: ['sqrt_fp64']}},
+  {a: 2.5e+2, b: 5.1e-21, ignoreFor: {intel: ['sqrt_fp64']}},
   // Fails on INTEL, margin 1.5332142001740705e-12
-  {a: 96, b: 1.7e+4, ignoreFor: {Intel: ['sqrt_fp64']}},
+  {a: 96, b: 1.7e+4, ignoreFor: {intel: ['sqrt_fp64']}},
   // // Fail on INTEL, margin 1.593162047558726e-12
-  {a: 0.27, b: 2.3e+16, ignoreFor: {Intel: ['sqrt_fp64']}},
-  // // Fails on INTEL, margin 1.014956357028767e-12
-  {a: 18, b: 9.1e-9, ignoreFor: {Intel: ['sqrt_fp64']}}
+  {a: 0.27, b: 2.3e+16, ignoreFor: {intel: ['sqrt_fp64']}},
+  // Fails on INTEL, margin 1.014956357028767e-12
+  {a: 18, b: 9.1e-9, ignoreFor: {intel: ['sqrt_fp64']}}
 ];
 
 // Filter all tests cases based on current gpu and glsFunc
@@ -80,7 +80,7 @@ function getTestCasesFor(glslFunc) {
     if (testCase.ignoreFor) {
       for (const gpu in testCase.ignoreFor) {
         if (
-            (gpu === 'all' || debugInfo.vendor.indexOf(gpu) >= 0) &&
+            (gpu === 'all' || debugInfo.vendor.toLowerCase().indexOf(gpu) >= 0) &&
             testCase.ignoreFor[gpu].includes(glslFunc)) {
           return false;
         }

--- a/test/modules/core/shadertools/fp64/fp64-test-utils-transform.js
+++ b/test/modules/core/shadertools/fp64/fp64-test-utils-transform.js
@@ -35,10 +35,6 @@ export function getRelativeError64(result, reference, index) {
   return Math.abs((reference64 - result64) / reference64);
 }
 
-export function getRelativeError(result, reference) {
-  return Math.abs((reference - result) / reference);
-}
-
 function getBinaryShader(operation) {
   const shader = `\
 attribute vec2 a;

--- a/test/modules/core/shadertools/fp64/fp64-test-utils-transform.js
+++ b/test/modules/core/shadertools/fp64/fp64-test-utils-transform.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+// Copyright (c) 2015 - 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the 'Software'), to deal

--- a/test/modules/core/shadertools/fp64/fp64-test-utils-transform.js
+++ b/test/modules/core/shadertools/fp64/fp64-test-utils-transform.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Special utility functions for df64 tests
+
+/* eslint-disable camelcase, prefer-template, max-len */
+
+import {Buffer, _Transform as Transform, fp64} from 'luma.gl';
+const {fp64ify} = fp64;
+
+export function getRelativeError64(result, reference, index) {
+  const reference64 = reference[index] + reference[index + 1];
+  const result64 = result[index] + result[index + 1];
+  // When refrence valu is < 1, dividing with it increases total value of difference.
+  if (reference64 < 1) {
+    return Math.abs(reference64 - result64);
+  }
+  return Math.abs((reference64 - result64) / reference64);
+}
+
+export function getRelativeError(result, reference) {
+  return Math.abs((reference - result) / reference);
+}
+
+function getBinaryShader(operation) {
+  const shader = `\
+attribute vec2 a;
+attribute vec2 b;
+varying vec2 result;
+void main(void) {
+  result = ${operation}(a, b);
+}
+`;
+  return shader;
+}
+
+function getUnaryShader(operation) {
+  return `\
+attribute vec2 a;
+attribute vec2 b;
+varying vec2 result;
+void main(void) {
+  result = ${operation}(a);
+}
+`;
+}
+
+const EPSILON = 1e-14;
+
+function setupFloatData({limit, op, testCases}) {
+  const count = testCases.length;
+  const a_fp64 = new Float32Array(count * 2);
+  const b_fp64 = new Float32Array(count * 2);
+  const expected_fp64 = new Float32Array(count * 2);
+  const a = new Array(count);
+  const b = new Array(count);
+  const expected = new Array(count);
+  for (let idx = 0; idx < count; idx++) {
+    const index = idx * 2;
+    a[idx] = testCases[idx].a;
+    b[idx] = testCases[idx].b;
+    expected[idx] = op(a[idx], b[idx]);
+
+    fp64ify(a[idx], a_fp64, index);
+    fp64ify(b[idx], b_fp64, index);
+    fp64ify(expected[idx], expected_fp64, index);
+  }
+  return {a, b, expected, a_fp64, b_fp64, expected_fp64};
+}
+
+function setupFloatTest(gl, {glslFunc, binary = false, limit = 256, op, testCases}) {
+  const {a, b, expected, a_fp64, b_fp64, expected_fp64} = setupFloatData({limit, op, testCases});
+  const vs = binary ? getBinaryShader(glslFunc) : getUnaryShader(glslFunc);
+  const transform = new Transform(gl, {
+    sourceBuffers: {
+      a: new Buffer(gl, {data: a_fp64}),
+      b: new Buffer(gl, {data: b_fp64})
+    },
+    vs,
+    modules: [fp64],
+    feedbackMap: {
+      a: 'result'
+    },
+    varyings: ['result'],
+    elementCount: testCases.length
+  });
+  return {a, b, expected, a_fp64, b_fp64, expected_fp64, transform};
+}
+
+export function runTests(gl, {glslFunc, binary, op, limit = 256, testCases, t}) {
+  if (!Transform.isSupported(gl)) {
+    t.comment('Transform not supported, skipping tests');
+    t.end();
+    return;
+  }
+
+  const {a, b, a_fp64, b_fp64, expected_fp64, transform} = setupFloatTest(gl, {
+    glslFunc, binary, op, limit, testCases
+  });
+  transform.run({uniforms: {ONE: 1}});
+  const gpu_result = transform.getBuffer('result').getData();
+  for (let idx = 0; idx < testCases.length; idx++) {
+    const relativeError = getRelativeError64(gpu_result, expected_fp64, 2 * idx);
+    const args = binary ? `(${a[idx].toPrecision(2)}, ${b[idx].toPrecision(2)})` : `(${a[idx].toPrecision(2)})`;
+    const message = `${glslFunc}${args}: error=${relativeError}, within ${EPSILON}`;
+    t.ok(relativeError < EPSILON, message);
+    if (relativeError >= EPSILON) {
+      t.comment(` (tested ${a_fp64.toString()}, ${b_fp64.toString()})`);
+    }
+  }
+  t.end();
+}

--- a/test/modules/core/shadertools/index.js
+++ b/test/modules/core/shadertools/index.js
@@ -1,0 +1,1 @@
+import './fp64/fp64-arithmetic-transform.spec';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #630 
<!-- For other PRs without open issue -->
#### Background
- Add support for `modules` for `Transform` class.
- Port old FP64 tests using new `Transform` class.
- Fix error checking when reference value is < 1, do not take relative error as division by a value less than 1 is increasing the error value. In those cases just use the difference between actual and reference value. This was the reason most tests are failing in old script.
- Instead of testing random floats, collect most possible cases and build test cases.
- Add ability to disable tests per glslFunc and per GPU as there are several failures on `Intel` gpu.
- Document error margin for each failing test so these can be debugged later.
<!-- For all the PRs -->
#### Change List
- Transform: add modules parameter
- FP64: Add Transform based unit testing