### PR TITLE
Fix and enable picking and pack unit tests

### DIFF
--- a/modules/core/src/webgl/accessor.js
+++ b/modules/core/src/webgl/accessor.js
@@ -16,14 +16,13 @@ const DEFAULT_ACCESSOR_VALUES = {
 export default class Accessor {
 
   static getBytesPerElement(accessor) {
-    assert(accessor.type);
-    const ArrayType = getTypedArrayFromGLType(accessor.type);
+    const ArrayType = getTypedArrayFromGLType(accessor.type || GL.FLOAT);
     return ArrayType.BYTES_PER_ELEMENT;
   }
 
   static getBytesPerVertex(accessor) {
-    assert(accessor.type && accessor.size);
-    const ArrayType = getTypedArrayFromGLType(accessor.type);
+    assert(accessor.size);
+    const ArrayType = getTypedArrayFromGLType(accessor.type || GL.FLOAT);
     return ArrayType.BYTES_PER_ELEMENT * accessor.size;
   }
 

--- a/test/modules/core/shadertools/index.js
+++ b/test/modules/core/shadertools/index.js
@@ -1,3 +1,3 @@
 import './fp64/fp64-arithmetic-transform.spec';
-// import './picking.spec';
-// import './pack.spec';
+import './picking.spec';
+import './pack.spec';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #654 
Restore old behavior (prior to #618) of using `FLOAT` when type is not defined for a `Buffer` object.
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Fix and enable picking and pack unit tests
