### PR TITLE
Transform: Add support for Texture as source.

### DIFF
--- a/modules/core/src/core/transform-shader-utils.js
+++ b/modules/core/src/core/transform-shader-utils.js
@@ -1,0 +1,87 @@
+import assert from 'assert';
+
+const REGEX_START_OF_MAIN = /main\s*\([^\)]*\)\s*\{\n?/; // Beginning of main
+
+// scan and update vertex shader for texture atrributes.
+// All attribute definitions , that have corresponding texture in `textureMap`
+// will be removed and a sample instruction is added to main body.
+// Also for each such attribute two uniforms are returend, one for Sampler and one for Size.
+export function updateTextureAttributes(vs, textureMap) {
+  const texAttributeNames = Object.keys(textureMap);
+  const uniforms = {};
+  // if (!this.hasSourceTextures) {
+  //   return {vs, uniforms};
+  // }
+  let updatedVs = vs;
+  let mainInstructions = null;
+  if (texAttributeNames.length > 0) {
+    const vsLines = updatedVs.split('\n');
+    const updateVsLines = vsLines.slice();
+    const sampleInstructions = [];
+    vsLines.forEach((line, index, lines) => {
+      const updated = processAttributeDefinition(line, textureMap);
+      if (updated) {
+        const {updatedLine, sampleInstruction, samplerUniforms} = updated;
+        updateVsLines[index] = updatedLine;
+        sampleInstructions.push(sampleInstruction);
+        Object.assign(uniforms, samplerUniforms);
+      }
+    });
+    updatedVs = updateVsLines.join('\n');
+    mainInstructions = mainInstructions ?
+      mainInstructions + sampleInstructions : sampleInstructions;
+  }
+
+  if (mainInstructions) {
+    updatedVs = updatedVs.replace(REGEX_START_OF_MAIN, match => match + mainInstructions);
+  }
+
+  return {vs: updatedVs, uniforms};
+}
+
+// build required definitions, sample instructions and uniforms for each texture attribute
+export function processAttributeDefinition(line, textureMap) {
+  const samplerUniforms = {};
+  const words = line.replace(/^\s+/, '').split(/\s+/);
+  const [qualifier, size, definition] = words;
+  if (
+    (qualifier !== 'attribute' && qualifier !== 'in') ||
+    !size ||
+    !definition
+  ) {
+    return null;
+  }
+  // check if a texture source is specified for this attribute
+  const name = definition.split(';')[0];
+  if (name && textureMap[name]) {
+    const updatedLine = `\
+uniform sampler2D transform_uSampler_${definition} \// ${line}
+uniform vec2 transform_uSize_${definition}`;
+    const channels = sizeToChannels(size);
+    const sampler = `transform_uSampler_${name}`;
+    const texSize = `transform_uSize_${name}`;
+    const sampleInstruction =
+      `  ${size} ${name} = transform_getInput(${sampler}, ${texSize}).${channels};\n`;
+
+    const samplerName = `transform_uSampler_${name}`;
+    const sizeName = `transform_uSize_${name}`;
+    const {width, height} = textureMap[name];
+    samplerUniforms[samplerName] = textureMap[name];
+    samplerUniforms[sizeName] = [width, height];
+
+    return {updatedLine, sampleInstruction, samplerUniforms};
+  }
+  return null;
+}
+
+export function sizeToChannels(size) {
+  switch (size) {
+  case 'float': return 'x';
+  case 'vec2': return 'xy';
+  case 'vec3': return 'xyz';
+  case 'vec4': return 'xyzw';
+  default :
+    assert(false);
+    return null;
+  }
+}

--- a/modules/core/src/core/transform.js
+++ b/modules/core/src/core/transform.js
@@ -129,33 +129,10 @@ export default class Transform {
 
   // Private
 
-  /* eslint-disable complexity, max-statements */
   _initialize(props = {}) {
-    let {feedbackBuffers, feedbackMap} = props;
-    const {destinationBuffers, sourceDestinationMap} = props;
-    if (destinationBuffers) {
-      log.deprecated('destinationBuffers', 'feedbackBuffers')();
-      feedbackBuffers = feedbackBuffers || destinationBuffers;
-    }
-    if (sourceDestinationMap) {
-      log.deprecated('sourceDestinationMap', 'feedbackMap')();
-      feedbackMap = feedbackMap || sourceDestinationMap;
-    }
+    const {feedbackBuffers, feedbackMap} = this._validateProps(props);
 
-    const {sourceBuffers, vs, elementCount} = props;
-    assert(sourceBuffers && vs && elementCount >= 0);
-    // If feedbackBuffers are not provided, sourceDestinationMap must be provided
-    // to create destinaitonBuffers with layout of corresponding source buffer.
-    assert(feedbackBuffers || feedbackMap, ' Transform needs feedbackBuffers or feedbackMap');
-    for (const bufferName in feedbackBuffers || {}) {
-      assert(feedbackBuffers[bufferName] instanceof Buffer);
-    }
-    const {_sourceTextures} = props;
-    for (const textureName in _sourceTextures || {}) {
-      assert(_sourceTextures[textureName] instanceof Texture2D);
-    }
-
-    const {varyings} = props;
+    const {sourceBuffers, varyings} = props;
     // If varyings are not provided feedbackMap must be provided to deduce varyings
     assert(Array.isArray(varyings) || feedbackMap);
     let varyingsArray = varyings;
@@ -174,8 +151,38 @@ export default class Transform {
       varyings: varyingsArray
     }));
   }
-  /* eslint-enable complexity, max-statements */
 
+  // assert on required parameters
+  _validateProps(props) {
+    let {feedbackBuffers, feedbackMap} = props;
+
+    // backward compitability
+    const {destinationBuffers, sourceDestinationMap} = props;
+    if (destinationBuffers) {
+      log.deprecated('destinationBuffers', 'feedbackBuffers')();
+      feedbackBuffers = feedbackBuffers || destinationBuffers;
+    }
+    if (sourceDestinationMap) {
+      log.deprecated('sourceDestinationMap', 'feedbackMap')();
+      feedbackMap = feedbackMap || sourceDestinationMap;
+    }
+
+    // assert on required parameters
+    const {sourceBuffers, vs, elementCount} = props;
+    assert(sourceBuffers && vs && elementCount >= 0);
+    // If feedbackBuffers are not provided, sourceDestinationMap must be provided
+    // to create destinaitonBuffers with layout of corresponding source buffer.
+    assert(feedbackBuffers || feedbackMap, ' Transform needs feedbackBuffers or feedbackMap');
+    for (const bufferName in feedbackBuffers || {}) {
+      assert(feedbackBuffers[bufferName] instanceof Buffer);
+    }
+    const {_sourceTextures} = props;
+    for (const textureName in _sourceTextures || {}) {
+      assert(_sourceTextures[textureName] instanceof Texture2D);
+    }
+
+    return {feedbackBuffers, feedbackMap};
+  }
   // setup source and destination buffers
   _setupBuffers({sourceBuffers = null, feedbackBuffers = null}) {
     this.sourceBuffers[0] = Object.assign({}, sourceBuffers);

--- a/modules/core/src/core/transform.js
+++ b/modules/core/src/core/transform.js
@@ -72,6 +72,7 @@ export default class Transform {
     this.model.setAttributes(attributes);
     this.model.transform({
       transformFeedback: this.transformFeedbacks[this.currentIndex],
+      uniforms,
       unbindModels
     });
   }

--- a/modules/core/src/shadertools/src/index.js
+++ b/modules/core/src/shadertools/src/index.js
@@ -12,3 +12,6 @@ export {default as lighting} from './modules/lighting/lighting';
 export {default as dirlight} from './modules/dirlight/dirlight';
 export {default as picking} from './modules/picking/picking';
 export {default as diffuse} from './modules/diffuse/diffuse';
+
+// experimental
+export {default as _transform} from './modules/transform/transform';

--- a/modules/core/src/shadertools/src/modules/transform/transform.js
+++ b/modules/core/src/shadertools/src/modules/transform/transform.js
@@ -1,0 +1,38 @@
+
+// Private shader module used by `Transform`
+
+const vs = `\
+attribute float transform_elementID;
+
+// returns current elementID's texture co-ordianate
+vec2 transform_getTexCoord(vec2 size) {
+  float yOffset =  1. / (2. * size[1]);
+  float xOffset =  1. / (2. * size[0]);
+  float yIndex = floor((transform_elementID / size[0]) + yOffset );
+  float xIndex = transform_elementID - (yIndex * size[0]);
+  xIndex = (xIndex / size[0]) + xOffset;
+  yIndex = (yIndex / size[1]) + yOffset;
+  return vec2(xIndex, yIndex);
+}
+
+// returns current elementID's position
+vec2 transform_getPos(vec2 size) {
+  vec2 texCoord = transform_getTexCoord(size);
+  // Change from [0 1] range to [-1 1]
+  vec2 pos = (texCoord * (2.0, 2.0)) - (1., 1.);
+  return pos;
+}
+
+// returns current elementID's pixel value
+vec4 transform_getInput(sampler2D texSampler, vec2 size) {
+  vec2 texCoord = transform_getTexCoord(size);
+  vec4 textureColor = texture2D(texSampler, texCoord);
+  return textureColor;
+}
+`;
+
+export default {
+  name: 'transform',
+  vs,
+  fs: null
+};


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #671 
[RFC](https://github.com/uber/luma.gl/blob/master/dev-docs/RFCs/v6.2/transform_floatTextures.md) 
<!-- For other PRs without open issue -->
#### Background
- Add ability to take `Texture2D` as a source for Transform, using `_sourceTextures` param. (Adding as private API for now, will upgrade to official in later PRs)
- Add a private `transform` shader module, containing useful (re-usable) GLSL function for accessing `Textures`.
- Add a unit tests
Next steps: Add support for `Texture2D` as destination.
<!-- For all the PRs -->
#### Change List
- Transform: Add support for textures as sources
