### PR TITLE
loaders.gl: Exclude `fs` in browsers

### DIFF
--- a/modules/loaders.gl/package.json
+++ b/modules/loaders.gl/package.json
@@ -28,7 +28,10 @@
     ".bin"
   ],
   "sideEffects": false,
-  "bin" : {
+  "browser": {
+    "fs": false
+  },
+  "bin": {
     "glbdump" : "./.bin/glbdump"
   },
   "scripts": {

--- a/modules/loaders.gl/src/common/loader-utils/load-uri.js
+++ b/modules/loaders.gl/src/common/loader-utils/load-uri.js
@@ -1,6 +1,6 @@
 // Based on binary-gltf-utils under MIT license: Copyright (c) 2016-17 Karl Cheng
 import path from 'path';
-import fs from 'fs';
+const fs = module.require && module.require('fs');
 
 /* global Buffer */
 
@@ -11,6 +11,10 @@ export function loadUri(uri, rootFolder = '.') {
 
   if (uri.startsWith('data:')) {
     return Promise.resolve(parseDataUri(uri));
+  }
+
+  if (!fs) {
+    return Promise.reject(new Error('Cannot load file URIs in browser'));
   }
 
   const filePath = path.join((rootFolder = '.'), uri);

--- a/modules/loaders.gl/src/gltf-instantiator/gltf-instantiator.js
+++ b/modules/loaders.gl/src/gltf-instantiator/gltf-instantiator.js
@@ -74,12 +74,15 @@ export default class GLTFInstantiator {
   }
 
   createAccessor(accessor) {
+    return null;
+    /*
     return new Accessor({
       type: accessor.componentType,
       size: accessor.components,
       offset: accessor.byteOffset || 0,
       stride: accessor.byteStride || 0
     });
+    */
   }
 
   createTexture(gltfTexture) {


### PR DESCRIPTION
#### Background
- Avoid bundling `fs` in browsers

#### Change List
- package.json `browser` field and conditional require
