### PR TITLE
Upgrade glsl-transpiler

### DIFF
--- a/examples/wip/debugger/app.js
+++ b/examples/wip/debugger/app.js
@@ -46,7 +46,7 @@ uniform mat4 uProjection;
 varying vec3 vPosition;
 
 void main(void) {
-  gl_Position = (uProjection * (uView * uModel)) * vec4(positions, 1.0);
+  gl_Position = uProjection * uView * uModel * vec4(positions, 1.0);
   vPosition = positions;
 }
 `;
@@ -80,7 +80,7 @@ varying vec3 vPosition;
 varying vec3 vNormal;
 
 void main(void) {
-  gl_Position = (uProjection * (uView * uModel)) * vec4(positions, 1.0);
+  gl_Position = uProjection * uView * uModel * vec4(positions, 1.0);
   vPosition = vec3(uModel * vec4(positions,1));
   vNormal = vec3(uModel * vec4(normals, 1));
 }

--- a/modules/debug/package.json
+++ b/modules/debug/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "luma.gl": "^6.1.0-alpha.3",
-    "glsl-transpiler": "1.5.9"
+    "glsl-transpiler": "^1.7.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4026,7 +4026,7 @@ globby@^8.0.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-glsl-parser@^2.0.0:
+glsl-parser@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/glsl-parser/-/glsl-parser-2.0.1.tgz#3ffac4ee05cc4d8141fd6b1e41e82b3766ff61b9"
   dependencies:
@@ -4040,13 +4040,13 @@ glsl-tokenizer@^2.0.2, glsl-tokenizer@^2.1.4:
   dependencies:
     through2 "^0.6.3"
 
-glsl-transpiler@1.5.9:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/glsl-transpiler/-/glsl-transpiler-1.5.9.tgz#cdbf1e438888dd86d6d1e168e98788891a26fd50"
+glsl-transpiler@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/glsl-transpiler/-/glsl-transpiler-1.7.1.tgz#b40fb682e322009cd494016941df6a7c401c0746"
   dependencies:
     array-flatten "^2.0.0"
-    glsl-parser "^2.0.0"
-    glsl-tokenizer "^2.0.2"
+    glsl-parser "^2.0.1"
+    glsl-tokenizer "^2.1.4"
     inherits "^2.0.1"
     prepr "^1.1.0"
     xtend "^4.0.1"


### PR DESCRIPTION
Use the latest glsl-transpiler release.

#### Change List
- Remove hacks in example shader
- Support WebGL2 shaders
