### PR TITLE
Transform: remove assert on sourceBuffer

### DIFF
--- a/modules/core/src/core/transform.js
+++ b/modules/core/src/core/transform.js
@@ -106,7 +106,7 @@ export default class Transform {
     }
 
     const {sourceBuffers, vs, elementCount} = props;
-    assert(sourceBuffers && vs && elementCount >= 0);
+    assert(vs && elementCount >= 0);
     // If feedbackBuffers are not provided, sourceDestinationMap must be provided
     // to create destinaitonBuffers with layout of corresponding source buffer.
     assert(feedbackBuffers || feedbackMap, ' Transform needs feedbackBuffers or feedbackMap');

--- a/test/modules/core/core/transform.spec.js
+++ b/test/modules/core/core/transform.spec.js
@@ -39,6 +39,16 @@ void main()
 }
 `;
 
+const VS_NO_SOURCE_BUFFER = `\
+varying float outValue;
+uniform float uValue;
+
+void main()
+{
+  outValue = uValue * 2.;
+}
+`;
+
 test('WebGL#Transform constructor/delete', t => {
   const {gl, gl2} = fixture;
 
@@ -111,6 +121,37 @@ test('WebGL#Transform run', t => {
   transform.run();
 
   const expectedData = sourceData.map(x => x * 2);
+  const outData = transform.getBuffer('outValue').getData();
+
+  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
+
+  t.end();
+});
+
+test('WebGL#Transform run (no source buffer)', t => {
+  const {gl2} = fixture;
+
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+
+  const INPUT = 101;
+  const outBuffer = new Buffer(gl2, 4);
+
+  const transform = new Transform(gl2, {
+    feedbackBuffers: {
+      outValue: outBuffer
+    },
+    vs: VS_NO_SOURCE_BUFFER,
+    varyings: ['outValue'],
+    elementCount: 1
+  });
+
+  transform.run({uniforms: {uValue: INPUT}});
+
+  const expectedData = [INPUT * 2];
   const outData = transform.getBuffer('outValue').getData();
 
   t.deepEqual(outData, expectedData, 'Transform.getData: is successful');


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
Remove assert for existence of `sourceBuffers`. In some cases data could be sourced from uniforms or hard coded in the shader. (mostly for unit tests)
<!-- For all the PRs -->
#### Change List
- Transform: remove assert on sourceBuffer
