### PR TITLE
ProgramConfiguration: Do not track built-in attributes to avoid crash…

### DIFF
--- a/modules/core/src/webgl/program-configuration.js
+++ b/modules/core/src/webgl/program-configuration.js
@@ -64,7 +64,11 @@ export default class ProgramConfiguration {
     for (let index = 0; index < count; index++) {
       const {name, type, size} = gl.getActiveAttrib(program.handle, index);
       const location = gl.getAttribLocation(program.handle, name);
-      this._addAttribute(location, name, type, size);
+      // Add only user provided attributes, for built-in attributes like
+      // `gl_InstanceID` locaiton will be < 0
+      if (location >= 0) {
+        this._addAttribute(location, name, type, size);
+      }
     }
 
     this.attributeInfos.sort((a, b) => a.location - b.location);


### PR DESCRIPTION
…es when we look for attribute definition.


<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- When debugging program objects that have built-in variables like `gl_InstanceID`, their `locaiton` will be -1. `ProgramConfiguration` code doesn't handle these cases and later tries to access `attribute` information based on `location` causing crashes when debugging is enabled.  Disable tracking built-in attributes.
#### Change List
- ProgramConfiguration: Do not track built-in attributes
