### PR TITLE
[Fix] Cannot resolve 'gl' warning in webpack 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "debug.js",
     "headless.js"
   ],
+  "browser": {
+    "gl": false,
+    "gl/wrap": false
+  },
   "scripts": {
     "start": "echo 'Please see luma.gl website for how to run examples' && open http://uber.github.io/luma.gl/#/documentation/getting-started/examples",
     "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5/packages dist/esm/packages dist/es6/packages",


### PR DESCRIPTION
Merged the fix of this issue https://github.com/uber/luma.gl/issues/620
