### PR TITLE
Fixed injection location for function declaration in inject shader

### DIFF
--- a/modules/core/src/shadertools/src/lib/inject-shader.js
+++ b/modules/core/src/shadertools/src/lib/inject-shader.js
@@ -8,8 +8,8 @@ const MODULE_INJECTORS = {
   [FRAGMENT_SHADER]: MODULE_INJECTORS_FS
 };
 
-const REGEX_DECLARATIONS = /^(#version[^\n]*\n)?/; // Beginning of file
-const REGEX_START_OF_MAIN = /main\s*\([^\)]*\)\s*\{\n?/; // Beginning of main
+// const REGEX_DECLARATIONS = /^(#version[^\n]*\n)?/; // Beginning of file
+const REGEX_START_OF_MAIN = /void main\s*\([^\)]*\)\s*\{\n?/; // Beginning of main
 const REGEX_END_OF_MAIN = /}\n?[^{}]*$/; // End of main, assumes main is last function
 
 // A minimal shader injection/templating system.
@@ -21,41 +21,41 @@ export default function injectShader(source, type, inject, injectStandardStubs) 
   for (const key in inject) {
     const fragment = inject[key];
     switch (key) {
-    // declarations are injected at beginning of shader
-    case 'vs:#decl':
-      if (isVertex) {
-        source = source.replace(REGEX_DECLARATIONS, match => match + fragment);
-      }
-      break;
-    // main code is injected at the end of main function
-    case 'vs:#main-start':
-      if (isVertex) {
-        source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
-      }
-      break;
-    case 'vs:#main-end':
-      if (isVertex) {
-        source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
-      }
-      break;
-    case 'fs:#decl':
-      if (!isVertex) {
-        source = source.replace(REGEX_DECLARATIONS, match => match + fragment);
-      }
-      break;
-    case 'fs:#main-start':
-      if (!isVertex) {
-        source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
-      }
-      break;
-    case 'fs:#main-end':
-      if (!isVertex) {
-        source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
-      }
-      break;
-    default:
-      // inject code after key, leaving key in place
-      source = source.replace(key, match => match + fragment);
+      // declarations are injected at beginning of shader
+      case 'vs:#decl':
+        if (isVertex) {
+          source = source.replace(REGEX_START_OF_MAIN, match => fragment + match);
+        }
+        break;
+      // main code is injected at the end of main function
+      case 'vs:#main-start':
+        if (isVertex) {
+          source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
+        }
+        break;
+      case 'vs:#main-end':
+        if (isVertex) {
+          source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
+        }
+        break;
+      case 'fs:#decl':
+        if (!isVertex) {
+          source = source.replace(REGEX_START_OF_MAIN, match => fragment + match);
+        }
+        break;
+      case 'fs:#main-start':
+        if (!isVertex) {
+          source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
+        }
+        break;
+      case 'fs:#main-end':
+        if (!isVertex) {
+          source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
+        }
+        break;
+      default:
+        // inject code after key, leaving key in place
+        source = source.replace(key, match => match + fragment);
     }
   }
 
@@ -79,3 +79,4 @@ export function combineInjects(injects) {
   });
   return result;
 }
+

--- a/modules/core/src/shadertools/src/lib/inject-shader.js
+++ b/modules/core/src/shadertools/src/lib/inject-shader.js
@@ -21,40 +21,40 @@ export default function injectShader(source, type, inject, injectStandardStubs) 
     const fragment = inject[key];
     switch (key) {
       // declarations are injected before the main function
-      case 'vs:#decl':
-        if (isVertex) {
-          source = source.replace(REGEX_START_OF_MAIN, match => fragment + match);
-        }
-        break;
-      // main code is injected at the end of main function
-      case 'vs:#main-start':
-        if (isVertex) {
-          source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
-        }
-        break;
-      case 'vs:#main-end':
-        if (isVertex) {
-          source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
-        }
-        break;
-      case 'fs:#decl':
-        if (!isVertex) {
-          source = source.replace(REGEX_START_OF_MAIN, match => fragment + match);
-        }
-        break;
-      case 'fs:#main-start':
-        if (!isVertex) {
-          source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
-        }
-        break;
-      case 'fs:#main-end':
-        if (!isVertex) {
-          source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
-        }
-        break;
-      default:
-        // inject code after key, leaving key in place
-        source = source.replace(key, match => match + fragment);
+    case 'vs:#decl':
+      if (isVertex) {
+        source = source.replace(REGEX_START_OF_MAIN, match => fragment + match);
+      }
+      break;
+    // main code is injected at the end of main function
+    case 'vs:#main-start':
+      if (isVertex) {
+        source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
+      }
+      break;
+    case 'vs:#main-end':
+      if (isVertex) {
+        source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
+      }
+      break;
+    case 'fs:#decl':
+      if (!isVertex) {
+        source = source.replace(REGEX_START_OF_MAIN, match => fragment + match);
+      }
+      break;
+    case 'fs:#main-start':
+      if (!isVertex) {
+        source = source.replace(REGEX_START_OF_MAIN, match => match + fragment);
+      }
+      break;
+    case 'fs:#main-end':
+      if (!isVertex) {
+        source = source.replace(REGEX_END_OF_MAIN, match => fragment + match);
+      }
+      break;
+    default:
+      // inject code after key, leaving key in place
+      source = source.replace(key, match => match + fragment);
     }
   }
 

--- a/modules/core/src/shadertools/src/lib/inject-shader.js
+++ b/modules/core/src/shadertools/src/lib/inject-shader.js
@@ -8,7 +8,6 @@ const MODULE_INJECTORS = {
   [FRAGMENT_SHADER]: MODULE_INJECTORS_FS
 };
 
-// const REGEX_DECLARATIONS = /^(#version[^\n]*\n)?/; // Beginning of file
 const REGEX_START_OF_MAIN = /void main\s*\([^\)]*\)\s*\{\n?/; // Beginning of main
 const REGEX_END_OF_MAIN = /}\n?[^{}]*$/; // End of main, assumes main is last function
 
@@ -21,7 +20,7 @@ export default function injectShader(source, type, inject, injectStandardStubs) 
   for (const key in inject) {
     const fragment = inject[key];
     switch (key) {
-      // declarations are injected at beginning of shader
+      // declarations are injected before the main function
       case 'vs:#decl':
         if (isVertex) {
           source = source.replace(REGEX_START_OF_MAIN, match => fragment + match);

--- a/modules/core/src/shadertools/test/lib/inject-shader.spec.js
+++ b/modules/core/src/shadertools/test/lib/inject-shader.spec.js
@@ -23,13 +23,13 @@ void main(void) {
 
 const VS_GLSL_RESOLVED = `\
 #version 300 es
-uniform float uNewUniform;
 
 in vec4 positions;
 out vec4 vColor;
 
 void f(out float a, in float b) {}
 
+uniform float uNewUniform;
 void main(void) {
   gl_Position = positions;
   vColor = vec4(1., 0., 0., 1.);
@@ -53,7 +53,6 @@ void main(void) {
 
 const FS_GLSL_RESOLVED = `\
 #version 300 es
-uniform bool uDiscard;
 
 precision highp float;
 
@@ -62,6 +61,7 @@ in vec4 vColor;
 
 void f(out float a, in float b) {}
 
+uniform bool uDiscard;
 void main(void) {
   if (uDiscard} { discard } else {
   fragmentColor = vColor;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #750 
<!-- For other PRs without open issue -->
#### Background
Functions are injected at the beginning of the shader, which cannot utilize the functions already defined in the target shader. We need to move the injected function before the main function.
<!-- For all the PRs -->
#### Change List
- Changed the location of the injected functions
- modified the test cases