### PR TITLE
API audit and documentation of AnimationLoopProxy class

### DIFF
--- a/docs/api-reference/core/animation-loop-proxy.md
+++ b/docs/api-reference/core/animation-loop-proxy.md
@@ -1,0 +1,83 @@
+# AnimationLoopProxy (Expermental)
+
+> This class is experimental. Its API may change between minor releases.
+
+Manages an [AnimationLoop](/docs/api-reference/core/animation-loop.md) that runs on a worker thread.
+
+## Usage
+
+Create a worker:
+```js
+// animation-worker.js
+import {AnimationLoop, _AnimationLoopProxy as AnimationLoopProxy} from 'luma.gl';
+
+const animationLoop = new AnimationLoop({...});
+AnimationLoopProxy.createWorker(animationLoop)(self);
+```
+
+Use a bundler e.g. Webpack to transpile and bundle `animation-worker.js` into a file e.g. `animation-worker.es5.js`. You can then use it as this:
+
+```js
+import {_AnimationLoopProxy as AnimationLoopProxy} from 'luma.gl';
+
+new AnimationLoopProxy(new Worker('animation-worker.es5.js')).start();
+```
+
+## Static Methods
+
+### createWorker
+
+```js
+AnimationLoopProxy.createWorker(animationLoop);
+```
+
+Returns a function `self => {...}` that sets up the message handling inside the worker thread when called with a [WorkerGlobalScope](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope) instance.
+
+## Methods
+
+### constructor
+
+```js
+new AnimationLoopProxy(worker, {
+  onInitialize,
+  onFinalize,
+  useDevicePixels,
+  autoResizeDrawingBuffer
+});
+```
+
+* `worker` - a [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker) instance using code created from `AnimationLoopProxy.createWorker`.
+* `options`
+  - `onInitialize` (callback) - if supplied, will be called once after first `start()` has been called, after page load completes and a context has been created.
+  - `onFinalize`=`null` (callback) - Called once when animation is stopped. Can be used to delete objects or free any resources created during `onInitialize`.
+  - `autoResizeDrawingBuffer`=`true` - If true, checks the canvas size every frame and updates the drawing buffer size if needed.
+  - `useDevicePixels` - Whether to use `window.devicePixelRatio` as a multiplier, e.g. in `autoResizeDrawingBuffer` etc.
+
+### start
+
+Restarts the animation
+
+```js
+animationLoopProxy.start(options)
+```
+
+* `options`=`{}` (object) - Options to create the canvas with.
+  + `options.canvas` (string | HTMLCanvasElement) - A *string* containing the `id` of an existing HTML element or a *DOMElement* instance. If `null` or not provided, a new canvas will be created.
+
+### stop
+
+Stops the animation
+
+```js
+animationLoopProxy.stop();
+```
+
+### setProps
+
+```js
+animationLoopProxy.setProps({...props});
+```
+
+* `autoResizeDrawingBuffer` - Update the drawing buffer size to match the canvas size before each call to `onRenderFrame()`
+* `useDevicePixels` - Whether to use `window.devicePixelRatio` as a multiplier, e.g. in `autoResizeDrawingBuffer` etc.
+

--- a/examples/wip/worker/app.js
+++ b/examples/wip/worker/app.js
@@ -4,7 +4,7 @@ import createWorker from 'webworkify-webpack';
 // Required by webworkify-webpack :(
 const worker = createWorker(require.resolve('./worker'));
 
-const animationLoop = new AnimationLoopProxy({worker});
+const animationLoop = new AnimationLoopProxy(worker);
 
 export default animationLoop;
 

--- a/examples/wip/worker/worker.js
+++ b/examples/wip/worker/worker.js
@@ -1,3 +1,5 @@
+import {_AnimationLoopProxy as AnimationLoopProxy} from 'luma.gl';
+
 // import animationLoop from '../../core/cubemap/app';  // not working - accesses document
 // import animationLoop from '../../core/fragment/app';
 // import animationLoop from '../../core/instancing/app';
@@ -7,4 +9,4 @@ import animationLoop from '../../core/picking/app';
 // import animationLoop from '../../core/transform/app';
 // import animationLoop from '../../core/transform-feedback/app';
 
-export default animationLoop.getWorker();
+export default AnimationLoopProxy.createWorker(animationLoop);

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -1,4 +1,3 @@
-import AnimationLoopProxy from './animation-loop-proxy';
 import {createGLContext, resizeGLContext, resetParameters} from '../webgl-context';
 import {getPageLoadPromise} from '../webgl-context';
 import {makeDebugContext} from '../webgl-context/debug-context';
@@ -25,7 +24,6 @@ export default class AnimationLoop {
       onRender = () => {},
       onFinalize = () => {},
 
-      offScreen = false,
       gl = null,
       glOptions = {},
       debug = false,
@@ -61,7 +59,6 @@ export default class AnimationLoop {
 
     // state
     this.gl = gl;
-    this.offScreen = offScreen;
     this.needsRedraw = null;
 
     this.setProps({
@@ -98,10 +95,6 @@ export default class AnimationLoop {
       this.useDevicePixels = props.useDevicePixels;
     }
     return this;
-  }
-
-  getWorker() {
-    return AnimationLoopProxy.createWorker(this);
   }
 
   // Starts a render loop if not already running
@@ -300,6 +293,8 @@ export default class AnimationLoop {
 
   // Either uses supplied or existing context, or calls provided callback to create one
   _createWebGLContext(opts) {
+    this.offScreen = opts.canvas && typeof OffscreenCanvas !== 'undefined' && opts.canvas instanceof OffscreenCanvas;
+
     // Create the WebGL context if necessary
     opts = Object.assign({}, opts, DEFAULT_GL_OPTIONS, this.props.glOptions);
     this.gl = this.props.gl || this.onCreateContext(opts);


### PR DESCRIPTION
#### Change List
- Update outdated AnimationLoop documentation
- Add AnimationLoopProxy documentation
- Remove `animationLoop.getWorker` - This was added in previous offscreen-fixing PR, never documented or released. Removing till we have a better worker story.
- Align `AnimationLoopProxy` API with `AnimationLoop`