### PR TITLE
IE browser WA: disable adding draw_buffers extension to shader source

### DIFF
--- a/modules/core/src/shadertools/src/lib/platform-defines.js
+++ b/modules/core/src/shadertools/src/lib/platform-defines.js
@@ -81,7 +81,7 @@ export function getVersionDefines(gl, glslVersion, isFragment) {
 `;
   }
   if (hasFeatures(gl, FEATURES.GLSL_FRAG_DATA) &&
-  canCompileGLGSExtension(gl, FEATURES.GLSL_FRAG_DATA)
+  canCompileGLGSExtension(gl, FEATURES.GLSL_FRAG_DATA, {behavior: 'require'})
   ) {
     versionDefines += `\
 // DRAW_BUFFERS => gl_FragData[] is available

--- a/modules/core/src/shadertools/src/lib/platform-defines.js
+++ b/modules/core/src/shadertools/src/lib/platform-defines.js
@@ -80,7 +80,9 @@ export function getVersionDefines(gl, glslVersion, isFragment) {
 #endif
 `;
   }
-  if (hasFeatures(gl, FEATURES.GLSL_FRAG_DATA)) {
+  if (hasFeatures(gl, FEATURES.GLSL_FRAG_DATA) &&
+  canCompileGLGSExtension(gl, FEATURES.GLSL_FRAG_DATA)
+  ) {
     versionDefines += `\
 // DRAW_BUFFERS => gl_FragData[] is available
 #ifdef GL_EXT_draw_buffers

--- a/modules/core/src/shadertools/src/utils/webgl-info.js
+++ b/modules/core/src/shadertools/src/utils/webgl-info.js
@@ -72,9 +72,17 @@ const compiledGlslExtensions = {};
 
 // Enables feature detection in IE11 due to a bug where gl.getExtension may return true
 // but fail to compile when the extension is enabled in the shader. Specifically,
-// the OES_standard_derivatives extension fails to compile in IE11 even though its included
+// the OES_standard_derivatives and WEBGL_draw_buffers extensions fails to compile in IE11 even though its included
 // in the list of supported extensions.
 // opts allows user agent to be overridden for testing
+/*
+* Inputs :
+*  gl : WebGL context
+*  cap : Key of WEBGL_FEATURES object identifying the extension
+*  opts :
+*   behavior : behavor of extension to be tested, by defualt `enable` is used
+* Returns : true, if shader is compiled successfully, false otherwise
+*/
 export function canCompileGLGSExtension(gl, cap, opts = {}) {
   const feature = WEBGL_FEATURES[cap];
   assert(feature, cap);

--- a/modules/core/src/shadertools/src/utils/webgl-info.js
+++ b/modules/core/src/shadertools/src/utils/webgl-info.js
@@ -88,7 +88,8 @@ export function canCompileGLGSExtension(gl, cap, opts = {}) {
   }
 
   const extensionName = feature[0];
-  const source = `#extension GL_${extensionName} : enable\nvoid main(void) {}`;
+  // "#extension extensionName require" results in error when not supported
+  const source = `#extension GL_${extensionName} : require\nvoid main(void) {}`;
 
   const shader = gl.createShader(gl.VERTEX_SHADER);
   gl.shaderSource(shader, source);

--- a/modules/core/src/shadertools/src/utils/webgl-info.js
+++ b/modules/core/src/shadertools/src/utils/webgl-info.js
@@ -88,8 +88,8 @@ export function canCompileGLGSExtension(gl, cap, opts = {}) {
   }
 
   const extensionName = feature[0];
-  // "#extension extensionName require" results in error when not supported
-  const source = `#extension GL_${extensionName} : require\nvoid main(void) {}`;
+  const behavior = opts.behavior || 'enable';
+  const source = `#extension GL_${extensionName} : ${behavior}\nvoid main(void) {}`;
 
   const shader = gl.createShader(gl.VERTEX_SHADER);
   gl.shaderSource(shader, source);


### PR DESCRIPTION

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #793 
<!-- For other PRs without open issue -->
#### Background
Add a WA to fix shader compilation issue in IE (IE 11 and old) browsers.
<!-- For all the PRs -->
#### Change List
- Old IE browser WA: disable adding draw_buffers extension to shader source