### PR TITLE
blend auto-highlight color and original color when an object is picked

### DIFF
--- a/modules/core/src/shadertools/src/modules/picking/picking.js
+++ b/modules/core/src/shadertools/src/modules/picking/picking.js
@@ -77,8 +77,18 @@ const float COLOR_SCALE = 1. / 255.;
  */
 vec4 picking_filterHighlightColor(vec4 color) {
   bool selected = bool(picking_vRGBcolor_Aselected.a);
-  vec4 highlightColor = selected ? (picking_uHighlightColor * COLOR_SCALE) : color;
-  return highlightColor * 0.3 + color * 0.7;
+
+  if (selected) {
+    vec4 highLightColor = picking_uHighlightColor * COLOR_SCALE;
+
+    float resultAlpha = highLightColor.a + color.a * (1.0 - highLightColor.a);
+
+    vec3 resultRGB = (highLightColor.rgb * highLightColor.a
+     + color.rgb * color.a * (1.0 - highLightColor.a)) / resultAlpha;
+    return vec4(resultRGB, color.a);
+  } else {
+    return color;
+  }
 }
 
 /*

--- a/modules/core/src/shadertools/src/modules/picking/picking.js
+++ b/modules/core/src/shadertools/src/modules/picking/picking.js
@@ -77,7 +77,8 @@ const float COLOR_SCALE = 1. / 255.;
  */
 vec4 picking_filterHighlightColor(vec4 color) {
   bool selected = bool(picking_vRGBcolor_Aselected.a);
-  return selected ? (picking_uHighlightColor * COLOR_SCALE) : color;
+  vec4 highlightColor = selected ? (picking_uHighlightColor * COLOR_SCALE) : color;
+  return highlightColor * 0.3 + color * 0.7;
 }
 
 /*

--- a/modules/core/src/shadertools/src/modules/picking/picking.js
+++ b/modules/core/src/shadertools/src/modules/picking/picking.js
@@ -81,10 +81,10 @@ vec4 picking_filterHighlightColor(vec4 color) {
   if (selected) {
     vec4 highLightColor = picking_uHighlightColor * COLOR_SCALE;
 
-    float resultAlpha = highLightColor.a + color.a * (1.0 - highLightColor.a);
+    float highLightAlpha = highLightColor.a;
+    float highLightRatio = highLightAlpha / (highLightAlpha + color.a * (1.0 - highLightAlpha));
 
-    vec3 resultRGB = (highLightColor.rgb * highLightColor.a
-     + color.rgb * color.a * (1.0 - highLightColor.a)) / resultAlpha;
+    vec3 resultRGB = mix(color.rgb, highLightColor.rgb, highLightRatio);
     return vec4(resultRGB, color.a);
   } else {
     return color;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #789
<!-- For other PRs without open issue -->
#### Background
The original color of the object is replace by the auto-highlight color when the object is picked. We need to blend these two colors.
<!-- For all the PRs -->
#### Change List
- blended the auto-highlight color with the original color of the object

![picking_bug](https://user-images.githubusercontent.com/42359372/49400248-83e5d500-f6f8-11e8-9ebc-8e6bb7f0ae85.gif)

