### PR TITLE
Add support for copyTexSubImage2D, misc fixes

### DIFF
--- a/docs/api-reference/webgl/framebuffer.md
+++ b/docs/api-reference/webgl/framebuffer.md
@@ -87,14 +87,15 @@ withParameters(gl, {framebuffer: framebuffer1}, () => {
 Reading data from a framebuffer color attachment.
 
 ```js
-// With CPU and GPU sync
+// Reading into an Array (CPU memory), results in a CPU and GPU sync
 const data = framebuffer.readPixels({
   x: 0,
   y: 0,
   width: 10,
   height: 10});
 
-// Without CPU and GPU sync
+
+// Reading into a Buffer object (GPU memory), doesn't result in CPU and GPU sync
 const buffer = framebuffer.readPixelsToBuffer({
   x: 0,
   y: 0,
@@ -108,7 +109,30 @@ const data = buffer.getData();
 model.setAttributes({
   attribute_name: buffer
 });
+
+
+// Reading into a Texture object (GPU memory), doesn't result in CPU and GPU sync
+
+framebuffer.copyToTexture({
+  texture, // Texture object to which data to be copied
+
+  // offset within texture
+  xoffset,
+  yoffset,
+  zoffset,
+
+  // rectangular area in framebuffer which needs to be copied
+  x,
+  y,
+  width,
+  height,
+});
+
+
 ```
+
+Reading data from a framebuffer into a texture.
+
 
 Blitting between framebuffers (WebGL2)
 
@@ -290,25 +314,48 @@ This function makes calls to the following WebGL APIs:
 [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer) (This is for WebGL2 only)
 
 
-### checkStatus
+### checkStatus() : Framebuffer
 
 Check that the framebuffer contains a valid combination of attachments
 
 [`gl.checkFramebufferStatus`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/checkFramebufferStatus), [`gl.bindFramebuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
 
 
-### clear
+### clear(opts: Object) : Framebuffer
 
 Clears the contents (pixels) of the framebuffer attachments.
 
-* `color` (Boolean or Array) - clears all active color buffers (any selected `drawBuffer`s) with either the provided color or the default color.
-* `depth`
-* `stencil`
-* `drawBuffers`=`[]` - An array of color values, with indices matching the buffers selected by `drawBuffers` argument.
+* opts
+  * `color` (Boolean or Array) - clears all active color buffers (any selected `drawBuffer`s) with either the provided color or the default color.
+  * `depth`
+  * `stencil`
+  * `drawBuffers`=`[]` - An array of color values, with indices matching the buffers selected by `drawBuffers` argument.
 
+Notes:
 * The scissor box bounds the cleared region.
 * The pixel ownership test, the scissor test, dithering, and the buffer writemasks affect the operation of `clear`.
 * Alpha function, blend function, logical operation, stenciling, texture mapping, and depth-buffering are ignored by `clear`.
+
+
+### copyToTexture(opts: Object) : Framebuffer
+
+Copies pixels from the this framebuffer into the specified area of a two-dimensional texture image or cube-map texture image. (gl.copyTexSubImage2D and gl.copyTexSubImage3D wrapper)
+
+* opts
+
+  Target options
+  * `texture` (Texture, optional) - If provided this object will be bound and data copied into it, if not provided `target` must be set.
+  * `target` (GLenum, optional) - Binding point where target texture is currently bound. Either `texture` or `target` must be specified.
+  * `xoffset` (GLint, optional, default: 0) - X offset with in target texture.
+  * `yoffset` (GLint, optional, default: 0) - Y offset with in target texture.
+  * `zoffset` (GLint, optional, default: 0, WebGL2) - Z offset with in target texture, when using copying into 2D Array of 3D texture.
+
+  Source options
+  * `x` (GLint, optional, default: 0) - x coordinate of the lower left corner where to start copying.
+  * `y` (GLint, optional, default: 0) - y coordinate of the lower left corner where to start copying.
+  * `width` (GLint, optional, default: texture.width) - Width of the are to be copied, if not specified defaults to texture's width
+  * `height` (GLint, optional, default: texture.height) - Height of the area to be copied, if not specified defaults to texture.height.
+
 
 ### readPixels
 

--- a/docs/api-reference/webgl/framebuffer.md
+++ b/docs/api-reference/webgl/framebuffer.md
@@ -7,7 +7,7 @@ For additional information, see OpenGL Wiki [Framebuffer](https://www.khronos.or
 
 ## Functionality
 
-luma.gl adds 
+luma.gl adds
 
 
 
@@ -231,6 +231,16 @@ Initializes the `Framebuffer` to match the supplied parameters. Unattaches any e
 * `stencil` - shortcut to the attachment in `GL.STENCIL_ATTACHMENT`
 
 
+### update(opts: Object) : Framebuffer
+
+Updates Framebuffers attachments using provided Texture and Renderbuffer objects. Optionally sets read and draw buffers when using WebGL2 context.
+
+* `attachments` - a map of attachments.
+* `readBuffer` - Buffer to be set as read buffer (WebGL2)
+* `drawBuffers` - Buffers to be set as draw buffers (WebGL2)
+* `clearAttachments` - When set to true, will first unattach all  binding points, default value is `false`.
+* `resizeAttachments` - When set to true, all attachments will be re-sized to Framebuffers size, default value is `true`.
+
 ### resize({width: Number, height: Number}) : Framebuffer
 
 `Framebuffer.resize({width, height})`
@@ -248,13 +258,17 @@ Returns itself to enable chaining
 WebGL References see `initialize`.
 
 
-### attach(attachments : Object) : Framebuffer
+### attach(attachments : Object, opts: Object) : Framebuffer
 
 Used to attach or unattach `Texture`s and `Renderbuffer`s from the `Framebuffer`s various attachment points.
 
 `Framebuffer.attach(attachments)`
 
 * `attachments` - a map of attachments.
+* opts
+  * `clearAttachments` - When set to true, will first unattach all  binding points, default value is `false`.
+  * `resizeAttachments` - When set to true, all attachments will be re-sized to Framebuffers size, default value is `true`.
+
 
 Returns itself to enable chaining.
 

--- a/docs/api-reference/webgl/texture.md
+++ b/docs/api-reference/webgl/texture.md
@@ -165,7 +165,6 @@ Note that binding a texture into a Framebuffer's color buffer and rendering can 
   Texture.copyFramebuffer({
     target = this.target,
     framebuffer,
-    offset = 0,
     x = 0,
     y = 0,
     width,
@@ -179,6 +178,31 @@ Note that binding a texture into a Framebuffer's color buffer and rendering can 
 The following WebGL APIs are called in the function
 
 [gl.copyTexImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D), [gl.bindFramebuffer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
+
+
+### copySubFramebuffer
+
+Updates defined area of a two-dimensional texture image or cube-map texture image with pixels from the current framebuffer (rather than from client memory). (gl.copyTexSubImage2D wrapper)
+
+Note: does not allocated memory for the texture, it is assumed the texture has enough memory for the copy.
+
+```js
+  Texture.copySubFramebuffer({
+    target = this.target,
+    framebuffer,
+    xOffset = 0,
+    yOffset = 0,
+    x = 0,
+    y = 0,
+    width,
+    height,
+    level = 0
+  });
+```
+
+The following WebGL APIs are called in the function
+
+[gl.copyTexSubImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexSubImage2D), [gl.bindFramebuffer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
 
 
 ### getActiveUnit

--- a/docs/api-reference/webgl/texture.md
+++ b/docs/api-reference/webgl/texture.md
@@ -180,31 +180,6 @@ The following WebGL APIs are called in the function
 [gl.copyTexImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D), [gl.bindFramebuffer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
 
 
-### copySubFramebuffer
-
-Updates defined area of a two-dimensional texture image or cube-map texture image with pixels from the current framebuffer (rather than from client memory). (gl.copyTexSubImage2D wrapper)
-
-Note: does not allocated memory for the texture, it is assumed the texture has enough memory for the copy.
-
-```js
-  Texture.copySubFramebuffer({
-    target = this.target,
-    framebuffer,
-    xOffset = 0,
-    yOffset = 0,
-    x = 0,
-    y = 0,
-    width,
-    height,
-    level = 0
-  });
-```
-
-The following WebGL APIs are called in the function
-
-[gl.copyTexSubImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexSubImage2D), [gl.bindFramebuffer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer)
-
-
 ### getActiveUnit
 
 Returns number of active textures.

--- a/modules/core/src/webgl/framebuffer.js
+++ b/modules/core/src/webgl/framebuffer.js
@@ -668,8 +668,17 @@ export default class Framebuffer extends Resource {
   }
 
   _unattach({attachment}) {
-    this.gl.bindRenderbuffer(GL.RENDERBUFFER, this.handle);
-    this.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, attachment, GL.RENDERBUFFER, null);
+    const oldAttachment = this.attachments[attachment];
+    if (!oldAttachment) {
+      return;
+    }
+    if (oldAttachment instanceof Renderbuffer) {
+      // render buffer
+      this.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, attachment, GL.RENDERBUFFER, null);
+    } else {
+      // Must be a texture attachment
+      this.gl.framebufferTexture2D(GL.FRAMEBUFFER, attachment, GL.TEXTURE_2D, null, 0);
+    }
     delete this.attachments[attachment];
   }
 

--- a/modules/core/src/webgl/framebuffer.js
+++ b/modules/core/src/webgl/framebuffer.js
@@ -128,9 +128,10 @@ export default class Framebuffer extends Resource {
     attachments = {},
     readBuffer,
     drawBuffers,
-    clearAttachments = false
+    clearAttachments = false,
+    resizeAttachments = true
   }) {
-    this.attach(attachments, {clearAttachments});
+    this.attach(attachments, {clearAttachments, resizeAttachments});
 
     const {gl} = this;
     // Multiple render target support, set read buffer and draw buffers
@@ -175,7 +176,7 @@ export default class Framebuffer extends Resource {
   }
 
   // Attach from a map of attachments
-  attach(attachments, {clearAttachments = false} = {}) {
+  attach(attachments, {clearAttachments = false, resizeAttachments = true} = {}) {
     const newAttachments = {};
 
     // Any current attachments need to be removed, add null values to map
@@ -212,7 +213,7 @@ export default class Framebuffer extends Resource {
       }
 
       // Resize objects
-      if (object) {
+      if (resizeAttachments && object) {
         object.resize({width: this.width, height: this.height});
       }
     }

--- a/modules/core/src/webgl/framebuffer.js
+++ b/modules/core/src/webgl/framebuffer.js
@@ -401,6 +401,8 @@ export default class Framebuffer extends Resource {
   // }
 
   // Copy a rectangle from a framebuffer attachment into a texture (at an offset)
+  // NOTE: assumes texture has enough storage allocated
+  // eslint-disable-next-line complexity
   copyToTexture({
     // Target
     texture,
@@ -419,12 +421,15 @@ export default class Framebuffer extends Resource {
   }) {
     const {gl} = this;
     const prevHandle = gl.bindFramebuffer(GL.FRAMEBUFFER, this.handle);
-    const prevBuffer = gl.readBuffer(attachment);
-
-    width = Number.isFinite(width) ? width : texture.width;
-    height = Number.isFinite(height) ? height : texture.height;
-
+    // TODO - support gl.readBuffer (WebGL2 only)
+    // const prevBuffer = gl.readBuffer(attachment);
+    assert(target || texture);
     // target
+    if (texture) {
+      width = Number.isFinite(width) ? width : texture.width;
+      height = Number.isFinite(height) ? height : texture.height;
+      texture.bind(0);
+    }
     switch (texture.target) {
     case GL.TEXTURE_2D:
     case GL.TEXTURE_CUBE_MAP:
@@ -455,10 +460,10 @@ export default class Framebuffer extends Resource {
       break;
     default:
     }
-
-    gl.readBuffer(prevBuffer);
+    if (texture) {
+      texture.unbind();
+    }
     gl.bindFramebuffer(GL.FRAMEBUFFER, prevHandle || null);
-
     return texture;
   }
 

--- a/modules/core/src/webgl/framebuffer.js
+++ b/modules/core/src/webgl/framebuffer.js
@@ -113,7 +113,7 @@ export default class Framebuffer extends Resource {
       }
     } else {
       // Create any requested default attachments
-      attachments = this._createDefaultAttachments({color, depth, stencil, width, height});
+      attachments = this._createDefaultAttachments(color, depth, stencil, width, height);
     }
 
     this.update({clearAttachments: true, attachments, readBuffer, drawBuffers});
@@ -201,7 +201,7 @@ export default class Framebuffer extends Resource {
       const descriptor = newAttachments[attachment];
       let object = descriptor;
       if (!object) {
-        this._unattach({attachment});
+        this._unattach(attachment);
       } else if (object instanceof Renderbuffer) {
         this._attachRenderbuffer({attachment, renderbuffer: object});
       } else if (Array.isArray(descriptor)) {
@@ -607,7 +607,7 @@ export default class Framebuffer extends Resource {
 
   // PRIVATE METHODS
 
-  _createDefaultAttachments({color, depth, stencil, width, height}) {
+  _createDefaultAttachments(color, depth, stencil, width, height) {
     let defaultAttachments = null;
 
     // Add a color buffer if requested and not supplied
@@ -673,7 +673,7 @@ export default class Framebuffer extends Resource {
     return defaultAttachments;
   }
 
-  _unattach({attachment}) {
+  _unattach(attachment) {
     const oldAttachment = this.attachments[attachment];
     if (!oldAttachment) {
       return;

--- a/modules/core/src/webgl/texture.js
+++ b/modules/core/src/webgl/texture.js
@@ -485,7 +485,6 @@ export default class Texture extends Resource {
   copyFramebuffer({
     target = this.target,
     framebuffer,
-    offset = 0,
     x = 0,
     y = 0,
     width,
@@ -499,7 +498,7 @@ export default class Texture extends Resource {
     }
 
     // target
-    this.bind();
+    this.bind(0);
     this.gl.copyTexImage2D(
       this.target, level, internalFormat, x, y, width, height, border);
     this.unbind();
@@ -508,6 +507,40 @@ export default class Texture extends Resource {
       framebuffer.unbind();
     }
   }
+
+  /**
+   * Updates defined area of a two-dimensional texture image or cube-map texture image with
+   * pixels from the current framebuffer (rather than from client memory).
+   * (gl.copyTexSubImage2D wrapper)
+   *
+   * Note: does not allocated memory for the texture, it is assumed the texture has enough memory for the copy.
+   */
+  copySubFramebuffer({
+    target = this.target,
+    framebuffer,
+    xOffset = 0,
+    yOffset = 0,
+    x = 0,
+    y = 0,
+    width,
+    height,
+    level = 0
+  }) {
+    if (framebuffer) {
+      framebuffer.bind();
+    }
+
+    // target
+    this.bind(0);
+    this.gl.copyTexSubImage2D(
+      this.target, level, xOffset, yOffset, x, y, width, height);
+    this.unbind();
+
+    if (framebuffer) {
+      framebuffer.unbind();
+    }
+  }
+
 
   getActiveUnit() {
     return this.gl.getParameter(GL.ACTIVE_TEXTURE) - GL.TEXTURE0;

--- a/modules/core/src/webgl/texture.js
+++ b/modules/core/src/webgl/texture.js
@@ -683,14 +683,14 @@ export default class Texture extends Resource {
     // Deduce compression from format
     compressed = compressed || (textureFormat && textureFormat.compressed);
 
-    ({width, height} = this._deduceImageSize({data, width, height}));
+    ({width, height} = this._deduceImageSize(data, width, height));
 
     return {dataFormat, type, compressed, width, height, format, data};
   }
 
   /* global ImageData, HTMLImageElement, HTMLCanvasElement, HTMLVideoElement */
   // eslint-disable-next-line complexity
-  _deduceImageSize({data, width, height}) {
+  _deduceImageSize(data, width, height) {
     let size;
 
     if (typeof ImageData !== 'undefined' && data instanceof ImageData) {

--- a/modules/core/src/webgl/texture.js
+++ b/modules/core/src/webgl/texture.js
@@ -508,40 +508,6 @@ export default class Texture extends Resource {
     }
   }
 
-  /**
-   * Updates defined area of a two-dimensional texture image or cube-map texture image with
-   * pixels from the current framebuffer (rather than from client memory).
-   * (gl.copyTexSubImage2D wrapper)
-   *
-   * Note: does not allocated memory for the texture, it is assumed the texture has enough memory for the copy.
-   */
-  copySubFramebuffer({
-    target = this.target,
-    framebuffer,
-    xOffset = 0,
-    yOffset = 0,
-    x = 0,
-    y = 0,
-    width,
-    height,
-    level = 0
-  }) {
-    if (framebuffer) {
-      framebuffer.bind();
-    }
-
-    // target
-    this.bind(0);
-    this.gl.copyTexSubImage2D(
-      this.target, level, xOffset, yOffset, x, y, width, height);
-    this.unbind();
-
-    if (framebuffer) {
-      framebuffer.unbind();
-    }
-  }
-
-
   getActiveUnit() {
     return this.gl.getParameter(GL.ACTIVE_TEXTURE) - GL.TEXTURE0;
   }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #800
<!-- For other PRs without open issue -->
#### Background
Fixes for issues found while working for #800

1. Add support for `copyTexSubImage2D` for Texture class.
2. Fix texture binding for `copyTexImage2D` (pass binding index for bind call)
3. Remove un-used `offset` argument form `copyTexImage2D`
4. Fix Framebuffer's `_unattach` method
5. Framebuffer: make attachment re-size optional during attach() , default behavior un-changed.

<!-- For all the PRs -->
#### Change List
- Add support for copyTexSubImage2D, misc fixes
