### PR TITLE
Update polyfillContext extension initialization to handle getSupportedExtensions returning null

### DIFF
--- a/modules/core/src/webgl1/polyfill-context.js
+++ b/modules/core/src/webgl1/polyfill-context.js
@@ -170,7 +170,8 @@ const WEBGL_CONTEXT_POLYFILLS = {
 
 function initializeExtensions(gl) {
   gl.luma.extensions = {};
-  const EXTENSIONS = gl.getSupportedExtensions();
+  // `getSupportedExtensions` can return null when context is lost.
+  const EXTENSIONS = gl.getSupportedExtensions() || [];
   for (const extension of EXTENSIONS) {
     gl.luma[extension] = gl.getExtension(extension);
   }

--- a/test/modules/core/webgl1/polyfill-context.spec.js
+++ b/test/modules/core/webgl1/polyfill-context.spec.js
@@ -1,5 +1,6 @@
 import polyfillContext from 'luma.gl/webgl1/polyfill-context';
 import test from 'tape-catch';
+import {makeSpy} from 'probe.gl/test-utils';
 
 import {fixture} from 'luma.gl/test/setup';
 
@@ -15,6 +16,27 @@ test('WebGL#polyfillContext', t => {
     const extensions2 = polyfillContext(gl2);
     t.ok(extensions2, 'extensions were returned');
   }
+
+  t.end();
+});
+
+
+test('WebGL#polyfillContext getSupportedExtensions when context is lost', t => {
+  const {gl, gl2} = fixture;
+
+  const getSupportedExtensionsSpy = makeSpy(gl, 'getSupportedExtensions');
+  getSupportedExtensionsSpy.returns(null);
+
+  const extensions = polyfillContext(gl);
+  t.ok(extensions, 'extensions were returned');
+
+  if (gl2) {
+    const getSupportedExtensions2Spy = makeSpy(gl2, 'getSupportedExtensions');
+    getSupportedExtensions2Spy.returns(null);
+    const extensions2 = polyfillContext(gl2);
+    t.ok(extensions2, 'extensions were returned');
+  }
+
 
   t.end();
 });

--- a/test/modules/core/webgl1/polyfill-context.spec.js
+++ b/test/modules/core/webgl1/polyfill-context.spec.js
@@ -29,14 +29,15 @@ test('WebGL#polyfillContext getSupportedExtensions when context is lost', t => {
 
   const extensions = polyfillContext(gl);
   t.ok(extensions, 'extensions were returned');
+  getSupportedExtensionsSpy.restore();
 
   if (gl2) {
     const getSupportedExtensions2Spy = makeSpy(gl2, 'getSupportedExtensions');
     getSupportedExtensions2Spy.returns(null);
     const extensions2 = polyfillContext(gl2);
     t.ok(extensions2, 'extensions were returned');
+    getSupportedExtensions2Spy.restore();
   }
-
 
   t.end();
 });


### PR DESCRIPTION
Fix For #807