### PR TITLE
Attribute enhancements

### DIFF
--- a/modules/core/src/core/attribute.js
+++ b/modules/core/src/core/attribute.js
@@ -2,6 +2,7 @@
 import GL from '@luma.gl/constants';
 import {Buffer} from '../webgl';
 import {log, uid} from '../utils';
+import {hasFeature, FEATURES} from '../webgl-context/context-features';
 
 export default class Attribute {
   constructor(gl, opts = {}) {
@@ -17,6 +18,10 @@ export default class Attribute {
     this.isIndexed = isIndexed;
     this.target = isIndexed ? GL.ELEMENT_ARRAY_BUFFER : GL.ARRAY_BUFFER;
     this.type = type;
+
+    if (isIndexed && !type) {
+      this.type = gl && hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? GL.UNSIGNED_INT : GL.UNSIGNED_SHORT;
+    }
 
     // Initialize the attribute descriptor, with WebGL and metadata fields
     this.value = null;

--- a/modules/core/src/core/attribute.js
+++ b/modules/core/src/core/attribute.js
@@ -20,6 +20,8 @@ export default class Attribute {
     this.type = type;
 
     if (isIndexed && !type) {
+      // If the attribute is indices, auto infer the correct type
+      // WebGL2 and WebGL1 w/ uint32 index extension support accepts Uint32Array, otherwise Uint16Array
       this.type = gl && hasFeature(gl, FEATURES.ELEMENT_INDEX_UINT32) ? GL.UNSIGNED_INT : GL.UNSIGNED_SHORT;
     }
 

--- a/modules/core/src/core/attribute.js
+++ b/modules/core/src/core/attribute.js
@@ -60,7 +60,7 @@ export default class Attribute {
       this.externalBuffer = null;
       this.value = value;
 
-      if (!constant) {
+      if (!constant && this.gl) {
         // Create buffer if needed
         this.buffer = this.buffer ||
           new Buffer(this.gl, Object.assign({}, opts, {

--- a/test/modules/core/core/attribute.spec.js
+++ b/test/modules/core/core/attribute.spec.js
@@ -36,6 +36,9 @@ test('WebGL#Attribute constructor/update/delete', t => {
   attribute.delete();
   t.ok(buffer._handle, 'External buffer is not deleted');
 
+  attribute = new Attribute(gl, {size: 1, isIndexed: true});
+  t.is(attribute.type, GL.UNSIGNED_INT, 'type is auto inferred');
+
   t.end();
 });
 

--- a/test/modules/core/core/attribute.spec.js
+++ b/test/modules/core/core/attribute.spec.js
@@ -39,6 +39,9 @@ test('WebGL#Attribute constructor/update/delete', t => {
   attribute = new Attribute(gl, {size: 1, isIndexed: true});
   t.is(attribute.type, GL.UNSIGNED_INT, 'type is auto inferred');
 
+  attribute = new Attribute(null, {size: 4, value: value1});
+  t.ok(attribute instanceof Attribute, 'Attribute construction successful without GL context');
+
   t.end();
 });
 


### PR DESCRIPTION
#### Background
For https://github.com/uber/deck.gl/pull/2490 - allow attributes to be constructed without a WebGLContext.

#### Change List
- Using attribute without a gl context
- Correctly infer attribute type when `isIndexed: true`