### PR TITLE
Forward shadertools exports (temporarily) to avoid breaking deck.gl

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@luma.gl/constants": "^7.0.0-alpha.3",
+    "@luma.gl/shadertools": "^7.0.0-alpha.3",
     "math.gl": "^2.2.0",
     "probe.gl": "^2.0.1",
     "seer": "^0.2.4"

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -153,6 +153,41 @@ export {
 // material
 export {default as PhongMaterial} from './materials/phong-material';
 
+// TODO/CLEAN UP FOR V7
+//  We should have a minimal set of forwarding exports from shadertools (ideally none)
+//  Analyze risk of breaking apps
+export {
+  registerShaderModules,
+  setDefaultShaderModules,
+  assembleShaders,
+
+  // HELPERS
+  combineInjects,
+  normalizeShaderModule,
+
+  // SHADER MODULES
+  fp32,
+  fp64,
+  project,
+  lighting,
+  dirlight,
+  picking,
+  diffuse,
+  phonglighting,
+
+  // experimental
+  _transform,
+
+  MODULAR_SHADERS,
+
+  getQualifierDetails,
+  getPassthroughFS,
+  typeToChannelSuffix,
+  typeToChannelCount,
+  convertToVec4
+} from '@luma.gl/shadertools';
+
+
 // TO BE REMOVED IN v7
 export {
   makeDebugContext} from './webgl-context/debug-context';

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -42,9 +42,6 @@
     "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
-    "@luma.gl/constants": "^7.0.0-alpha.3",
-    "glsl-transpiler": "^1.8.5",
-    "luma.gl": "^7.0.0-alpha.3",
-    "webgl-debug": "^2.0.1"
+    "@luma.gl/constants": "^7.0.0-alpha.3"
   }
 }


### PR DESCRIPTION
# For #724

#### Background
- deck.gl depends on luma.gl exporting shadertools symbols

#### Change List
- (Temporarily) forward shadertools exports
- Make luma.gl depend on shadertools, not the other way around.
