### PR TITLE
disable lighting by default

### DIFF
--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
@@ -49,7 +49,7 @@ vec3 lighting_getLightColor(vec3 surfaceColor, vec3 position_worldspace, vec3 no
   if (lighting_uEnabled) {
     vec3 camera_pos_worldspace = project_uCameraPosition;
     vec3 view_direction = normalize(camera_pos_worldspace - position_worldspace);
-    vec3 lightColor = lighting_uAmbient * surfaceColor * lighting_uAmbientLight.intensity;
+    lightColor = lighting_uAmbient * surfaceColor * lighting_uAmbientLight.intensity;
 
     for (int i = 0; i < MAX_LIGHTS; i++) {
       if (i >= lighting_uPointLightCount) {

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
@@ -29,6 +29,8 @@ uniform float lighting_diffuse;
 uniform float lighting_shininess;
 uniform vec3  lighting_specularColor;
 
+uniform bool lighting_enabled;
+
 vec3 lighting_getLightColor(vec3 surfaceColor, vec3 light_direction, vec3 view_direction, vec3 normal_worldspace, float intensity) {
     vec3 halfway_direction = normalize(light_direction + view_direction);
     float lambertian = dot(light_direction, normal_worldspace);
@@ -42,26 +44,30 @@ vec3 lighting_getLightColor(vec3 surfaceColor, vec3 light_direction, vec3 view_d
 }
 
 vec3 lighting_getLightColor(vec3 surfaceColor, vec3 position_worldspace, vec3 normal_worldspace) {
-  vec3 camera_pos_worldspace = project_uCameraPosition;
-  vec3 view_direction = normalize(camera_pos_worldspace - position_worldspace);
-  vec3 lightColor = lighting_ambient * surfaceColor * lighting_ambientLight.intensity;
+  vec3 lightColor = surfaceColor;
 
-  for (int i = 0; i < MAX_LIGHTS; i++) {
-    if (i >= lighting_pointLightCount) {
-      break;
-    }
-    PointLight pointLight = lighting_pointLight[i];
-    vec3 light_position_worldspace = pointLight.position;
-    vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
-    lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.intensity);
-  }
+  if (lighting_enabled) {
+    vec3 camera_pos_worldspace = project_uCameraPosition;
+    vec3 view_direction = normalize(camera_pos_worldspace - position_worldspace);
+    vec3 lightColor = lighting_ambient * surfaceColor * lighting_ambientLight.intensity;
 
-  for (int i = 0; i < MAX_LIGHTS; i++) {
-    if (i >= lighting_directionalLightCount) {
-      break;
+    for (int i = 0; i < MAX_LIGHTS; i++) {
+      if (i >= lighting_pointLightCount) {
+        break;
+      }
+      PointLight pointLight = lighting_pointLight[i];
+      vec3 light_position_worldspace = pointLight.position;
+      vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
+      lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.intensity);
     }
-    DirectionalLight directionalLight = lighting_directionalLight[i];
-    lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.intensity);
+
+    for (int i = 0; i < MAX_LIGHTS; i++) {
+      if (i >= lighting_directionalLightCount) {
+        break;
+      }
+      DirectionalLight directionalLight = lighting_directionalLight[i];
+      lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.intensity);
+    }
   }
   return lightColor;
 }

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
@@ -18,18 +18,18 @@ struct DirectionalLight {
   vec3 direction;
 };
  
-uniform AmbientLight lighting_ambientLight;
-uniform PointLight lighting_pointLight[MAX_LIGHTS];
-uniform DirectionalLight lighting_directionalLight[MAX_LIGHTS];
-uniform int lighting_pointLightCount;
-uniform int lighting_directionalLightCount;
+uniform AmbientLight lighting_uAmbientLight;
+uniform PointLight lighting_uPointLight[MAX_LIGHTS];
+uniform DirectionalLight lighting_uDirectionalLight[MAX_LIGHTS];
+uniform int lighting_uPointLightCount;
+uniform int lighting_uDirectionalLightCount;
 
-uniform float lighting_ambient;
-uniform float lighting_diffuse;
-uniform float lighting_shininess;
-uniform vec3  lighting_specularColor;
+uniform float lighting_uAmbient;
+uniform float lighting_uDiffuse;
+uniform float lighting_uShininess;
+uniform vec3  lighting_uSpecularColor;
 
-uniform bool lighting_enabled;
+uniform bool lighting_uEnabled;
 
 vec3 lighting_getLightColor(vec3 surfaceColor, vec3 light_direction, vec3 view_direction, vec3 normal_worldspace, float intensity) {
     vec3 halfway_direction = normalize(light_direction + view_direction);
@@ -37,35 +37,35 @@ vec3 lighting_getLightColor(vec3 surfaceColor, vec3 light_direction, vec3 view_d
     float specular = 0.0;
     if (lambertian > 0.0) {
       float specular_angle = max(dot(normal_worldspace, halfway_direction), 0.0);
-      specular = pow(specular_angle, lighting_shininess);
+      specular = pow(specular_angle, lighting_uShininess);
     }
     lambertian = max(lambertian, 0.0);
-    return (lambertian * lighting_diffuse * surfaceColor + specular * lighting_specularColor) * intensity;
+    return (lambertian * lighting_uDiffuse * surfaceColor + specular * lighting_uSpecularColor) * intensity;
 }
 
 vec3 lighting_getLightColor(vec3 surfaceColor, vec3 position_worldspace, vec3 normal_worldspace) {
   vec3 lightColor = surfaceColor;
 
-  if (lighting_enabled) {
+  if (lighting_uEnabled) {
     vec3 camera_pos_worldspace = project_uCameraPosition;
     vec3 view_direction = normalize(camera_pos_worldspace - position_worldspace);
-    vec3 lightColor = lighting_ambient * surfaceColor * lighting_ambientLight.intensity;
+    vec3 lightColor = lighting_uAmbient * surfaceColor * lighting_uAmbientLight.intensity;
 
     for (int i = 0; i < MAX_LIGHTS; i++) {
-      if (i >= lighting_pointLightCount) {
+      if (i >= lighting_uPointLightCount) {
         break;
       }
-      PointLight pointLight = lighting_pointLight[i];
+      PointLight pointLight = lighting_uPointLight[i];
       vec3 light_position_worldspace = pointLight.position;
       vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
       lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.intensity);
     }
 
     for (int i = 0; i < MAX_LIGHTS; i++) {
-      if (i >= lighting_directionalLightCount) {
+      if (i >= lighting_uDirectionalLightCount) {
         break;
       }
-      DirectionalLight directionalLight = lighting_directionalLight[i];
+      DirectionalLight directionalLight = lighting_uDirectionalLight[i];
       lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.intensity);
     }
   }

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -59,7 +59,7 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
   } = opts;
 
   if (!(ambientLight || pointLights || directionalLights) || !material) {
-    return {lighting_uEnabled: false};
+    return {};
   }
 
   const lightUniforms = Object.assign(

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -12,41 +12,41 @@ function getLightSourceUniforms({ambientLight, pointLights, directionalLights}) 
   const lightSourceUniforms = {};
 
   if (ambientLight) {
-    lightSourceUniforms['lighting_ambientLight.color'] = ambientLight.color;
-    lightSourceUniforms['lighting_ambientLight.intensity'] = ambientLight.intensity;
+    lightSourceUniforms['lighting_uAmbientLight.color'] = ambientLight.color;
+    lightSourceUniforms['lighting_uAmbientLight.intensity'] = ambientLight.intensity;
   }
 
   let index = 0;
   for (const i in pointLights) {
     const pointLight = pointLights[i];
-    lightSourceUniforms[`lighting_pointLight[${index}].color`] = pointLight.color;
-    lightSourceUniforms[`lighting_pointLight[${index}].intensity`] = pointLight.intensity;
-    lightSourceUniforms[`lighting_pointLight[${index}].position`] = pointLight.position;
+    lightSourceUniforms[`lighting_uPointLight[${index}].color`] = pointLight.color;
+    lightSourceUniforms[`lighting_uPointLight[${index}].intensity`] = pointLight.intensity;
+    lightSourceUniforms[`lighting_uPointLight[${index}].position`] = pointLight.position;
     index++;
   }
-  lightSourceUniforms.lighting_pointLightCount = pointLights.length;
+  lightSourceUniforms.lighting_uPointLightCount = pointLights.length;
 
   index = 0;
   for (const i in directionalLights) {
     const directionalLight = directionalLights[i];
-    lightSourceUniforms[`lighting_directionalLight[${index}].color`] = directionalLight.color;
-    lightSourceUniforms[`lighting_directionalLight[${index}].intensity`] =
+    lightSourceUniforms[`lighting_uDirectionalLight[${index}].color`] = directionalLight.color;
+    lightSourceUniforms[`lighting_uDirectionalLight[${index}].intensity`] =
       directionalLight.intensity;
-    lightSourceUniforms[`lighting_directionalLight[${index}].direction`] =
+    lightSourceUniforms[`lighting_uDirectionalLight[${index}].direction`] =
       directionalLight.direction;
     index++;
   }
-  lightSourceUniforms.lighting_directionalLightCount = directionalLights.length;
+  lightSourceUniforms.lighting_uDirectionalLightCount = directionalLights.length;
 
   return lightSourceUniforms;
 }
 
 function getMaterialUniforms(material) {
   const materialUniforms = {};
-  materialUniforms.lighting_ambient = material.ambient;
-  materialUniforms.lighting_diffuse = material.diffuse;
-  materialUniforms.lighting_shininess = material.shininess;
-  materialUniforms.lighting_specularColor = material.specularColor;
+  materialUniforms.lighting_uAmbient = material.ambient;
+  materialUniforms.lighting_uDiffuse = material.diffuse;
+  materialUniforms.lighting_uShininess = material.shininess;
+  materialUniforms.lighting_uSpecularColor = material.specularColor;
   return materialUniforms;
 }
 
@@ -59,14 +59,14 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
   } = opts;
 
   if (!(ambientLight || pointLights || directionalLights) || !material) {
-    return {lighting_enabled: false};
+    return {lighting_uEnabled: false};
   }
 
   const lightUniforms = Object.assign(
     {},
     getLightSourceUniforms({ambientLight, pointLights, directionalLights}),
     getMaterialUniforms(material),
-    {lighting_enabled: true}
+    {lighting_uEnabled: true}
   );
 
   return lightUniforms;

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -59,13 +59,14 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
   } = opts;
 
   if (!(ambientLight || pointLights || directionalLights) || !material) {
-    return {};
+    return {lighting_enabled: false};
   }
 
   const lightUniforms = Object.assign(
     {},
     getLightSourceUniforms({ambientLight, pointLights, directionalLights}),
-    getMaterialUniforms(material)
+    getMaterialUniforms(material),
+    {lighting_enabled: true}
   );
 
   return lightUniforms;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #835
<!-- For other PRs without open issue -->
#### Background
Need disable the lighting when there is no light source or material specified, initially thought this was handled in deck.gl, but actually the lighting is enabled all the time.
<!-- For all the PRs -->
#### Change List
- Disable lighting when there is no light source or material
