### PR TITLE
Fix parameter forwarding in loadTextures

### DIFF
--- a/docs/api-reference/io/README.md
+++ b/docs/api-reference/io/README.md
@@ -174,13 +174,15 @@ Enables loading of multiple remote images asynchronously and returns an array wi
 Loads multiple textures from image urls asynchronously and in parallel.
 
 ```js
-	const textures = await loadTextures({paths, params, ...options});
+	const textures = await loadTextures(gl, options);
 ```
 
-1. paths - (*array*) An array of strings pointing to image urls.
+1. gl - (*WebGLContext*)
 2. options - (*object*) An object containing the following options:
-
-* noCache - (*boolean*, optional, default=false)
-  If true a random number will be appended to the url in order to
-  force the reload of the file and avoid the use of the cache.
+  - urls - (*array*) An array of strings pointing to image urls.
+  - onProgress - (*function*) Callback during loading.
+  - noCache - (*boolean*, optional, default=false)
+    If true a random number will be appended to the url in order to
+    force the reload of the file and avoid the use of the cache.
+  - Any additional options to forwarded to the `Texture2D` constructor.
 

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -135,6 +135,7 @@ export {
   setPathPrefix,
   loadFile,
   loadImage,
+  loadTexture,
   loadFiles,
   loadImages,
   loadTextures,

--- a/modules/core/src/io/load-files.js
+++ b/modules/core/src/io/load-files.js
@@ -66,9 +66,7 @@ export function loadTextures(gl, opts = {}) {
 
   return loadImages(Object.assign({urls, onProgress}, opts))
   .then(images => images.map((img, i) => {
-    let params = Array.isArray(opts.parameters) ? opts.parameters[i] : opts.parameters;
-    params = params === undefined ? {} : params;
-    return new Texture2D(gl, {id: urls[i], parameters: params, data: img});
+    return new Texture2D(gl, Object.assign({id: urls[i]}, opts, {data: img}));
   }));
 }
 

--- a/modules/core/src/io/load-files.js
+++ b/modules/core/src/io/load-files.js
@@ -68,7 +68,7 @@ export function loadTextures(gl, opts = {}) {
   .then(images => images.map((img, i) => {
     let params = Array.isArray(opts.parameters) ? opts.parameters[i] : opts.parameters;
     params = params === undefined ? {} : params;
-    return new Texture2D(gl, Object.assign({id: urls[i]}, {parameters: params, data: img}));
+    return new Texture2D(gl, {id: urls[i], parameters: params, data: img});
   }));
 }
 

--- a/modules/core/src/io/load-files.js
+++ b/modules/core/src/io/load-files.js
@@ -68,7 +68,7 @@ export function loadTextures(gl, opts = {}) {
   .then(images => images.map((img, i) => {
     let params = Array.isArray(opts.parameters) ? opts.parameters[i] : opts.parameters;
     params = params === undefined ? {} : params;
-    return new Texture2D(gl, Object.assign({id: urls[i]}, params, {data: img}));
+    return new Texture2D(gl, Object.assign({id: urls[i]}, {parameters: params, data: img}));
   }));
 }
 


### PR DESCRIPTION
`Texture2D` constructor is not receiving user params when using `loadTextures`.

#### Change List
- `loadTextures` forward parameters properly
