### PR TITLE
add new lighting glsl API and better check for lighting_uEnabled.

### DIFF
--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.js
@@ -43,13 +43,40 @@ vec3 lighting_getLightColor(vec3 surfaceColor, vec3 light_direction, vec3 view_d
     return (lambertian * lighting_uDiffuse * surfaceColor + specular * lighting_uSpecularColor) * intensity;
 }
 
-vec3 lighting_getLightColor(vec3 surfaceColor, vec3 position_worldspace, vec3 normal_worldspace) {
+vec3 lighting_getLightColor(vec3 surfaceColor, vec3 cameraPosition, vec3 position_worldspace, vec3 normal_worldspace) {
   vec3 lightColor = surfaceColor;
 
   if (lighting_uEnabled) {
-    vec3 camera_pos_worldspace = project_uCameraPosition;
-    vec3 view_direction = normalize(camera_pos_worldspace - position_worldspace);
+    vec3 view_direction = normalize(cameraPosition - position_worldspace);
     lightColor = lighting_uAmbient * surfaceColor * lighting_uAmbientLight.intensity;
+
+    for (int i = 0; i < MAX_LIGHTS; i++) {
+      if (i >= lighting_uPointLightCount) {
+        break;
+      }
+      PointLight pointLight = lighting_uPointLight[i];
+      vec3 light_position_worldspace = pointLight.position;
+      vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
+      lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.intensity);
+    }
+
+    for (int i = 0; i < MAX_LIGHTS; i++) {
+      if (i >= lighting_uDirectionalLightCount) {
+        break;
+      }
+      DirectionalLight directionalLight = lighting_uDirectionalLight[i];
+      lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.intensity);
+    }
+  }
+  return lightColor;
+}
+
+vec3 lighting_getSpecularLightColor(vec3 cameraPosition, vec3 position_worldspace, vec3 normal_worldspace) {
+  vec3 lightColor = vec3(0, 0, 0);
+  vec3 surfaceColor = vec3(0, 0, 0);
+
+  if (lighting_uEnabled) {
+    vec3 view_direction = normalize(cameraPosition - position_worldspace);
 
     for (int i = 0; i < MAX_LIGHTS; i++) {
       if (i >= lighting_uPointLightCount) {

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -14,6 +14,9 @@ function getLightSourceUniforms({ambientLight, pointLights, directionalLights}) 
   if (ambientLight) {
     lightSourceUniforms['lighting_uAmbientLight.color'] = ambientLight.color;
     lightSourceUniforms['lighting_uAmbientLight.intensity'] = ambientLight.intensity;
+  } else {
+    lightSourceUniforms['lighting_uAmbientLight.color'] = [0, 0, 0];
+    lightSourceUniforms['lighting_uAmbientLight.intensity'] = 0.0;
   }
 
   let index = 0;
@@ -51,10 +54,21 @@ function getMaterialUniforms(material) {
 }
 
 function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
+  if (
+    !(
+      'ambientLight' in opts ||
+      'pointLights' in opts ||
+      'directionalLights' in opts ||
+      'material' in opts
+    )
+  ) {
+    return {};
+  }
+
   const {ambientLight, pointLights, directionalLights, material} = opts;
 
-  if (!(ambientLight || pointLights || directionalLights) || !material) {
-    return {};
+  if (!(ambientLight || (pointLights && pointLights.length > 0) || (directionalLights && directionalLights.length > 0)) || !material) {
+    return {lighting_uEnabled: false};
   }
 
   const lightUniforms = Object.assign(


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #852 
<!-- For other PRs without open issue -->
#### Background
- Add better check for lighting_uEnabled, so we can turn off lighting when there is available light sources or material.
- When integrating with mesh layer, found that surface color is only available in fragment shader while our current lighting has to be in vertex shader, so adding a new API to handle that problem, in long term we need move lighting to fragment shader for better results.
<!-- For all the PRs -->
#### Change List
- Better check for lighting_uEnabled
- New GLSL API(lighting_getSpecularLightColor)
