### PR TITLE
fix documentation for #858

### DIFF
--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -38,7 +38,7 @@ animationLoop.start();
 
 Use a canvas in the existing DOM through its HTML id
 ```js
-animationLoop.start({id: 'my-canvas'});
+animationLoop.start({canvas: 'my-canvas'});
 ```
 
 ## Methods


### PR DESCRIPTION
The parameter `id` is not used in createGLContext, use `canvas` instead.

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #858
<!-- For other PRs without open issue -->
#### Background
I tested that the `canvas` property is the correct implementation and updated the docs. 
#### Change List
- Update documentation for AnimationLoop
