### PR TITLE
Remove excessive debug import

### DIFF
--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -1,4 +1,3 @@
-import '@luma.gl/debug';
 import {AnimationLoop, setParameters, pickModels, Cube, picking, dirlight} from 'luma.gl';
 import {Matrix4, radians} from 'math.gl';
 

--- a/website-old/contents/demos.js
+++ b/website-old/contents/demos.js
@@ -1,4 +1,3 @@
-import '@luma.gl/debug';
 import {setContextDefaults} from 'luma.gl';
 setContextDefaults({webgl2: true});
 


### PR DESCRIPTION
For #862 

Debug mode should be off in the website. This causes compatibility issues in older browsers.
