### PR TITLE
Fix `Accessor.type` to override buffer typed array

### DIFF
--- a/modules/core/src/core/attribute.js
+++ b/modules/core/src/core/attribute.js
@@ -52,9 +52,12 @@ export default class Attribute {
       this.externalBuffer = buffer;
       this.constant = false;
 
-      this.type = buffer.accessor.type;
+      this.type = opts.type || buffer.accessor.type;
       if (buffer.accessor.divisor !== undefined) {
         this.divisor = buffer.accessor.divisor;
+      }
+      if (opts.divisor !== undefined) {
+        this.divisor = opts.divisor;
       }
     } else if (value) {
       this.externalBuffer = null;

--- a/modules/core/src/webgl/classes/vertex-array.js
+++ b/modules/core/src/webgl/classes/vertex-array.js
@@ -30,6 +30,7 @@ export default class VertexArray {
 
     // Extracted information
     this.elements = null;
+    this.elementsAccessor = null;
     this.values = null;
     this.accessors = null;
     this.unused = null;
@@ -65,6 +66,7 @@ export default class VertexArray {
     // this.vertexArrayObject.reset();
 
     this.elements = null;
+    this.elementsAccessor = null;
     const {MAX_ATTRIBUTES} = this.vertexArrayObject;
     this.values = new Array(MAX_ATTRIBUTES).fill(null);
     this.accessors = new Array(MAX_ATTRIBUTES).fill(null);
@@ -132,6 +134,7 @@ export default class VertexArray {
   // Must be a Buffer bound to GL.ELEMENT_ARRAY_BUFFER. Constants not supported
   setElementBuffer(elementBuffer = null, accessor = {}) {
     this.elements = elementBuffer; // Save value for debugging
+    this.elementsAccessor = accessor;
     this.clearDrawParams();
 
     // Update vertexArray immediately if we have our own array
@@ -145,7 +148,7 @@ export default class VertexArray {
   setBuffer(locationOrName, buffer, appAccessor = {}) {
     // Check target
     if (buffer.target === GL.ELEMENT_ARRAY_BUFFER) {
-      return this.setElementBuffer(buffer);
+      return this.setElementBuffer(buffer, appAccessor);
     }
 
     const {location, accessor} = this._resolveLocationAndAccessor(
@@ -387,7 +390,7 @@ export default class VertexArray {
       // index type is saved for drawElement calls
       drawParams.elementCount = this.elements.getElementCount(this.elements.accessor);
       drawParams.isIndexed = true;
-      drawParams.indexType = this.elements.accessor.type;
+      drawParams.indexType = this.elementsAccessor.type || this.elements.accessor.type;
     }
 
     // Post-calculation checks


### PR DESCRIPTION
#### Background
https://github.com/uber/luma.gl/commit/234db05a9a6a5f176401e35a1d0238fe9e627381 gives us the ability to reuse a buffer with different accessors, however the accessor.type is overridden by the buffer.accessor.
