### PR TITLE
Fix submodule scripts

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -36,7 +36,8 @@
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
     "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
     "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
+    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",

--- a/modules/webgl-state-tracker/package.json
+++ b/modules/webgl-state-tracker/package.json
@@ -30,11 +30,7 @@
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
     "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
     "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
-    "cover": "../../scripts/test.sh cover",
-    "prepublishOnly": "npm run build",
-    "publish-prod": "npm run build && npm run test-fast && npm publish",
-    "publish-beta": "npm run build && npm run test-fast && npm publish --tag beta"
+    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",

--- a/modules/webgl2-polyfill/package.json
+++ b/modules/webgl2-polyfill/package.json
@@ -25,11 +25,7 @@
     "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
     "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
     "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
-    "cover": "../../scripts/test.sh cover",
-    "prepublishOnly": "npm run build",
-    "publish-prod": "npm run build && npm run test-fast && npm publish",
-    "publish-beta": "npm run build && npm run test-fast && npm publish --tag beta"
+    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",


### PR DESCRIPTION
#### Change List
- Submodule packages should not have cover and test scripts
- `prepublishOnly` is only needed if inline version string is used (called after lerna bumps the package version and before publishing)
