### PR TITLE
use "lightSources" in module parameters

### DIFF
--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -56,16 +56,15 @@ function getMaterialUniforms(material) {
 function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
   if (
     !(
-      'ambientLight' in opts ||
-      'pointLights' in opts ||
-      'directionalLights' in opts ||
+      'lightSources' in opts &&
       'material' in opts
     )
   ) {
     return {};
   }
 
-  const {ambientLight, pointLights, directionalLights, material} = opts;
+  const {ambientLight, pointLights, directionalLights} = opts.lightSources;
+  const {material} = opts;
   const hasLights =
     ambientLight ||
     (pointLights && pointLights.length > 0) ||


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
Better to wrap all the lights in the "lightSources" parameter
<!-- For all the PRs -->
#### Change List
- use "lightSources"
