### PR TITLE
Test-utils bug fixes

### DIFF
--- a/docs/api-reference/test-utils/snapshot-test-runner.md
+++ b/docs/api-reference/test-utils/snapshot-test-runner.md
@@ -70,6 +70,7 @@ Add one or a list of test cases. Each test case may contain the following fields
  
 * `name` (String) - name of the test case.
 * `goldenImage` (String) - path to the golden image, relative to the root where the node script is executed.
+* `timeout` (Number) - time to wait for this test case to resolve (by calling the `done` callback) before aborting, in milliseconds. If not provided, fallback to the shared option that is passed to `SnapshotTestRunner.run`.
 * `imageDiffOptions` (Object) - image diffing options for this test case. See "Image Diff Options" section below.
 * `onInitialize` (Function) - called once when the test case starts. Receives a single object that is the [AnimationLoop callback parameters](/docs/api-reference/core/animation-loop.md#callback-parameters). If this callback returns an object or a promise, the content that it resolves to will be passed to `onRender` and `onFinalize` later.
 * `onRender` (Function) - called every animation frame when the test case is running. Receives a single object that is the [AnimationLoop callback parameters](/docs/api-reference/core/animation-loop.md#callback-parameters), plus the following:

--- a/modules/test-utils/src/test-runner.js
+++ b/modules/test-utils/src/test-runner.js
@@ -73,7 +73,7 @@ export default class TestRunner {
       this.isDiffing = false;
       this._currentTestCase = null;
     }).catch(error => {
-      this.onTestFail(this._currentTestCase, {error: error.message});
+      this._fail({error: error.message});
     });
   }
 
@@ -96,8 +96,8 @@ export default class TestRunner {
   }
 
   assert(testCase) {
-    this.onTestPass(testCase);
-    this.next();
+    this._pass(testCase);
+    this._next();
   }
 
   /* Utilities */

--- a/modules/webgl2-polyfill/test/polyfill-context.spec.js
+++ b/modules/webgl2-polyfill/test/polyfill-context.spec.js
@@ -1,6 +1,6 @@
 import polyfillContext from '@luma.gl/webgl2-polyfill';
 import test from 'tape-catch';
-import {makeSpy} from 'probe.gl/test-utils';
+import {makeSpy} from '@probe.gl/test-utils';
 
 import {fixture} from 'luma.gl/test/setup';
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
     "@loaders.gl/gltf": "^0.6.2",
+    "@probe.gl/bench": "^3.0.0-alpha.3",
     "@probe.gl/test-utils": "^3.0.0-alpha.4",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.0",

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 /* eslint-disable no-console, no-invalid-this */
-import {Bench} from 'probe.gl/bench';
+import {Bench} from '@probe.gl/bench';
 
 import shadersBench from './shaders.bench';
 import uniformsBench from './uniforms.bench';

--- a/test/modules/core/webgl/features/features.spec.js
+++ b/test/modules/core/webgl/features/features.spec.js
@@ -1,6 +1,6 @@
 import {canCompileGLGSExtension, hasFeature, hasFeatures, getFeatures, FEATURES} from 'luma.gl';
 import test from 'tape-catch';
-import {makeSpy} from 'probe.gl/test-utils';
+import {makeSpy} from '@probe.gl/test-utils';
 
 import {fixture} from 'luma.gl/test/setup';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,6 +739,14 @@
   resolved "https://registry.yarnpkg.com/@luma.gl/glfx/-/glfx-6.3.0.tgz#08929e3488b58ddf339c6df0627282543d78c66a"
   integrity sha512-6k3hTQefv2Fawy+yEnsdqQDm7eCT5eIQ6Q4iA+WM6agmTpNaRCQw61sNJEjpZYYl3ppxR92wjHvObYzcUbVxNQ==
 
+"@probe.gl/bench@^3.0.0-alpha.3":
+  version "3.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@probe.gl/bench/-/bench-3.0.0-alpha.3.tgz#bea1dc7504bfdff117d4ef17bb0a05a110f251ab"
+  integrity sha512-6TKk7jschwe2lW7TwzMd3xviAFXp4fjWAeVUyyVncmw5nsF4fsb2zpZWR1i4on4PKFNBSc3vKVsp/wR5DPH2Ig==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    probe.gl "^3.0.0-alpha.3"
+
 "@probe.gl/test-utils@^3.0.0-alpha.4":
   version "3.0.0-alpha.4"
   resolved "https://registry.yarnpkg.com/@probe.gl/test-utils/-/test-utils-3.0.0-alpha.4.tgz#86d80115144f0d087f2816c1dd770722a7bc8406"


### PR DESCRIPTION
#### Change List
- Remove usage of deprecated methods
- Remove imports from deprecated `probe.gl/test-utils` (bundles puppeteer)
