### PR TITLE
Don't perserve the drawing buffer

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -141,7 +141,17 @@ This table lists parameter mapping between old and new function.
 
 ### Default Framebuffer
 
-The default framebuffer is no longer preserved between frames. If this functionality is required, draw to an offscreen framebuffer to preserve drawing results.
+The default framebuffer is no longer preserved between frames. For functionality that requires capturing the canvas, simply moving relevant code to the end of `onRender`, after all draw operations, should suffice. If not, default framebuffer contents can be preserved using the `glOptions` argument to the `AnimationLoop` constructor:
+
+```
+new AnimationLoop({
+  glOptions: {
+    preserveDrawingBuffer: true
+  }
+});
+```
+
+Please note that this may come with significant performance drops on some platforms.
 
 
 ## Upgrading from v5.3 to v6.0

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -139,6 +139,11 @@ This table lists parameter mapping between old and new function.
 | `opts.filter`     | `opts.filter` |
 
 
+### Default Framebuffer
+
+The default framebuffer is no longer preserved between frames. If this functionality is required, draw to an offscreen framebuffer to preserve drawing results.
+
+
 ## Upgrading from v5.3 to v6.0
 
 luma.gl v6.0 underwent a major API cleanup, resulting in a smaller, easier-to-learn API and smaller application bundles. While there are many smaller changes, the impact on most applications should be limited:

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -8,10 +8,6 @@ import assert from '../utils/assert';
 // TODO - remove dependency on webgl classes
 import {Framebuffer} from '../webgl';
 
-const DEFAULT_GL_OPTIONS = {
-  preserveDrawingBuffer: true
-};
-
 export default class AnimationLoop {
   /*
    * @param {HTMLCanvasElement} canvas - if provided, width and height will be passed to context
@@ -309,7 +305,7 @@ export default class AnimationLoop {
       opts.canvas instanceof OffscreenCanvas;
 
     // Create the WebGL context if necessary
-    opts = Object.assign({}, opts, DEFAULT_GL_OPTIONS, this.props.glOptions);
+    opts = Object.assign({}, opts, this.props.glOptions);
     this.gl = this.props.gl || this.onCreateContext(opts);
 
     if (!isWebGL(this.gl)) {


### PR DESCRIPTION
Per the WebGL spec (section 2.2): 

> While it is sometimes desirable to preserve the drawing buffer, it can cause significant performance loss on some platforms. Whenever possible this flag should remain false and other techniques used. 

It doesn't appear that we use the previous frame's contents for anything and @Pessimistress did some performance tests and found a non-trivial improvement.
