### PR TITLE
Frame timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `AnimationLoop` properties `cpuTime` and `gpuTime` track per-frame CPU and GPU execution time.
 - `Query.getResult` now returns raw query results. `Query.getTimerMilliseconds` can be used to retrieve timer results in milliseconds.
+- `Query.isTimerDisjoint` method now indicates if a timing query was disjoint (i.e. results are invalid).
 
 ## v7.0.0-alpha.12 - Feb 20, 2019
 - use "lightSources" in module parameters (#920)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 7.0 Pre-releases
 
+- `AnimationLoop` properties `cpuTime` and `gpuTime` track per-frame CPU and GPU execution time.
+- `Query.getResult` now returns raw query results. `Query.getTimerMilliseconds` can be used to retrieve timer results in milliseconds.
+
 ## v7.0.0-alpha.12 - Feb 20, 2019
 - use "lightSources" in module parameters (#920)
 - glTF: Add PBR debug options and ability to drag-and-drop GLB files (#914)

--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -110,7 +110,6 @@ Notes:
 * `autoResizeDrawingBuffer` - Update the drawing buffer size to match the canvas size before each call to `onRenderFrame()`
 * `useDevicePixels` - Whether to use `window.devicePixelRatio` as a multiplier, e.g. in `autoResizeDrawingBuffer` etc.
 
-
 ## Callback Parameters
 
 The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies to the `AnimationLoop`, will be called with an object containing named parameters:
@@ -132,6 +131,8 @@ The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies 
 | `_offScreen` | `Boolean` | (**experimental**) If the animation loop is rendering to an OffscreenCanvas. |
 | ...       | Any fields in the object that was returned by the `onInitialize` method. |
 
+### Frame timers
+* The animation loop tracks GPU and CPU render time of each frame the in member properties `cpuTime` and `gpuTime`. If `gpuTime` is set to `-1`, then the timing for the last frame was invalid ("disjoint") and should not be used.
 
 ## Remarks
 

--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -132,7 +132,7 @@ The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies 
 | ...       | Any fields in the object that was returned by the `onInitialize` method. |
 
 ### Frame timers
-* The animation loop tracks GPU and CPU render time of each frame the in member properties `cpuTime` and `gpuTime`. If `gpuTime` is set to `-1`, then the timing for the last frame was invalid ("disjoint") and should not be used.
+* The animation loop tracks GPU and CPU render time of each frame the in member properties `cpuTime` and `gpuTime`. If `gpuTime` is set to `-1`, then the timing for the last frame was invalid and should not be used (this rare and might occur, for example, if the GPU was throttled mid-frame).
 
 ## Remarks
 

--- a/docs/api-reference/webgl/query.md
+++ b/docs/api-reference/webgl/query.md
@@ -152,7 +152,14 @@ return {Boolean} - true if query result is available
 
 ### getResult
 
-Returns the query result, converted to milliseconds to match JavaScript conventions.
+Returns the query result
+
+return {Number} - query result. Semantics depend on query type
+
+
+### getTimerMilliseconds
+
+Shorthand for getting timer query results and converting to milliseconds to match JavaScript conventions.
 
 return {Number} - measured time or timestamp, in milliseconds
 

--- a/docs/api-reference/webgl/query.md
+++ b/docs/api-reference/webgl/query.md
@@ -163,6 +163,12 @@ Shorthand for getting timer query results and converting to milliseconds to matc
 
 return {Number} - measured time or timestamp, in milliseconds
 
+### isTimerDisjoint
+
+Returns `true` if the timer query was disjoint, indicating that timing results are invalid.
+This is rare and might occur, for example, if the GPU was throttled while timing.
+
+return {Boolean} - true if timer query was disjoint
 
 ## Remarks
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -153,6 +153,10 @@ new AnimationLoop({
 
 Please note that this may come with significant performance drops on some platforms.
 
+### Query Results
+
+Use `Query.getTimerMilliseconds` to retrieve timer results in milliseconds. `Query.getResult` now returns raw query results.
+
 
 ## Upgrading from v5.3 to v6.0
 

--- a/examples/core/dof/app.js
+++ b/examples/core/dof/app.js
@@ -512,9 +512,11 @@ class TimerElement {
   }
 
   update() {
-    this.cpuTime += this.timer.cpuTime;
-    this.gpuTime += this.timer.gpuTime;
-    ++this.frameCount;
+    if (this.timer.gpuTime !== -1) {
+      this.cpuTime += this.timer.cpuTime;
+      this.gpuTime += this.timer.gpuTime;
+      ++this.frameCount;
+    }
 
     if (this.frameCount === this.framesToUpdate) {
       this.cpuElement.innerText = (this.cpuTime / this.frameCount).toFixed(2) + "ms";

--- a/examples/core/dof/app.js
+++ b/examples/core/dof/app.js
@@ -7,7 +7,7 @@ import {Matrix4, radians} from 'math.gl';
 
 /*
   Based on: https://github.com/tsherif/picogl.js/blob/master/examples/dof.html
-  Origirnal algorithm: http://www.nutty.ca/?page_id=352&link=depth_of_field
+  Original algorithm: http://www.nutty.ca/?page_id=352&link=depth_of_field
 */
 
 const INFO_HTML = `

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -196,9 +196,11 @@ class TimerElement {
   }
 
   update() {
-    this.cpuTime += this.timer.cpuTime;
-    this.gpuTime += this.timer.gpuTime;
-    ++this.frameCount;
+    if (this.timer.gpuTime !== -1) {
+      this.cpuTime += this.timer.cpuTime;
+      this.gpuTime += this.timer.gpuTime;
+      ++this.frameCount;
+    }
 
     if (this.frameCount === this.framesToUpdate) {
       this.cpuElement.innerText = (this.cpuTime / this.frameCount).toFixed(2) + "ms";

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -9,6 +9,32 @@ A luma.gl <code>Cube</code>, rendering 65,536 instances in a
 single GPU draw call using instanced vertex attributes.
 `;
 
+const TIMER_HTML = `
+<div>
+  CPU Time: <span id="cpu-time"><span>
+</div>
+<div>
+  GPU Time: <span id="gpu-time"><span>
+</div>
+`;
+
+const timerElement = document.createElement('div');
+timerElement.innerHTML = TIMER_HTML;
+timerElement.style.position = 'absolute';
+timerElement.style.top = '20px';
+timerElement.style.left = '20px';
+timerElement.style.backgroundColor = 'white';
+timerElement.style.padding = '0.5em';
+
+document.body.appendChild(timerElement);
+
+const cpuElement = document.getElementById('cpu-time');
+const gpuElement = document.getElementById('gpu-time');
+let cpuTime = 0;
+let gpuTime = 0;
+let frameCount = 0;
+const FRAMES_TO_UPDATE = 60;
+
 const SIDE = 256;
 
 // Make a cube with 65K instances and attributes to control offset and color of each instance
@@ -135,6 +161,18 @@ class AppAnimationLoop extends AnimationLoop {
   }
 
   onRender(animationProps) {
+    cpuTime += this.cpuTime;
+    gpuTime += this.gpuTime;
+    ++frameCount;
+
+    if (frameCount === FRAMES_TO_UPDATE) {
+      cpuElement.innerText = (cpuTime / frameCount).toFixed(2) + "ms";
+      gpuElement.innerText = (gpuTime / frameCount).toFixed(2) + "ms";
+      cpuTime = 0;
+      gpuTime = 0;
+      frameCount = 0;
+    }
+
     const {gl, framebuffer, useDevicePixels, _mousePosition} = animationProps;
 
     // "Pick" the cube under the mouse

--- a/examples/core/mandelbrot/app.js
+++ b/examples/core/mandelbrot/app.js
@@ -142,9 +142,11 @@ class TimerElement {
   }
 
   update() {
-    this.cpuTime += this.timer.cpuTime;
-    this.gpuTime += this.timer.gpuTime;
-    ++this.frameCount;
+    if (this.timer.gpuTime !== -1) {
+      this.cpuTime += this.timer.cpuTime;
+      this.gpuTime += this.timer.gpuTime;
+      ++this.frameCount;
+    }
 
     if (this.frameCount === this.framesToUpdate) {
       this.cpuElement.innerText = (this.cpuTime / this.frameCount).toFixed(2) + "ms";

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -43,7 +43,7 @@
     "@luma.gl/webgl-state-tracker": "^7.0.0-alpha.11",
     "@luma.gl/webgl2-polyfill": "^7.0.0-alpha.11",
     "math.gl": "^2.2.0",
-    "probe.gl": "^2.0.1",
+    "probe.gl": "3.0.0-alpha.5",
     "seer": "^0.2.4"
   },
   "nyc": {

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -6,17 +6,13 @@ import {getPageLoadPromise} from '../webgl/context';
 import {isWebGL, requestAnimationFrame, cancelAnimationFrame} from '../webgl/utils';
 import {log} from '../utils';
 import assert from '../utils/assert';
-import {Stats} from 'probe.gl';
 import {Query} from '../webgl';
 
 // TODO - remove dependency on webgl classes
 import {Framebuffer} from '../webgl';
 
-const GL_GPU_DISJOINT_EXT = 0x8fbb; // Whether GPU performed any disjoint operation.
 const USE_PERFORMANCE = typeof performance !== 'undefined';
 const USE_HRTIME = typeof process !== 'undefined';
-
-let count = 0;
 
 // TODO - Remove when available from probe.gl
 function getHiResTimestamp() {

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -6,31 +6,13 @@ import {getPageLoadPromise} from '../webgl/context';
 import {isWebGL, requestAnimationFrame, cancelAnimationFrame} from '../webgl/utils';
 import {log} from '../utils';
 import assert from '../utils/assert';
-import {Stats} from 'probe.gl';
+import {Stats, getHiResTimestamp} from 'probe.gl';
 import {Query} from '../webgl';
 
 // TODO - remove dependency on webgl classes
 import {Framebuffer} from '../webgl';
 
-const USE_PERFORMANCE = typeof performance !== 'undefined';
-const USE_HRTIME = typeof process !== 'undefined';
 let statIdCounter = 0;
-
-// TODO - Remove when available from probe.gl
-function getHiResTimestamp() {
-  let timestamp;
-  // Get best timer available.
-  if (USE_PERFORMANCE) {
-    timestamp = performance.now();
-  } else if (USE_HRTIME) {
-    const timeParts = process.hrtime();
-    timestamp = timeParts[0] * 1000 + timeParts[1] / 1e6;
-  } else {
-    timestamp = Date.now();
-  }
-
-  return timestamp;
-}
 
 export default class AnimationLoop {
   /*
@@ -427,10 +409,12 @@ export default class AnimationLoop {
   }
 
   _beginTimers() {
-    if (this.gpuTimeQuery && this.gpuTimeQuery.queryPending) {
-      if (this.gpuTimeQuery.isResultAvailable() && !this.gpuTimeQuery.isTimerDisjoint()) {
-        this.gpuTime = this.gpuTimeQuery.getResult();
+    if (this.gpuTimeQuery && this.gpuTimeQuery.isResultAvailable()) {
+      if (!this.gpuTimeQuery.isTimerDisjoint()) {
         this.stats.addTime("GPU Time", this.gpuTime);
+        this.gpuTime = this.gpuTimeQuery.getTimerMilliseconds();
+      } else {
+        this.gpuTime = -1;
       }
     }
 

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -1,5 +1,4 @@
 /* global OffscreenCanvas */
-/* global performance, process */
 
 import {createGLContext, resizeGLContext, resetParameters} from '../webgl/context';
 import {getPageLoadPromise} from '../webgl/context';
@@ -409,15 +408,13 @@ export default class AnimationLoop {
   }
 
   _beginTimers() {
-
     // Check if timer for last frame has completed.
     // GPU timer results are never available in the same
     // frame they are captured.
     if (this.gpuTimeQuery && this.gpuTimeQuery.isResultAvailable()) {
-
       // A disjoint timer means the timing results are invalid.
       if (!this.gpuTimeQuery.isTimerDisjoint()) {
-        this.stats.addTime("GPU Time", this.gpuTime);
+        this.stats.addTime('GPU Time', this.gpuTime);
         this.gpuTime = this.gpuTimeQuery.getTimerMilliseconds();
       } else {
         // gpuTime === -1 indicates that previous gpu timing was invalid.
@@ -435,7 +432,7 @@ export default class AnimationLoop {
 
   _endTimers() {
     this.cpuTime = getHiResTimestamp() - this._cpuStartTime;
-    this.stats.addTime("CPU Time", this.cpuTime);
+    this.stats.addTime('CPU Time', this.cpuTime);
 
     if (this.gpuTimeQuery) {
       // GPU time query end. Results will be available on next frame.

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -409,16 +409,24 @@ export default class AnimationLoop {
   }
 
   _beginTimers() {
+
+    // Check if timer for last frame has completed.
+    // GPU timer results are never available in the same
+    // frame they are captured.
     if (this.gpuTimeQuery && this.gpuTimeQuery.isResultAvailable()) {
+
+      // A disjoint timer means the timing results are invalid.
       if (!this.gpuTimeQuery.isTimerDisjoint()) {
         this.stats.addTime("GPU Time", this.gpuTime);
         this.gpuTime = this.gpuTimeQuery.getTimerMilliseconds();
       } else {
+        // gpuTime === -1 indicates that previous gpu timing was invalid.
         this.gpuTime = -1;
       }
     }
 
-    if (this.gpuTimeQuery && !this.gpuTimeQuery.queryPending) {
+    if (this.gpuTimeQuery) {
+      // GPU time query start
       this.gpuTimeQuery.beginTimeElapsedQuery();
     }
 
@@ -429,7 +437,8 @@ export default class AnimationLoop {
     this.cpuTime = getHiResTimestamp() - this._cpuStartTime;
     this.stats.addTime("CPU Time", this.cpuTime);
 
-    if (this.gpuTimeQuery && !this.gpuTimeQuery.queryPending) {
+    if (this.gpuTimeQuery) {
+      // GPU time query end. Results will be available on next frame.
       this.gpuTimeQuery.end();
     }
   }

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -1,18 +1,19 @@
 /* global OffscreenCanvas */
+/* global performance, process */
+
 import {createGLContext, resizeGLContext, resetParameters} from '../webgl/context';
 import {getPageLoadPromise} from '../webgl/context';
 import {isWebGL, requestAnimationFrame, cancelAnimationFrame} from '../webgl/utils';
 import {log} from '../utils';
 import assert from '../utils/assert';
-import {Stats} from 'probe.gl';
 import {Query} from '../webgl';
 
 // TODO - remove dependency on webgl classes
 import {Framebuffer} from '../webgl';
 
 const GL_GPU_DISJOINT_EXT = 0x8fbb; // Whether GPU performed any disjoint operation.
-const USE_PERFORMANCE = (typeof performance !== "undefined");
-const USE_HRTIME = (typeof process !== "undefined");
+const USE_PERFORMANCE = typeof performance !== 'undefined';
+const USE_HRTIME = typeof process !== 'undefined';
 
 // TODO - Remove when available from probe.gl
 function getHiResTimestamp() {
@@ -171,7 +172,6 @@ export default class AnimationLoop {
 
   // Redraw now
   redraw() {
-
     this._beginTimers();
 
     this._setupFrame();

--- a/modules/core/src/scenegraph/base-model.js
+++ b/modules/core/src/scenegraph/base-model.js
@@ -421,7 +421,7 @@ export default class BaseModel extends ScenegraphNode {
       // should this be incorporated into Query object?
       if (this.timeElapsedQuery.isResultAvailable()) {
         this.lastQueryReturned = true;
-        const elapsedTime = this.timeElapsedQuery.getResult();
+        const elapsedTime = this.timeElapsedQuery.getTimerMilliseconds();
 
         // Update stats (e.g. for seer)
         this.stats.lastFrameTime = elapsedTime;

--- a/modules/core/src/scenegraph/model.js
+++ b/modules/core/src/scenegraph/model.js
@@ -253,7 +253,7 @@ export default class Model extends BaseModel {
       // should this be incorporated into Query object?
       if (this.timeElapsedQuery.isResultAvailable()) {
         this.lastQueryReturned = true;
-        const elapsedTime = this.timeElapsedQuery.getResult();
+        const elapsedTime = this.timeElapsedQuery.getTimerMilliseconds();
 
         // Update stats (e.g. for seer)
         this.stats.lastFrameTime = elapsedTime;

--- a/modules/core/src/webgl/classes/query.js
+++ b/modules/core/src/webgl/classes/query.js
@@ -62,6 +62,7 @@ export default class Query extends Resource {
     const {onComplete = noop, onError = noop} = opts;
 
     this.target = null;
+    this.queryPending = false;
     this.onComplete = onComplete;
     this.onError = onError;
 
@@ -126,6 +127,7 @@ export default class Query extends Resource {
     if (this.target) {
       this.gl.endQuery(this.target);
       this.target = null;
+      this.queryPending = true;
     }
     return this;
   }
@@ -139,7 +141,15 @@ export default class Query extends Resource {
 
   // Returns true if the query result is available
   isResultAvailable() {
-    return this.gl.getQueryParameter(this.handle, GL_QUERY_RESULT_AVAILABLE);
+    const resultAvailable = this.gl.getQueryParameter(this.handle, GL_QUERY_RESULT_AVAILABLE);
+    if (resultAvailable) {
+      this.queryPending = false;
+    }
+    return resultAvailable;
+  }
+
+  isTimerDisjoint() {
+    return this.gl.getParameter(GL_GPU_DISJOINT_EXT);
   }
 
   // Returns the query result, converted to milliseconds to match JavaScript conventions.

--- a/modules/core/src/webgl/classes/query.js
+++ b/modules/core/src/webgl/classes/query.js
@@ -141,6 +141,10 @@ export default class Query extends Resource {
 
   // Returns true if the query result is available
   isResultAvailable() {
+    if (!this.queryPending) {
+      return false;
+    }
+
     const resultAvailable = this.gl.getQueryParameter(this.handle, GL_QUERY_RESULT_AVAILABLE);
     if (resultAvailable) {
       this.queryPending = false;
@@ -152,11 +156,13 @@ export default class Query extends Resource {
     return this.gl.getParameter(GL_GPU_DISJOINT_EXT);
   }
 
-  // Returns the query result, converted to milliseconds to match JavaScript conventions.
-  // TODO - what about non-timer queries
   getResult() {
-    const result = this.gl.getQueryParameter(this.handle, GL_QUERY_RESULT);
-    return Number.isFinite(result) ? result / 1e6 : 0;
+    return this.gl.getQueryParameter(this.handle, GL_QUERY_RESULT);
+  }
+
+  // Returns the query result, converted to milliseconds to match JavaScript conventions.
+  getTimerMilliseconds() {
+    return this.getResult() / 1e6;
   }
 
   static poll(gl) {

--- a/modules/core/src/webgl/classes/query.js
+++ b/modules/core/src/webgl/classes/query.js
@@ -108,6 +108,11 @@ export default class Query extends Resource {
   // outstanding queries representing disjoint `begin()`/`end()` intervals.
   // It is not possible to interleave or overlap `begin` and `end` calls.
   begin(target) {
+    // Don't start a new query if one is already active.
+    if (this.queryPending) {
+      return this;
+    }
+
     // - Triggering a new query when a Query is already tracking an
     //   unresolved query causes that query to be cancelled.
     queryManager.beginQuery(this, this.onComplete, this.onError);
@@ -123,6 +128,11 @@ export default class Query extends Resource {
 
   // ends the current query
   end() {
+    // Can't end a new query if the last one hasn't been resolved.
+    if (this.queryPending) {
+      return this;
+    }
+
     // Note: calling end does not affect the pending promise
     if (this.target) {
       this.gl.endQuery(this.target);

--- a/modules/core/src/webgl/classes/query.js
+++ b/modules/core/src/webgl/classes/query.js
@@ -162,10 +162,12 @@ export default class Query extends Resource {
     return resultAvailable;
   }
 
+  // Timing query is disjoint, i.e. results are invalid
   isTimerDisjoint() {
     return this.gl.getParameter(GL_GPU_DISJOINT_EXT);
   }
 
+  // Returns query result.
   getResult() {
     return this.gl.getQueryParameter(this.handle, GL_QUERY_RESULT);
   }

--- a/modules/core/src/wip/mesh-model.js
+++ b/modules/core/src/wip/mesh-model.js
@@ -552,7 +552,7 @@ export default class MeshModel extends Node {
       // should this be incorporated into Query object?
       if (this.timeElapsedQuery.isResultAvailable()) {
         this.lastQueryReturned = true;
-        const elapsedTime = this.timeElapsedQuery.getResult();
+        const elapsedTime = this.timeElapsedQuery.getTimerMilliseconds();
 
         // Update stats (e.g. for seer)
         this.stats.lastFrameTime = elapsedTime;

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,12 +740,12 @@
   integrity sha512-6k3hTQefv2Fawy+yEnsdqQDm7eCT5eIQ6Q4iA+WM6agmTpNaRCQw61sNJEjpZYYl3ppxR92wjHvObYzcUbVxNQ==
 
 "@probe.gl/bench@^3.0.0-alpha.3":
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@probe.gl/bench/-/bench-3.0.0-alpha.3.tgz#bea1dc7504bfdff117d4ef17bb0a05a110f251ab"
-  integrity sha512-6TKk7jschwe2lW7TwzMd3xviAFXp4fjWAeVUyyVncmw5nsF4fsb2zpZWR1i4on4PKFNBSc3vKVsp/wR5DPH2Ig==
+  version "3.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@probe.gl/bench/-/bench-3.0.0-alpha.5.tgz#e53433566d84a4226c797468126efa0bc40d11f4"
+  integrity sha512-hiw+d3cwK8dOKBYvLlDxsBF00hxfiEqMfQlp/P17vadLdhtmbKsANfQCmjhMez+yJzsctptL11soaFDh8tJ3lA==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    probe.gl "^3.0.0-alpha.3"
+    probe.gl "^3.0.0-alpha.5"
 
 "@probe.gl/test-utils@^3.0.0-alpha.4":
   version "3.0.0-alpha.4"
@@ -6188,6 +6188,13 @@ private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
+
+probe.gl@3.0.0-alpha.5, probe.gl@^3.0.0-alpha.5:
+  version "3.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-3.0.0-alpha.5.tgz#0e79879fa0c3977da3ced90e3276503364d42fa3"
+  integrity sha512-CH/IJWw80KQkDD4TU+YmrtmALNDsGyxaNJAu/LqkCsgZ+0JQf75XUJ1D97FN8aRKb08Nc8fkHOMYbIXbUMW49A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
 
 probe.gl@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
#### Background
Add CPU and GPU timers to AnimationLoop.
#### Change List
- Add `cpuTime` and `gpuTime` properties to `AnimationLoop`. These will be updated each frame with the time spend on the cpu and gpu each frame.
- Track these times in a probe.gl `Stats` instance.
- Update `Query` to track when a query is in progress.
- Add frame time widget to Instancing, DOF and Mandelbrot examples.

Note that I'd like to move the following functionality into probe.gl:
- All tracking of times. The Stats class in probe.gl is currently tightly tied to FPS measurements.
- The TimerElement I created in the examples should be replaced with StatsWidget from probe.gl. The latter class currently only displays FPS.
- The hiResTimestamp function in AnimationLoop should be replace with the one from probe.gl once the latter is live.