### PR TITLE
Don't create no-op Promises for queries

### DIFF
--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -66,8 +66,6 @@ export default class AnimationLoop {
     this.cpuTime = 0;
     this.gpuTime = 0;
 
-
-
     this._initialized = false;
     this._running = false;
     this._animationFrameId = null;

--- a/modules/core/src/webgl/classes/query.js
+++ b/modules/core/src/webgl/classes/query.js
@@ -5,8 +5,6 @@ import {isWebGL2} from '../utils';
 import queryManager from '../utils/query-manager';
 import {assert} from '../../utils';
 
-const noop = x => x;
-
 const ERR_GPU_DISJOINT = 'Disjoint GPU operation invalidated timer queries';
 const ERR_TIMER_QUERY_NOT_SUPPORTED = 'Timer queries require "EXT_disjoint_timer_query" extension';
 
@@ -59,7 +57,7 @@ export default class Query extends Resource {
   constructor(gl, opts = {}) {
     super(gl, opts);
 
-    const {onComplete = noop, onError = noop} = opts;
+    const {onComplete = null, onError = null} = opts;
 
     this.target = null;
     this.queryPending = false;

--- a/modules/core/src/webgl/utils/query-manager.js
+++ b/modules/core/src/webgl/utils/query-manager.js
@@ -70,7 +70,6 @@ class QueryManager {
       });
       Object.assign(query.promise, resolvers);
 
-
       // Register the callbacks
       query.promise.then(onComplete).catch(onError);
     }

--- a/modules/core/src/webgl/utils/query-manager.js
+++ b/modules/core/src/webgl/utils/query-manager.js
@@ -14,8 +14,6 @@
 const ERR_DELETED = 'Query was deleted before result was available';
 const ERR_CANCEL = 'Query was canceled before result was available';
 
-const noop = x => x;
-
 class QueryManager {
   constructor() {
     this.pendingQueries = new Set();
@@ -51,7 +49,7 @@ class QueryManager {
   }
 
   // Starts a query, sets up a new promise
-  beginQuery(query, onComplete = noop, onError = noop) {
+  beginQuery(query, onComplete, onError) {
     // Make sure disjoint state is cleared, so that this query starts fresh
     // Cancel other queries if needed
     this.cancelInvalidQueries(query.gl);
@@ -59,18 +57,23 @@ class QueryManager {
     // Cancel current promise - noop if already resolved or rejected
     this.cancelQuery(query);
 
-    // Create a new promise with attached resolve and reject methods
-    const resolvers = {};
-    query.promise = new Promise((resolve, reject) => {
-      resolvers.resolve = resolve;
-      resolvers.reject = reject;
-    });
-    Object.assign(query.promise, resolvers);
-
     // Add this query to the pending queries
     this.pendingQueries.add(query);
-    // Register the callbacks
-    return query.promise.then(onComplete).catch(onError);
+
+    // Create a new promise with attached resolve and reject methods
+
+    if (onComplete || onError) {
+      const resolvers = {};
+      query.promise = new Promise((resolve, reject) => {
+        resolvers.resolve = resolve;
+        resolvers.reject = reject;
+      });
+      Object.assign(query.promise, resolvers);
+
+
+      // Register the callbacks
+      query.promise.then(onComplete).catch(onError);
+    }
   }
 
   // Resolves a query with a result


### PR DESCRIPTION
Beginning a query was instantiating a Promise object whether callbacks were provided or not. This caused a performance hit as well as unnecessary memory allocations. Promises are now only created if callbacks are actually provided to the Query constructor. Improves performance of `Query.begin` on my machine from ~170us to ~50us. 

As an aside, I'm not sure associating Promises with queries is really useful, and perhaps we should consider deprecating that functionality. It seems less clear to me to have result-handling code defined at the point of query creation, rather than at the point where the results are retrieved.