### PR TITLE
Ensure that externally created contexts are polyfilled, tracked

### DIFF
--- a/examples/core/dof/app.js
+++ b/examples/core/dof/app.js
@@ -379,8 +379,8 @@ export const animationLoopOptions = {
     const statsWidget = new StatsWidget(_animationLoop.stats, {
       containerStyle: 'position: absolute;top: 20px;left: 20px;'
     });
-    statsWidget.setFormatter('CPU Time', stat => `CPU Time: ${stat.getAverageTime().toFixed(2)}`);
-    statsWidget.setFormatter('GPU Time', stat => `GPU Time: ${stat.getAverageTime().toFixed(2)}`);
+    statsWidget.setFormatter('CPU Time', stat => `CPU Time: ${stat.getAverageTime().toFixed(2)}ms`);
+    statsWidget.setFormatter('GPU Time', stat => `GPU Time: ${stat.getAverageTime().toFixed(2)}ms`);
     statsWidget.setFormatter('Frame Rate', stat => `Frame Rate: ${stat.getHz().toFixed(2)}fps`);
 
     return {

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -137,8 +137,8 @@ class AppAnimationLoop extends AnimationLoop {
     const statsWidget = new StatsWidget(this.stats, {
       containerStyle: 'position: absolute;top: 20px;left: 20px;'
     });
-    statsWidget.setFormatter('CPU Time', stat => `CPU Time: ${stat.getAverageTime().toFixed(2)}`);
-    statsWidget.setFormatter('GPU Time', stat => `GPU Time: ${stat.getAverageTime().toFixed(2)}`);
+    statsWidget.setFormatter('CPU Time', stat => `CPU Time: ${stat.getAverageTime().toFixed(2)}ms`);
+    statsWidget.setFormatter('GPU Time', stat => `GPU Time: ${stat.getAverageTime().toFixed(2)}ms`);
     statsWidget.setFormatter('Frame Rate', stat => `Frame Rate: ${stat.getHz().toFixed(2)}fps`);
 
     return {statsWidget};

--- a/examples/core/mandelbrot/app.js
+++ b/examples/core/mandelbrot/app.js
@@ -101,8 +101,8 @@ const animationLoop = new AnimationLoop({
     const statsWidget = new StatsWidget(_animationLoop.stats, {
       containerStyle: 'position: absolute;top: 20px;left: 20px;'
     });
-    statsWidget.setFormatter('CPU Time', stat => `CPU Time: ${stat.getAverageTime().toFixed(2)}`);
-    statsWidget.setFormatter('GPU Time', stat => `GPU Time: ${stat.getAverageTime().toFixed(2)}`);
+    statsWidget.setFormatter('CPU Time', stat => `CPU Time: ${stat.getAverageTime().toFixed(2)}ms`);
+    statsWidget.setFormatter('GPU Time', stat => `GPU Time: ${stat.getAverageTime().toFixed(2)}ms`);
     statsWidget.setFormatter('Frame Rate', stat => `Frame Rate: ${stat.getHz().toFixed(2)}fps`);
 
     return {

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -2,7 +2,7 @@
 
 import {
   createGLContext,
-  getTooledContext,
+  instrumentGLContext,
   resizeGLContext,
   resetParameters
 } from '../webgl/context';
@@ -351,7 +351,7 @@ export default class AnimationLoop {
 
     // Create the WebGL context if necessary
     opts = Object.assign({}, opts, this.props.glOptions);
-    this.gl = this.props.gl ? getTooledContext(this.props.gl, opts) : this.onCreateContext(opts);
+    this.gl = this.props.gl ? instrumentGLContext(this.props.gl, opts) : this.onCreateContext(opts);
 
     if (!isWebGL(this.gl)) {
       throw new Error('AnimationLoop.onCreateContext - illegal context returned');

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -345,8 +345,8 @@ export default class AnimationLoop {
       opts.canvas instanceof OffscreenCanvas;
 
     // Create the WebGL context if necessary
-    opts = Object.assign({}, opts, this.props.glOptions);
-    this.gl = this.props.gl || this.onCreateContext(opts);
+    opts = Object.assign({ gl: this.props.gl }, opts, this.props.glOptions);
+    this.gl = this.onCreateContext(opts);
 
     if (!isWebGL(this.gl)) {
       throw new Error('AnimationLoop.onCreateContext - illegal context returned');

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -350,7 +350,7 @@ export default class AnimationLoop {
       opts.canvas instanceof OffscreenCanvas;
 
     // Create the WebGL context if necessary
-    opts = Object.assign({gl: this.props.gl}, opts, this.props.glOptions);
+    opts = Object.assign({}, opts, this.props.glOptions);
     this.gl = this.props.gl ? getTooledContext(this.props.gl) : this.onCreateContext(opts);
 
     if (!isWebGL(this.gl)) {

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -351,7 +351,7 @@ export default class AnimationLoop {
 
     // Create the WebGL context if necessary
     opts = Object.assign({}, opts, this.props.glOptions);
-    this.gl = this.props.gl ? getTooledContext(this.props.gl) : this.onCreateContext(opts);
+    this.gl = this.props.gl ? getTooledContext(this.props.gl, opts) : this.onCreateContext(opts);
 
     if (!isWebGL(this.gl)) {
       throw new Error('AnimationLoop.onCreateContext - illegal context returned');

--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -1,6 +1,11 @@
 /* global OffscreenCanvas */
 
-import {createGLContext, resizeGLContext, resetParameters} from '../webgl/context';
+import {
+  createGLContext,
+  getTooledContext,
+  resizeGLContext,
+  resetParameters
+} from '../webgl/context';
 import {getPageLoadPromise} from '../webgl/context';
 import {isWebGL, requestAnimationFrame, cancelAnimationFrame} from '../webgl/utils';
 import {log} from '../utils';
@@ -345,8 +350,8 @@ export default class AnimationLoop {
       opts.canvas instanceof OffscreenCanvas;
 
     // Create the WebGL context if necessary
-    opts = Object.assign({ gl: this.props.gl }, opts, this.props.glOptions);
-    this.gl = this.onCreateContext(opts);
+    opts = Object.assign({gl: this.props.gl}, opts, this.props.glOptions);
+    this.gl = this.props.gl ? getTooledContext(this.props.gl) : this.onCreateContext(opts);
 
     if (!isWebGL(this.gl)) {
       throw new Error('AnimationLoop.onCreateContext - illegal context returned');

--- a/modules/core/src/webgl/context/context.js
+++ b/modules/core/src/webgl/context/context.js
@@ -77,7 +77,7 @@ export function setContextDefaults(opts = {}) {
 /* eslint-disable complexity, max-statements */
 export function createGLContext(opts = {}) {
   opts = Object.assign({}, contextDefaults, opts);
-  const {canvas, width, height, throwOnError, manageState, debug} = opts;
+  const {canvas, width, height, throwOnError} = opts;
 
   // Error reporting function, enables exceptions to be disabled
   function onError(message) {
@@ -87,23 +87,33 @@ export function createGLContext(opts = {}) {
     return null;
   }
 
-  let gl = opts.gl;
-
-  if (!gl) {
-    if (isBrowser) {
-      // Get or create a canvas
-      const targetCanvas = getCanvas({canvas, width, height, onError});
-      // Create a WebGL context in the canvas
-      gl = createBrowserContext({canvas: targetCanvas, opts});
-    } else {
-      // Create a headless-gl context under Node.js
-      gl = createHeadlessContext({width, height, opts, onError});
-    }
+  let gl;
+  if (isBrowser) {
+    // Get or create a canvas
+    const targetCanvas = getCanvas({canvas, width, height, onError});
+    // Create a WebGL context in the canvas
+    gl = createBrowserContext({canvas: targetCanvas, opts});
+  } else {
+    // Create a headless-gl context under Node.js
+    gl = createHeadlessContext({width, height, opts, onError});
   }
 
   if (!gl) {
     return null;
   }
+
+  gl = getTooledContext(gl);
+
+  // Log some debug info about the newly created context
+  logInfo(gl);
+
+  // Add to seer integration
+  return gl;
+}
+
+export function getTooledContext(gl, opts = {}) {
+  opts = Object.assign({}, contextDefaults, opts);
+  const {manageState, debug} = opts;
 
   // Install context state tracking
   if (manageState) {
@@ -124,10 +134,6 @@ export function createGLContext(opts = {}) {
     }
   }
 
-  // Log some debug info about the newly created context
-  logInfo(gl);
-
-  // Add to seer integration
   return gl;
 }
 

--- a/modules/core/src/webgl/context/context.js
+++ b/modules/core/src/webgl/context/context.js
@@ -102,7 +102,7 @@ export function createGLContext(opts = {}) {
     return null;
   }
 
-  gl = getTooledContext(gl);
+  gl = instrumentGLContext(gl);
 
   // Log some debug info about the newly created context
   logInfo(gl);
@@ -111,7 +111,7 @@ export function createGLContext(opts = {}) {
   return gl;
 }
 
-export function getTooledContext(gl, opts = {}) {
+export function instrumentGLContext(gl, opts = {}) {
   opts = Object.assign({}, contextDefaults, opts);
   const {manageState, debug} = opts;
 

--- a/modules/core/src/webgl/context/context.js
+++ b/modules/core/src/webgl/context/context.js
@@ -87,16 +87,20 @@ export function createGLContext(opts = {}) {
     return null;
   }
 
-  let gl;
-  if (isBrowser) {
-    // Get or create a canvas
-    const targetCanvas = getCanvas({canvas, width, height, onError});
-    // Create a WebGL context in the canvas
-    gl = createBrowserContext({canvas: targetCanvas, opts});
-  } else {
-    // Create a headless-gl context under Node.js
-    gl = createHeadlessContext({width, height, opts, onError});
+  let gl = opts.gl;
+
+  if (!gl) {
+    if (isBrowser) {
+      // Get or create a canvas
+      const targetCanvas = getCanvas({canvas, width, height, onError});
+      // Create a WebGL context in the canvas
+      gl = createBrowserContext({canvas: targetCanvas, opts});
+    } else {
+      // Create a headless-gl context under Node.js
+      gl = createHeadlessContext({width, height, opts, onError});
+    }
   }
+
   if (!gl) {
     return null;
   }

--- a/modules/core/src/webgl/context/index.js
+++ b/modules/core/src/webgl/context/index.js
@@ -11,7 +11,7 @@ export {
 
 export {
   createGLContext,
-  getTooledContext,
+  instrumentGLContext,
   destroyGLContext,
   resizeGLContext,
   setContextDefaults

--- a/modules/core/src/webgl/context/index.js
+++ b/modules/core/src/webgl/context/index.js
@@ -9,6 +9,12 @@ export {
   getModifiedParameters
 } from '@luma.gl/webgl-state-tracker';
 
-export {createGLContext, destroyGLContext, resizeGLContext, setContextDefaults} from './context';
+export {
+  createGLContext,
+  getTooledContext,
+  destroyGLContext,
+  resizeGLContext,
+  setContextDefaults
+} from './context';
 
 export {getPageLoadPromise, getCanvas} from './create-canvas';


### PR DESCRIPTION
Ensure that context polyfills always occur, even if an external context is provided. This was only happening accidentally, if `withParameters` happened to be called while rendering a scene.
