### PR TITLE
Move waitForRender resolve into core render loop. Use for toDataURL

### DIFF
--- a/modules/core/src/core/animation-loop.js
+++ b/modules/core/src/core/animation-loop.js
@@ -210,8 +210,10 @@ export default class AnimationLoop {
     return this._nextFramePromise;
   }
 
-  toDataURL() {
-    return this.waitForRender().then(self => self.gl.canvas.toDataURL());
+  async toDataURL() {
+    await this.waitForRender();
+
+    return this.gl.canvas.toDataURL();
   }
 
   onCreateContext(...args) {


### PR DESCRIPTION
Clean up `toDataURL` based on @rolyatmax's new `waitForRender` method, and move `waitForRender` resolution into core render loop so the resolution counts toward frame time.


