### PR TITLE
Models don't create buffers

### DIFF
--- a/docs/api-reference/core/model.md
+++ b/docs/api-reference/core/model.md
@@ -331,7 +331,7 @@ Use a `Geometry` instance to define attribute buffers
 
 ### setAttributes(attributes : Object) : Model
 
-Sets map of attributes
+Sets map of attributes (passes through to [VertexArray.setAttributes](/docs/api-reference/webgl/vertex-array.md))
 
 
 ## Remarks

--- a/docs/api-reference/core/model.md
+++ b/docs/api-reference/core/model.md
@@ -54,7 +54,7 @@ const model =  new Model(gl, {
   uniforms: {uSampler: texture},
   attributes: {
     attributeName1: bufferObject,
-    attributeName2: {data: new Float32Array(...), size: 3, type: GL.FLOAT} // new buffer object will be constructed
+    attributeName2: [new Buffer(gl, new Float32Array(...)), {size: 3, type: GL.FLOAT}]
   }
   drawMode: gl.TRIANGLE_FAN,
   vertexCount: 3,
@@ -119,7 +119,7 @@ model.draw({
 
 ## Properties
 
-`Model` extends the `ScenegraphNode` class and inherits the transformation matrix properties from that class.
+`Model` extends the `BaseModel` class and inherits all properties from that class.
 
 
 ### moduleSettings : Object
@@ -326,12 +326,12 @@ How many instances will be rendered
 
 ### setGeometry() : Model
 
-Get model's `Geometry` instance
+Use a `Geometry` instance to define attribute buffers
 
 
 ### setAttributes(attributes : Object) : Model
 
-Sets map of attributes (Attribute instances)
+Sets map of attributes
 
 
 ## Remarks

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -5,7 +5,8 @@ import {
   picking,
   dirlight,
   lumaStats,
-  readPixelsToArray
+  readPixelsToArray,
+  Buffer
 } from '@luma.gl/core';
 import {Matrix4, radians} from 'math.gl';
 import {StatsWidget} from '@probe.gl/stats-widget';
@@ -88,6 +89,10 @@ void main(void) {
 }
 `;
 
+    const offsetsBuffer = new Buffer(gl, offsets);
+    const colorsBuffer = new Buffer(gl, colors);
+    const pickingColorsBuffer = new Buffer(gl, pickingColors);
+
     super(
       gl,
       Object.assign({}, props, {
@@ -97,10 +102,10 @@ void main(void) {
         isInstanced: 1,
         instanceCount: SIDE * SIDE,
         attributes: {
-          instanceSizes: {value: new Float32Array([1]), divisor: 1, constant: true},
-          instanceOffsets: {value: offsets, divisor: 1},
-          instanceColors: {value: colors, divisor: 1},
-          instancePickingColors: {value: pickingColors, divisor: 1}
+          instanceSizes: new Float32Array([1]),
+          instanceOffsets: [offsetsBuffer, {divisor: 1}],
+          instanceColors: [colorsBuffer, {divisor: 1}],
+          instancePickingColors: [pickingColorsBuffer, {divisor: 1}]
         }
       })
     );

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -102,7 +102,7 @@ void main(void) {
         isInstanced: 1,
         instanceCount: SIDE * SIDE,
         attributes: {
-          instanceSizes: new Float32Array([1]),
+          instanceSizes: new Float32Array([1]), // Constant attribute
           instanceOffsets: [offsetsBuffer, {divisor: 1}],
           instanceColors: [colorsBuffer, {divisor: 1}],
           instancePickingColors: [pickingColorsBuffer, {divisor: 1}]

--- a/examples/core/instancing/package.json
+++ b/examples/core/instancing/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@luma.gl/core": "7.0.0-alpha",
-    "@probe.gl/stats-widget": "^3.0.0-alpha.3",
+    "@probe.gl/stats-widget": "^3.0.0-alpha.7",
     "math.gl": "^2.3.1"
   },
   "devDependencies": {

--- a/examples/core/mandelbrot/app.js
+++ b/examples/core/mandelbrot/app.js
@@ -1,4 +1,4 @@
-import {AnimationLoop, ClipSpace} from '@luma.gl/core';
+import {AnimationLoop, ClipSpace, Buffer} from '@luma.gl/core';
 import {StatsWidget} from '@probe.gl/stats-widget';
 
 const INFO_HTML = `
@@ -112,24 +112,28 @@ const animationLoop = new AnimationLoop({
       }
     });
 
+    const cornersBuffer = new Buffer(gl, 32);
+
     return {
-      clipSpace: new ClipSpace(gl, {fs: MANDELBROT_FRAGMENT_SHADER}),
+      clipSpace: new ClipSpace(gl, {
+        fs: MANDELBROT_FRAGMENT_SHADER,
+        attributes: {
+          aCoordinate: [cornersBuffer, {size: 2}]
+        }
+      }),
+      cornersBuffer,
       statsWidget
     };
   },
 
-  onRender: ({gl, canvas, tick, clipSpace, statsWidget}) => {
+  onRender: ({gl, canvas, tick, clipSpace, statsWidget, cornersBuffer}) => {
     statsWidget.update();
 
     gl.viewport(0, 0, Math.max(canvas.width, canvas.height), Math.max(canvas.width, canvas.height));
 
-    // Feed in new extents every draw
-    const corners = getZoomedCorners();
-    clipSpace.draw({
-      attributes: {
-        aCoordinate: {value: new Float32Array(corners), size: 2}
-      }
-    });
+    cornersBuffer.setData(new Float32Array(getZoomedCorners()));
+
+    clipSpace.draw();
   }
 });
 

--- a/examples/core/mandelbrot/package.json
+++ b/examples/core/mandelbrot/package.json
@@ -4,7 +4,8 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open -d"
   },
   "dependencies": {
-    "@luma.gl/core": "^7.0.0-alpha"
+    "@luma.gl/core": "^7.0.0-alpha",
+    "@probe.gl/stats-widget": "^3.0.0-alpha.7"
   },
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -197,9 +197,10 @@ const animationLoop = new AnimationLoop({
     }
 
     const positionBuffer = new Buffer(gl, trianglePositions);
-    const colorBuffer = new Buffer(gl, {data: instanceColors, accessor: {divisor: 1}});
-    const offsetBuffer = new Buffer(gl, {data: instanceOffsets, accessor: {divisor: 1}});
-    const rotationBuffer = new Buffer(gl, {data: instanceRotations, accessor: {divisor: 1}});
+    const colorBuffer = new Buffer(gl, instanceColors);
+    const offsetBuffer = new Buffer(gl, instanceOffsets);
+    const rotationBuffer = new Buffer(gl, instanceRotations);
+    const pickingColorBuffer = new Buffer(gl, pickingColors);
 
     const renderModel = new Model(gl, {
       id: 'RenderModel',
@@ -211,10 +212,10 @@ const animationLoop = new AnimationLoop({
       instanceCount: NUM_INSTANCES,
       attributes: {
         a_position: positionBuffer,
-        a_color: colorBuffer,
-        a_offset: offsetBuffer,
-        a_rotation: rotationBuffer,
-        instancePickingColors: {value: pickingColors, accessor: {divisor: 1}}
+        a_color: [colorBuffer, {divisor: 1}],
+        a_offset: [offsetBuffer, {divisor: 1}],
+        a_rotation: [rotationBuffer, {divisor: 1}],
+        instancePickingColors: [pickingColorBuffer, {divisor: 1}]
       },
       modules: [picking]
     });
@@ -288,12 +289,14 @@ const animationLoop = new AnimationLoop({
     offsetBuffer.updateAccessor({divisor: 0});
     rotationBuffer.updateAccessor({divisor: 0});
 
-    const dpr = useDevicePixels ? getDevicePixelRatio() : 1;
+    if (pickPosition) {
+      const dpr = useDevicePixels ? getDevicePixelRatio() : 1;
 
-    const pickX = pickPosition[0] * dpr;
-    const pickY = gl.canvas.height - pickPosition[1] * dpr;
+      const pickX = pickPosition[0] * dpr;
+      const pickY = gl.canvas.height - pickPosition[1] * dpr;
 
-    pickInstance(gl, pickX, pickY, renderModel, framebuffer);
+      pickInstance(gl, pickX, pickY, renderModel, framebuffer);
+    }
   },
 
   onFinalize({renderModel, transform}) {

--- a/modules/core/src/core/geometry.js
+++ b/modules/core/src/core/geometry.js
@@ -1,6 +1,4 @@
 import {uid, assert} from '../utils';
-import GL from '@luma.gl/constants';
-import {Buffer} from '@luma.gl/webgl';
 
 // Rendering primitives - specify how to extract primitives from vertices.
 // NOTE: These are numerically identical to the corresponding WebGL/OpenGL constants
@@ -20,21 +18,6 @@ export function getDrawMode(drawMode) {
   const mode = typeof drawMode === 'string' ? DRAW_MODE[drawMode] || DRAW_MODE.TRIANGLES : drawMode;
   assert(mode >= 0 && mode <= DRAW_MODE.TRIANGLE_FAN, 'Illegal drawMode');
   return mode;
-}
-
-export function getBuffersFromGeometry(gl, geometry) {
-  const attributes = geometry.getAttributes();
-  const buffers = {};
-
-  for (const name in attributes) {
-    const attribute = attributes[name];
-    buffers[name] = new Buffer(gl, {
-      data: attribute.value,
-      target: attribute.isIndexed ? GL.ELEMENT_ARRAY_BUFFER : GL.ARRAY_BUFFER
-    });
-  }
-
-  return buffers;
 }
 
 export default class Geometry {

--- a/modules/core/src/core/geometry.js
+++ b/modules/core/src/core/geometry.js
@@ -1,4 +1,6 @@
 import {uid, assert} from '../utils';
+import GL from '@luma.gl/constants';
+import {Buffer} from '@luma.gl/webgl';
 
 // Rendering primitives - specify how to extract primitives from vertices.
 // NOTE: These are numerically identical to the corresponding WebGL/OpenGL constants
@@ -18,6 +20,21 @@ export function getDrawMode(drawMode) {
   const mode = typeof drawMode === 'string' ? DRAW_MODE[drawMode] || DRAW_MODE.TRIANGLES : drawMode;
   assert(mode >= 0 && mode <= DRAW_MODE.TRIANGLE_FAN, 'Illegal drawMode');
   return mode;
+}
+
+export function getBuffersFromGeometry(gl, geometry) {
+  const attributes = geometry.getAttributes();
+  const buffers = {};
+
+  for (const name in attributes) {
+    const attribute = attributes[name];
+    buffers[name] = new Buffer(gl, {
+      data: attribute.value,
+      target: attribute.isIndexed ? GL.ELEMENT_ARRAY_BUFFER : GL.ARRAY_BUFFER
+    });
+  }
+
+  return buffers;
 }
 
 export default class Geometry {

--- a/modules/core/src/core/model-utils.js
+++ b/modules/core/src/core/model-utils.js
@@ -1,0 +1,17 @@
+import GL from '@luma.gl/constants';
+import {Buffer} from '@luma.gl/webgl';
+
+export function getBuffersFromGeometry(gl, geometry) {
+  const attributes = geometry.getAttributes();
+  const buffers = {};
+
+  for (const name in attributes) {
+    const attribute = attributes[name];
+    buffers[name] = new Buffer(gl, {
+      data: attribute.value,
+      target: attribute.isIndexed ? GL.ELEMENT_ARRAY_BUFFER : GL.ARRAY_BUFFER
+    });
+  }
+
+  return buffers;
+}

--- a/modules/core/src/core/model.js
+++ b/modules/core/src/core/model.js
@@ -61,13 +61,13 @@ export default class Model extends BaseModel {
   // SETTERS
 
   setDrawMode(drawMode) {
-    this.props.drawMode = drawMode;
+    this.drawMode = drawMode;
     return this;
   }
 
   setVertexCount(vertexCount) {
     assert(Number.isFinite(vertexCount));
-    this.props.vertexCount = vertexCount;
+    this.vertexCount = vertexCount;
     return this;
   }
 

--- a/modules/core/src/core/model.js
+++ b/modules/core/src/core/model.js
@@ -1,6 +1,6 @@
 import GL from '@luma.gl/constants';
 import {Query, TransformFeedback} from '@luma.gl/webgl';
-import {getBuffersFromGeometry} from './geometry';
+import {getBuffersFromGeometry} from './model-utils';
 import BaseModel from './base-model';
 // import {getDrawMode} from '../core/geometry';
 

--- a/modules/core/src/core/model.js
+++ b/modules/core/src/core/model.js
@@ -1,6 +1,6 @@
 import GL from '@luma.gl/constants';
-import {Buffer, Query, TransformFeedback} from '@luma.gl/webgl';
-import Attribute from '../core/attribute';
+import {Query, TransformFeedback} from '@luma.gl/webgl';
+import {getBuffersFromGeometry} from './geometry';
 import BaseModel from './base-model';
 // import {getDrawMode} from '../core/geometry';
 
@@ -11,21 +11,13 @@ const ERR_MODEL_PARAMS = 'Model needs drawMode and vertexCount';
 const LOG_DRAW_PRIORITY = 2;
 
 export default class Model extends BaseModel {
-  constructor(gl, props = {}) {
-    super(gl, props);
-    this._setModelProps(props);
-  }
-
   /* eslint-disable max-statements  */
   /* eslint-disable complexity  */
   initialize(props = {}) {
     super.initialize(props);
 
-    // Attributes and buffers
-
-    // Model manages auto Buffer creation from typed arrays
-    this._attributes = {}; // All attributes
-    this.attributes = {}; // User defined attributes
+    this.drawMode = props.drawMode !== undefined ? props.drawMode : GL.TRIANGLES;
+    this.vertexCount = props.vertexCount || 0;
 
     // geometry might have set drawMode and vertexCount
     this.isInstanced = props.isInstanced || props.instanced;
@@ -49,20 +41,6 @@ export default class Model extends BaseModel {
   }
 
   // GETTERS
-
-  get vertexCount() {
-    if (Number.isFinite(this.props.vertexCount)) {
-      return this.props.vertexCount;
-    }
-    return this.geometry && this.geometry.getVertexCount();
-  }
-
-  get drawMode() {
-    if (Number.isFinite(this.props.drawMode)) {
-      return this.props.drawMode;
-    }
-    return this.geometry && this.geometry.drawMode;
-  }
 
   getDrawMode() {
     return this.drawMode;
@@ -101,9 +79,9 @@ export default class Model extends BaseModel {
 
   // TODO - just set attributes, don't hold on to geometry
   setGeometry(geometry) {
-    this.geometry = geometry;
-    const buffers = this._createBuffersFromAttributeDescriptors(this.geometry.getAttributes());
-    this.vertexArray.setAttributes(buffers);
+    this.drawMode = geometry.drawMode;
+    this.vertexCount = geometry.getVertexCount();
+    this.vertexArray.setAttributes(getBuffersFromGeometry(this.gl, geometry));
     this.setNeedsRedraw();
     return this;
   }
@@ -114,11 +92,7 @@ export default class Model extends BaseModel {
       return this;
     }
 
-    Object.assign(this.attributes, attributes);
-    const buffers = this._createBuffersFromAttributeDescriptors(attributes);
-
-    // Object.assign(this.attributes, buffers);
-    this.vertexArray.setAttributes(buffers);
+    this.vertexArray.setAttributes(attributes);
     this.setNeedsRedraw();
 
     return this;
@@ -264,52 +238,5 @@ count: ${this.stats.profileFrameCount}`
         )();
       }
     }
-  }
-
-  // Makes sure buffers are created for all attributes
-  // and that the program is updated with those buffers
-  // TODO - do we need the separation between "attributes" and "buffers"
-  // couldn't apps just create buffers directly?
-  _createBuffersFromAttributeDescriptors(attributes) {
-    const {
-      program: {gl}
-    } = this;
-
-    // const attributes = {};
-    const buffers = {};
-
-    for (const attributeName in attributes) {
-      const descriptor = attributes[attributeName];
-
-      let attribute = this._attributes[attributeName];
-
-      if (descriptor instanceof Attribute) {
-        attribute = descriptor;
-      } else if (descriptor instanceof Buffer) {
-        attribute =
-          attribute ||
-          new Attribute(
-            gl,
-            Object.assign({}, descriptor, descriptor.accessor, {
-              id: attributeName
-            })
-          );
-        attribute.update({buffer: descriptor});
-      } else if (attribute) {
-        attribute.update(descriptor);
-      } else {
-        attribute = new Attribute(
-          gl,
-          Object.assign({}, descriptor, {
-            id: attributeName
-          })
-        );
-      }
-
-      this._attributes[attributeName] = attribute;
-      buffers[attributeName] = attribute.getValue();
-    }
-
-    return buffers;
   }
 }

--- a/modules/core/src/scenegraph/nodes/model-node.js
+++ b/modules/core/src/scenegraph/nodes/model-node.js
@@ -12,16 +12,15 @@ export default class ModelNode extends ScenegraphNode {
     // Create new Model or used supplied Model
     if (gl instanceof Model) {
       this.model = gl;
+      this._setModelNodeProps(props);
     } else {
       this.model = new Model(gl, props);
     }
-
-    this._setNodelNodeProps(props);
   }
 
   setProps(props) {
     super.setProps(props);
-    this._setNodelNodeProps(props);
+    this._setModelNodeProps(props);
     return this;
   }
 
@@ -52,7 +51,7 @@ export default class ModelNode extends ScenegraphNode {
 
   // PRIVATE
 
-  _setNodelNodeProps(props) {
+  _setModelNodeProps(props) {
     this.model.setProps(props);
   }
 }

--- a/modules/core/test/core/attribute.spec.js
+++ b/modules/core/test/core/attribute.spec.js
@@ -170,68 +170,73 @@ test('Attribute#missing component', t => {
       drawMode: GL.POINTS,
       vertexCount: 4,
       attributes: {
-        position: {size: 3, value: new Float32Array([-1, -1, 0, 1, -1, 0, -1, 1, 0, 1, 1, 0])}
+        position: [
+          new Buffer(gl, new Float32Array([-1, -1, 0, 1, -1, 0, -1, 1, 0, 1, 1, 0])),
+          {size: 3}
+        ]
       }
     });
 
-  const testCases = [
-    // This doesn't work for vec2
-    // {
-    //   attributeName: 'texCoord',
-    //   type: 'vec2',
-    //   accessor: 'texCoord, 0.0, 1.0',
-    //   attributes: {
-    //     size: {
-    //       size: 1,
-    //       value: new Float32Array([0.5, 1, 0.25, 0])
-    //     }
-    //   },
-    //   output: [128, 0, 0, 255, 255, 0, 0, 255, 64, 0, 0, 255, 0, 0, 0, 255]
-    // },
-    {
-      attributeName: 'size',
-      type: 'vec3',
-      accessor: 'size, 1.0',
-      attributes: {
-        size: {
-          size: 2,
-          value: new Float32Array([0.5, 0, 1, 0.5, 0, 1, 0.5, 1])
-        }
+  function getTestCases(gl) {
+    return [
+      // This doesn't work for vec2
+      // {
+      //   attributeName: 'texCoord',
+      //   type: 'vec2',
+      //   accessor: 'texCoord, 0.0, 1.0',
+      //   attributes: {
+      //     size: {
+      //       size: 1,
+      //       value: new Float32Array([0.5, 1, 0.25, 0])
+      //     }
+      //   },
+      //   output: [128, 0, 0, 255, 255, 0, 0, 255, 64, 0, 0, 255, 0, 0, 0, 255]
+      // },
+      {
+        attributeName: 'size',
+        type: 'vec3',
+        accessor: 'size, 1.0',
+        attributes: {
+          size: [new Buffer(gl, new Float32Array([0.5, 0, 1, 0.5, 0, 1, 0.5, 1])), {size: 2}]
+        },
+        output: [128, 0, 0, 255, 255, 128, 0, 255, 0, 255, 0, 255, 128, 255, 0, 255]
       },
-      output: [128, 0, 0, 255, 255, 128, 0, 255, 0, 255, 0, 255, 128, 255, 0, 255]
-    },
-    {
-      attributeName: 'size',
-      type: 'vec3',
-      accessor: 'size, 1.0',
-      attributes: {
-        size: {
-          size: 2,
-          stride: 12,
-          value: new Float32Array([0.5, 0, 1, 1, 0.5, 1, 0, 1, 1, 0.5, 1, 1])
-        }
+      {
+        attributeName: 'size',
+        type: 'vec3',
+        accessor: 'size, 1.0',
+        attributes: {
+          size: [
+            new Buffer(gl, new Float32Array([0.5, 0, 1, 1, 0.5, 1, 0, 1, 1, 0.5, 1, 1])),
+            {size: 2, stride: 12}
+          ]
+        },
+        output: [128, 0, 0, 255, 255, 128, 0, 255, 0, 255, 0, 255, 128, 255, 0, 255]
       },
-      output: [128, 0, 0, 255, 255, 128, 0, 255, 0, 255, 0, 255, 128, 255, 0, 255]
-    },
-    {
-      attributeName: 'color',
-      type: 'vec4',
-      accessor: 'color / 255.0',
-      attributes: {
-        color: {
-          size: 3,
-          value: new Uint8ClampedArray([32, 100, 40, 64, 64, 64, 128, 0, 0, 255, 18, 255])
-        }
-      },
-      output: [32, 100, 40, 1, 64, 64, 64, 1, 128, 0, 0, 1, 255, 18, 255, 1]
-    }
-  ];
+      {
+        attributeName: 'color',
+        type: 'vec4',
+        accessor: 'color / 255.0',
+        attributes: {
+          color: [
+            new Buffer(
+              gl,
+              new Uint8ClampedArray([32, 100, 40, 64, 64, 64, 128, 0, 0, 255, 18, 255])
+            ),
+            {size: 3}
+          ]
+        },
+        output: [32, 100, 40, 1, 64, 64, 64, 1, 128, 0, 0, 1, 255, 18, 255, 1]
+      }
+    ];
+  }
 
   for (const contextName in contexts) {
     const gl = contexts[contextName];
 
     if (gl) {
       t.comment(contextName);
+      const testCases = getTestCases(gl);
 
       testCases.forEach(tc => {
         const model = getModel(gl, tc);

--- a/modules/core/test/core/model.spec.js
+++ b/modules/core/test/core/model.spec.js
@@ -25,7 +25,7 @@ test('Model#construct/destruct', t => {
   t.end();
 });
 
-test.only('Model#setAttribute', t => {
+test('Model#setAttribute', t => {
   const {gl} = fixture;
 
   const buffer1 = new Buffer(gl, {size: 2, data: new Float32Array(4).fill(1)});

--- a/modules/core/test/core/model.spec.js
+++ b/modules/core/test/core/model.spec.js
@@ -1,7 +1,7 @@
 import GL from '@luma.gl/constants';
 import luma from '@luma.gl/webgl/init';
 // TODO - Model test should not depend on Cube
-import {Buffer, _Attribute as Attribute, Model, Cube} from '@luma.gl/core';
+import {Buffer, Model, Cube} from '@luma.gl/core';
 import test from 'tape-catch';
 import {fixture} from 'test/setup';
 
@@ -25,7 +25,7 @@ test('Model#construct/destruct', t => {
   t.end();
 });
 
-test('Model#setAttribute', t => {
+test.only('Model#setAttribute', t => {
   const {gl} = fixture;
 
   const buffer1 = new Buffer(gl, {size: 2, data: new Float32Array(4).fill(1)});
@@ -42,9 +42,9 @@ test('Model#setAttribute', t => {
   );
 
   model.setAttributes({
-    instanceSizes: new Attribute(gl, {size: 1, buffer: buffer1}),
+    instanceSizes: [buffer1, {size: 1}],
     instancePositions: buffer2,
-    instanceWeight: {size: 1, constant: true, value: new Float32Array([10])}
+    instanceWeight: new Float32Array([10])
   });
 
   t.is(stats.get('Buffers Active').count - initialActiveBuffers, 4, 'Did not create new buffers');


### PR DESCRIPTION
Models no longer create buffers automatically. `Model.setAttributes` now passes args directly to `VertexArray.setAttributes`.