### PR TITLE
Remove redraw flag handling

### DIFF
--- a/docs/api-reference/core/model.md
+++ b/docs/api-reference/core/model.md
@@ -201,11 +201,9 @@ Free WebGL resources associated with this model
 Updates properties
 
 
-### getNeedsRedraw() : Boolean
+### isAnimated() : Boolean
 
-* clearRedrawFlags - clear the redraw flag
-
-Gets the value of the redraw flag.
+Returns `true` if the model is animated (i.e. needs to be redrawn every frame).
 
 
 ### getProgram() : Program
@@ -216,12 +214,6 @@ Get model's `Program` instance
 ### getUniforms() : Object
 
 Returns map of currently stored uniforms
-
-
-### setNeedsRedraw() : Model
-
-Set the redraw flag for the model. It is recommended that the redraw flag is a string so that redraw reasons can be traced.
-
 
 ### setUniforms(uniforms : Object) : Model
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -79,21 +79,26 @@ with
 import "@luma.gl/debug";
 ```
 
-## Model
+### Model
 
-`Model` no longer inherits from `ScenegraphNode`, ensuring that applications that do not need scenegraph support do not need to include scenegraph related code.
+Changes:
+* `Model` no longer extends `ScenegraphNode`. This ensures that applications that do not need scenegraph support do not need to include scenegraph related code. Use the new `ModelNode` class to inject `Models` into scenegraphs.
 
-Instead, the new `ModelNode` class supports the use of `Model` in scenegraphs. `ModelNode` inherits from `ScenegraphNode` and holds a `Model` instance, and forwards many of the `Model` methods and can be used interchangeably in most cases.
+Deletions:
+* Redraw flag handling has been removed: `Model.setNeedsRedraw()` and `Model.getNeedsRedraw()`.
+
+Additions:
+* A new `Model.isAnimated()` method is provided, indicating that redraws are required every frame.
 
 
-## Buffer
+### Buffer
 
 | Removed Method               | Replacement | Reason for Change |
 | ---                          | ---         | ---               |
 | `Buffer.updateAccessor(...)` | `Buffer.setAccessor(new Accessor(buffer.accessor, ...)` | Decoupling accessors from `Buffer` |
 
 
-## Framebuffer
+### Framebuffer
 
 To maximize rendering performance, the default framebuffer is no longer preserved between frames.
 

--- a/modules/core/src/core/base-model.js
+++ b/modules/core/src/core/base-model.js
@@ -100,17 +100,9 @@ export default class BaseModel {
 
   // GETTERS
 
-  getNeedsRedraw({clearRedrawFlags = false} = {}) {
-    let redraw = false;
-    redraw = redraw || this.needsRedraw;
-    this.needsRedraw = this.needsRedraw && !clearRedrawFlags;
-    if (this.geometry) {
-      redraw = redraw || this.geometry.getNeedsRedraw({clearRedrawFlags});
-    }
-    if (this.animated) {
-      redraw = redraw || `animated model ${this.id}`;
-    }
-    return redraw;
+
+  isAnimated() {
+    return this.animated;
   }
 
   getProgram() {
@@ -122,11 +114,6 @@ export default class BaseModel {
   }
 
   // SETTERS
-
-  setNeedsRedraw(redraw = true) {
-    this.needsRedraw = redraw;
-    return this;
-  }
 
   // TODO - should actually set the uniforms
   setUniforms(uniforms = {}) {
@@ -140,7 +127,6 @@ export default class BaseModel {
     this.program.setUniforms(uniforms, () => {
       // if something changed
       this._checkForDeprecatedUniforms(uniforms);
-      this.setNeedsRedraw();
     });
 
     return this;
@@ -221,10 +207,6 @@ export default class BaseModel {
     this._timerQueryEnd();
 
     onAfterRender();
-
-    if (didDraw) {
-      this.setNeedsRedraw(false);
-    }
 
     this._logDrawCallEnd(logPriority, vertexArray, framebuffer);
 

--- a/modules/core/src/core/base-model.js
+++ b/modules/core/src/core/base-model.js
@@ -100,7 +100,6 @@ export default class BaseModel {
 
   // GETTERS
 
-
   isAnimated() {
     return this.animated;
   }

--- a/modules/core/src/core/geometry.js
+++ b/modules/core/src/core/geometry.js
@@ -28,25 +28,12 @@ export default class Geometry {
     this.drawMode = getDrawMode(drawMode);
     this.vertexCount = vertexCount;
     this.attributes = {};
-    this.needsRedraw = true;
     this.userData = {};
     Object.seal(this);
 
     if (attributes) {
       this.setAttributes(attributes);
     }
-  }
-
-  setNeedsRedraw(redraw = true) {
-    this.needsRedraw = redraw;
-    return this;
-  }
-
-  getNeedsRedraw({clearRedrawFlags = false} = {}) {
-    let redraw = false;
-    redraw = redraw || this.needsRedraw;
-    this.needsRedraw = this.needsRedraw && !clearRedrawFlags;
-    return redraw;
   }
 
   setVertexCount(vertexCount) {
@@ -107,7 +94,6 @@ export default class Geometry {
 
       this.attributes[attributeName] = attribute;
     }
-    this.setNeedsRedraw();
     return this;
   }
 

--- a/modules/core/src/core/model.js
+++ b/modules/core/src/core/model.js
@@ -82,7 +82,6 @@ export default class Model extends BaseModel {
     this.drawMode = geometry.drawMode;
     this.vertexCount = geometry.getVertexCount();
     this.vertexArray.setAttributes(getBuffersFromGeometry(this.gl, geometry));
-    this.setNeedsRedraw();
     return this;
   }
 
@@ -93,8 +92,6 @@ export default class Model extends BaseModel {
     }
 
     this.vertexArray.setAttributes(attributes);
-    this.setNeedsRedraw();
-
     return this;
   }
 
@@ -170,7 +167,6 @@ export default class Model extends BaseModel {
       this.program.setUniforms(animatedUniforms, () => {
         // if something changed
         this._checkForDeprecatedUniforms(animatedUniforms);
-        this.setNeedsRedraw();
       });
     }
   }
@@ -191,9 +187,6 @@ export default class Model extends BaseModel {
       });
 
     this.transformFeedback.setBuffers(feedbackBuffers);
-
-    this.setNeedsRedraw();
-
     return this;
   }
 

--- a/wip/src/mesh-model.js
+++ b/wip/src/mesh-model.js
@@ -145,19 +145,6 @@ export default class MeshModel extends Node {
     return this.geometry && this.geometry.drawMode;
   }
 
-  getNeedsRedraw({clearRedrawFlags = false} = {}) {
-    let redraw = false;
-    redraw = redraw || this.needsRedraw;
-    this.needsRedraw = this.needsRedraw && !clearRedrawFlags;
-    if (this.geometry) {
-      redraw = redraw || this.geometry.getNeedsRedraw({clearRedrawFlags});
-    }
-    if (this.animated) {
-      redraw = redraw || `animated model ${this.id}`;
-    }
-    return redraw;
-  }
-
   getDrawMode() {
     return this.drawMode;
   }
@@ -184,11 +171,6 @@ export default class MeshModel extends Node {
 
   // SETTERS
 
-  setNeedsRedraw(redraw = true) {
-    this.needsRedraw = redraw;
-    return this;
-  }
-
   setDrawMode(drawMode) {
     this.props.drawMode = getDrawMode(drawMode);
     return this;
@@ -211,7 +193,6 @@ export default class MeshModel extends Node {
     this.geometry = geometry;
     const buffers = this._createBuffersFromAttributeDescriptors(this.geometry.getAttributes());
     this.vertexArray.setAttributes(buffers);
-    this.setNeedsRedraw();
     return this;
   }
 
@@ -226,8 +207,6 @@ export default class MeshModel extends Node {
 
     // Object.assign(this.attributes, buffers);
     this.vertexArray.setAttributes(buffers);
-    this.setNeedsRedraw();
-
     return this;
   }
 
@@ -243,7 +222,6 @@ export default class MeshModel extends Node {
     this.program.setUniforms(uniforms, samplers, () => {
       // if something changed
       this._checkForDeprecatedUniforms(uniforms);
-      this.setNeedsRedraw();
     });
   }
 
@@ -256,7 +234,6 @@ export default class MeshModel extends Node {
       this.program.setUniforms(animatedUniforms, {}, () => {
         // if something changed
         this._checkForDeprecatedUniforms(animatedUniforms);
-        this.setNeedsRedraw();
       });
     }
   }
@@ -331,8 +308,6 @@ export default class MeshModel extends Node {
 
     this._timerQueryEnd();
     this.onAfterRender();
-
-    this.setNeedsRedraw(false);
 
     this._logDrawCallEnd(logPriority, vertexArray, framebuffer);
 
@@ -525,9 +500,6 @@ export default class MeshModel extends Node {
       });
 
     this.transformFeedback.setBuffers(feedbackBuffers);
-
-    this.setNeedsRedraw();
-
     return this;
   }
 


### PR DESCRIPTION
For #
<!-- For other PRs without open issue -->
#### Background
- Per discussions today, removes redraw flag handling from luma `Model` and `Geometry`.
- replace with `Model.isAnimated()` flag
#### Change List
-
