### PR TITLE
Initial round of fixes

### DIFF
--- a/modules/core/src/core/model-utils.js
+++ b/modules/core/src/core/model-utils.js
@@ -22,6 +22,8 @@ export function getBuffersFromGeometry(gl, geometry, options) {
     delete attribute.value;
     const remappedName = mapAttributeName(name, options);
     buffers[remappedName] = [new Buffer(gl, typedArray), attribute];
+
+    inferAttributeAccessor(name, attribute);
   }
 
   if (geometry.indices) {

--- a/modules/core/src/core/model.js
+++ b/modules/core/src/core/model.js
@@ -25,6 +25,9 @@ export default class Model extends BaseModel {
 
     this._setModelProps(props);
 
+    // TODO - just to unbreak deck.gl 7.0-beta, remove as soon as updated
+    this.geometry = {};
+
     // assert(program || program instanceof Program);
     assert(this.drawMode !== undefined && Number.isFinite(this.vertexCount), ERR_MODEL_PARAMS);
   }
@@ -91,7 +94,15 @@ export default class Model extends BaseModel {
       return this;
     }
 
-    this.vertexArray.setAttributes(attributes);
+    // Loose support for deck.gl `Attribute` class by checking for presence of `getValue``
+    // TODO - remove once deck is updated
+    const normalizedAttributes = {};
+    for (const name in attributes) {
+      const attribute = attributes[name];
+      normalizedAttributes[name] = attribute.getValue ? attribute.getValue() : attribute;
+    }
+
+    this.vertexArray.setAttributes(normalizedAttributes);
     return this;
   }
 

--- a/modules/core/src/geometry/geometry.js
+++ b/modules/core/src/geometry/geometry.js
@@ -113,6 +113,15 @@ export default class Geometry {
         vertexCount = Math.min(vertexCount, value.length / size);
       }
     }
+
+    // TODO - Magic, should this be removed?
+    if (!Number.isFinite(vertexCount)) {
+      const attribute = attributes.POSITION || attributes.positions;
+      if (attribute) {
+        vertexCount = attribute.value && attribute.value.length / (attribute.size || 3);
+      }
+    }
+
     assert(Number.isFinite(vertexCount));
     return vertexCount;
   }


### PR DESCRIPTION
For #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Add back support for `Attribute` in setModel.
- Add back `vertexCount` inference from `POSITION`/`position`
- Add back `size` inference when creating Buffers (did not seem to make a difference but adding anyway to ensure we unblock).
- Add dummy `Model.geometry` object so that deck does not crash when setting `id`.
 