### PR TITLE
Fix typo s/onInitailize/onInitialize

### DIFF
--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -3,7 +3,7 @@
 Manages an animation loop and optionally a WebGL context and a WebGL canvas. It provides a number of features related to initialization and animation of a WebGL context.
 
 * Provides a number of commonly needed variables as part of the `context` object which is passed to `onRender` and `onFinalize` callbacks.
-* Objects returned by `onInitailize` will be appended to `context` object hence available to `onRender` and `onFinalize`.
+* Objects returned by `onInitialize` will be appended to `context` object hence available to `onRender` and `onFinalize`.
 * To avoid problems with page load timing, move context creation to the `onCreateContext` method.
 * By default, `onRender` method manages resizing of canvas, viewport and framebuffer.
 * Makes it easy to wait for the HTML page to load before creating a canvas and WebGL resources.


### PR DESCRIPTION
#### Background

There's a small typo `onInitailize` on https://luma.gl/#/documentation/api-reference/animation-loop

<!-- For all the PRs -->
#### Change List
- Fix typo, replacing `onInitailize` with `onInitialize`.