### PR TITLE
Move @luma.gl/core to peerDependencies

### DIFF
--- a/modules/addons/package.json
+++ b/modules/addons/package.json
@@ -25,24 +25,16 @@
     "README.md"
   ],
   "sideEffects": false,
-  "browser": {
-    "fs": false
-  },
   "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
     "@loaders.gl/core": "1.0.0-alpha.2",
     "@loaders.gl/draco": "1.0.0-alpha.2",
     "@loaders.gl/gltf": "1.0.0-alpha.2",
     "@luma.gl/constants": "7.0.0-beta.1",
-    "@luma.gl/core": "7.0.0-beta.1",
-    "@luma.gl/shadertools": "7.0.0-beta.1",
-    "@luma.gl/webgl": "7.0.0-beta.1",
-    "math.gl": "^2.3.1"
+    "math.gl": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@luma.gl/core": "7.0.0-beta.1"
   }
 }

--- a/modules/addons/src/gltf/create-gltf-model.js
+++ b/modules/addons/src/gltf/create-gltf-model.js
@@ -1,6 +1,4 @@
-import {pbr} from '@luma.gl/shadertools';
-import {isWebGL2} from '@luma.gl/webgl';
-import {ModelNode, log} from '@luma.gl/core';
+import {isWebGL2, ModelNode, log, pbr} from '@luma.gl/core';
 import GLTFMaterialParser from './gltf-material-parser';
 
 const vs = `

--- a/modules/addons/src/gltf/gltf-environment.js
+++ b/modules/addons/src/gltf/gltf-environment.js
@@ -1,5 +1,5 @@
 import GL from '@luma.gl/constants';
-import {Texture2D, TextureCube, loadImage} from '@luma.gl/webgl';
+import {Texture2D, TextureCube, loadImage} from '@luma.gl/core';
 
 export default class GLTFEnvironment {
   constructor(gl, {brdfLutUrl, getTexUrl}) {

--- a/modules/addons/src/gltf/gltf-instantiator.js
+++ b/modules/addons/src/gltf/gltf-instantiator.js
@@ -1,6 +1,5 @@
 import {Matrix4} from 'math.gl';
-import {Buffer, Accessor} from '@luma.gl/webgl';
-import {GroupNode, log} from '@luma.gl/core';
+import {Buffer, _Accessor as Accessor, GroupNode, log} from '@luma.gl/core';
 
 import GLTFAnimator from './gltf-animator';
 import createGLTFModel from './create-gltf-model';

--- a/modules/addons/src/gltf/gltf-material-parser.js
+++ b/modules/addons/src/gltf/gltf-material-parser.js
@@ -1,5 +1,4 @@
-import {Texture2D} from '@luma.gl/webgl';
-import {log} from '@luma.gl/core';
+import {Texture2D, log} from '@luma.gl/core';
 
 export default class GLTFMaterialParser {
   constructor(gl, {attributes, material, pbrDebug, imageBasedLightingEnvironment, lights}) {

--- a/modules/constants/package.json
+++ b/modules/constants/package.json
@@ -24,9 +24,6 @@
     "README.md"
   ],
   "sideEffects": false,
-  "browser": {
-    "fs": false
-  },
   "scripts": {
     "clean": "echo nothing to clean",
     "build": "echo nothing to build"

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -24,17 +24,7 @@
     "dist",
     "README.md"
   ],
-  "browser": {
-    "gl": false,
-    "gl/wrap": false
-  },
   "scripts": {
-    "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
-    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
@@ -43,21 +33,8 @@
     "@luma.gl/webgl": "7.0.0-beta.1",
     "@luma.gl/webgl-state-tracker": "7.0.0-beta.1",
     "@luma.gl/webgl2-polyfill": "7.0.0-beta.1",
-    "math.gl": "^2.3.0-beta.2",
+    "math.gl": "^2.3.0",
     "probe.gl": "^3.0.1",
     "seer": "^0.2.4"
-  },
-  "nyc": {
-    "require": [
-      "@babel/register"
-    ],
-    "sourceMap": false,
-    "instrument": false,
-    "include": [
-      "src/**/*.js"
-    ],
-    "exclude": [
-      "test/**/*.js"
-    ]
   }
 }

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -147,6 +147,7 @@ export {
   diffuse,
   gouraudlighting,
   phonglighting,
+  pbr,
   // experimental
   _transform,
   MODULAR_SHADERS,

--- a/modules/debug/package.json
+++ b/modules/debug/package.json
@@ -25,21 +25,15 @@
     "README.md"
   ],
   "sideEffects": false,
-  "browser": {
-    "fs": false
-  },
   "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
     "@luma.gl/constants": "7.0.0-beta.1",
-    "@luma.gl/core": "7.0.0-beta.1",
     "glsl-transpiler": "^1.8.5",
-    "math.gl": "^2.3.0-beta.2",
-    "webgl-debug": "^2.0.1"
+    "webgl-debug": "^2.0.1",
+    "math.gl": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@luma.gl/core": "7.0.0-beta.1"
   }
 }

--- a/modules/effects/package.json
+++ b/modules/effects/package.json
@@ -18,14 +18,11 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
-    "@luma.gl/constants": "^7.0.0-alpha.2",
+    "@luma.gl/constants": "7.0.0-beta.1"
+  },
+  "peerDependencies": {
     "@luma.gl/core": "^7.0.0-alpha.17"
   }
 }

--- a/modules/glfx/package.json
+++ b/modules/glfx/package.json
@@ -20,14 +20,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
-  "dependencies": {
-    "@luma.gl/constants": "7.0.0-beta.1",
+  "peerDependencies": {
     "@luma.gl/core": "7.0.0-beta.1"
   }
 }

--- a/modules/gpgpu/package.json
+++ b/modules/gpgpu/package.json
@@ -25,18 +25,12 @@
     "README.md"
   ],
   "sideEffects": false,
-  "browser": {
-    "fs": false
-  },
   "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
-    "@luma.gl/constants": "7.0.0-beta.1",
+    "@luma.gl/constants": "7.0.0-beta.1"
+  },
+  "peerDependencies": {
     "@luma.gl/core": "7.0.0-beta.1"
   }
 }

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -27,11 +27,6 @@
     "README.md"
   ],
   "scripts": {
-    "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
     "@luma.gl/addons": "7.0.0-beta.1",

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -31,18 +31,10 @@
     "README.md"
   ],
   "sideEffects": false,
-  "browser": {
-    "fs": false
-  },
   "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
-    "@luma.gl/constants": "7.0.0-beta.1",
-    "math.gl": "^2.3.0-beta.2"
+    "@babel/runtime": "^7.0.0",
+    "math.gl": "^2.3.0"
   }
 }

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -32,12 +32,11 @@
     "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0",
-    "@luma.gl/core": "7.0.0-beta.1",
-    "@luma.gl/webgl-state-tracker": "7.0.0-beta.1"
+    "probe.gl": "^3.0.1"
   },
   "peerDependencies": {
-    "@probe.gl/test-utils": "^3.0.1",
-    "probe.gl": "^3.0.1"
+    "@luma.gl/core": "7.0.0-beta.1",
+    "@luma.gl/webgl-state-tracker": "7.0.0-beta.1",
+    "@probe.gl/test-utils": "^3.0.1"
   }
 }

--- a/modules/webgl-state-tracker/package.json
+++ b/modules/webgl-state-tracker/package.json
@@ -21,22 +21,10 @@
     "dist",
     "README.md"
   ],
-  "browser": {
-    "gl": false,
-    "gl/wrap": false
-  },
   "scripts": {
-    "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@luma.gl/constants": "7.0.0-beta.1"
-  },
-  "devDependencies": {
-    "probe.gl": "^3.0.1"
   }
 }

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -29,32 +29,12 @@
     "gl/wrap": false
   },
   "scripts": {
-    "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
-    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@luma.gl/constants": "7.0.0-beta.1",
     "@luma.gl/webgl-state-tracker": "7.0.0-beta.1",
     "@luma.gl/webgl2-polyfill": "7.0.0-beta.1",
-    "probe.gl": "^3.0.1",
-    "seer": "^0.2.4"
-  },
-  "nyc": {
-    "require": [
-      "@babel/register"
-    ],
-    "sourceMap": false,
-    "instrument": false,
-    "include": [
-      "src/**/*.js"
-    ],
-    "exclude": [
-      "test/**/*.js"
-    ]
+    "probe.gl": "^3.0.1"
   }
 }

--- a/modules/webgl2-polyfill/package.json
+++ b/modules/webgl2-polyfill/package.json
@@ -21,17 +21,9 @@
     "README.md"
   ],
   "scripts": {
-    "clean": "rm -fr dist dist-es6 && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@luma.gl/constants": "7.0.0-beta.1"
-  },
-  "devDependencies": {
-    "probe.gl": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cover": "ocular-test cover",
     "lint": "ocular-lint",
     "publish": "ocular-publish",
+    "version": "ocular-build webgl",
     "test": "ocular-test",
     "test-fast": "ocular-test fast",
     "test-browser": "ocular-test browser",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5242,7 +5242,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-math.gl@^2.3.0-beta.2, math.gl@^2.3.1:
+math.gl@^2.3.0, math.gl@^2.3.0-beta.2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-2.3.1.tgz#4099e0e34f03dbc458e57945583badb3a517ce8f"
   integrity sha512-364xFXawzGCp46BmaEcKMAYgDLsaSqXO3ki4XAh+8aJAFNcdJFeORpoZFRLdZMZzwdOepwfcc+rk3LhDNJZF1Q==


### PR DESCRIPTION
#### Change List
- Remove unused build scripts (handled by ocular-dev-tools)
- Remove unused browser fields
- Clean up dependencies:
  + For additional packages, `@luma.gl/core` should be peer dependency instead of dependency.
  + `@babel/runtime` is only explicitly included as a dependency if `@luma.gl/core` is not.
  + `@luma.gl/constants` is kept as a dependency (it is removed by custom babel plugin after transpilation)
  + `math.gl` and `probe.gl` are kept as dependencies (small enough)
