### PR TITLE
Fix attribute handling for matrices

### DIFF
--- a/modules/webgl/src/classes/program-configuration.js
+++ b/modules/webgl/src/classes/program-configuration.js
@@ -9,6 +9,9 @@ export default class ProgramConfiguration {
     this.id = program.id;
     this.attributeInfos = [];
     this.attributeInfosByName = {};
+
+    // Locations may not be contiguous the case of matrix attributes
+    // so keep a separate location->attribute map.
     this.attributeInfosByLocation = [];
     this.varyingInfos = [];
     this.varyingInfosByName = {};

--- a/modules/webgl/src/classes/program-configuration.js
+++ b/modules/webgl/src/classes/program-configuration.js
@@ -9,6 +9,7 @@ export default class ProgramConfiguration {
     this.id = program.id;
     this.attributeInfos = [];
     this.attributeInfosByName = {};
+    this.attributeInfosByLocation = [];
     this.varyingInfos = [];
     this.varyingInfosByName = {};
     Object.seal(this);
@@ -19,7 +20,7 @@ export default class ProgramConfiguration {
   getAttributeInfo(locationOrName) {
     const location = Number(locationOrName);
     if (Number.isFinite(location)) {
-      return this.attributeInfos[location];
+      return this.attributeInfosByLocation[location];
     }
     return this.attributeInfosByName[locationOrName] || null;
   }
@@ -96,6 +97,7 @@ export default class ProgramConfiguration {
 
     const attributeInfo = {location, name, accessor: new Accessor(accessor)}; // Base values
     this.attributeInfos.push(attributeInfo);
+    this.attributeInfosByLocation[location] = attributeInfo; // For quick location based lookup
     this.attributeInfosByName[attributeInfo.name] = attributeInfo; // For quick name based lookup
   }
 

--- a/modules/webgl/src/classes/vertex-array.js
+++ b/modules/webgl/src/classes/vertex-array.js
@@ -287,6 +287,15 @@ export default class VertexArray {
 
     const accessInfo = this._getAttributeInfo(name || location);
 
+    // Attribute location wasn't directly found.
+    // Likely due to multi-location attributes (e.g. matrix)
+    if (!accessInfo) {
+      return {
+        location: -1,
+        accessor: null
+      };
+    }
+
     // Resolve the partial accessors into a final accessor
     const accessor = Accessor.resolve(accessInfo.accessor, valueAccessor, appAccessor);
 


### PR DESCRIPTION
Subtle bug in attribute handling introduced by the matrix attributes. `ProgramConfiguration` was assuming that locations were consecutive starting from 0, which is not the case if there are matrix attributes. Seems to only have become an issue when trying to rebind buffers to attributes manually (when VAOs aren't available).
