### PR TITLE
Model handles geometry with constant attributes

### DIFF
--- a/modules/core/src/core/model-utils.js
+++ b/modules/core/src/core/model-utils.js
@@ -16,14 +16,20 @@ export function getBuffersFromGeometry(gl, geometry, options) {
   const buffers = {};
 
   for (const name in geometry.attributes) {
-    const typedArray = geometry.attributes[name].value;
-    // Create accessor by copying the attribute and removing `value``
-    const attribute = {...geometry.attributes[name]};
-    delete attribute.value;
+    const attribute = geometry.attributes[name];
     const remappedName = mapAttributeName(name, options);
-    buffers[remappedName] = [new Buffer(gl, typedArray), attribute];
 
-    inferAttributeAccessor(name, attribute);
+    if (attribute.constant) {
+      buffers[remappedName] = attribute.value;
+    } else {
+      const typedArray = attribute.value;
+      // Create accessor by copying the attribute and removing `value``
+      const accessor = {...attribute};
+      delete accessor.value;
+      buffers[remappedName] = [new Buffer(gl, typedArray), accessor];
+
+      inferAttributeAccessor(name, accessor);
+    }
   }
 
   if (geometry.indices) {

--- a/modules/core/src/core/model.js
+++ b/modules/core/src/core/model.js
@@ -1,5 +1,5 @@
 import GL from '@luma.gl/constants';
-import {Query, TransformFeedback} from '@luma.gl/webgl';
+import {Query, TransformFeedback, Buffer} from '@luma.gl/webgl';
 import {getBuffersFromGeometry} from './model-utils';
 import BaseModel from './base-model';
 import {log, isObjectEmpty, uid, assert} from '../utils';
@@ -183,7 +183,9 @@ export default class Model extends BaseModel {
     for (const name in this.geometryBuffers) {
       // Buffer is raw value (for indices) or first element of [buffer, accessor] pair
       const buffer = this.geometryBuffers[name][0] || this.geometryBuffers[name];
-      buffer.delete();
+      if (buffer instanceof Buffer) {
+        buffer.delete();
+      }
     }
   }
 


### PR DESCRIPTION
Geometry objects are sometimes created with constant attributes (e.g. from loaders.gl). `Model.setGeometry` wasn't handling this case.
