### PR TITLE
don't need enable lighting flag with only material

### DIFF
--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -43,7 +43,7 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
     return {lighting_uEnabled: false};
   }
 
-  return Object.assign({}, getMaterialUniforms(material), {lighting_uEnabled: true});
+  return getMaterialUniforms(material);
 }
 
 export {gouraudlighting, phonglighting};

--- a/modules/shadertools/test/modules/index.js
+++ b/modules/shadertools/test/modules/index.js
@@ -1,6 +1,7 @@
 import './fp64/fp64-arithmetic-transform.spec';
 import '../../src/modules/lights/test/lights.spec';
 import '../../src/modules/picking/test/picking.spec';
+import './phong-lighting/phong-lighting.spec';
 
 import {
   registerShaderModules,

--- a/modules/shadertools/test/modules/phong-lighting/phong-lighting.spec.js
+++ b/modules/shadertools/test/modules/phong-lighting/phong-lighting.spec.js
@@ -1,0 +1,19 @@
+import test from 'tape-catch';
+import {phonglighting} from '@luma.gl/shadertools';
+
+test('shadertools#phonglighting', t => {
+  let uniforms = phonglighting.getUniforms();
+  t.deepEqual(uniforms, {}, `Default phong lighting uniforms ok`);
+
+  uniforms = phonglighting.getUniforms({
+    material: {ambient: 0.0, diffuse: 0.0, shininess: 0.0, specularColor: 0.0}
+  });
+  t.equal(uniforms.lighting_uEnabled, undefined, `Not enable lighting flag with only material`);
+
+  uniforms = phonglighting.getUniforms({
+    material: null
+  });
+  t.equal(uniforms.lighting_uEnabled, false, 'Disable lighting without material');
+
+  t.end();
+});


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->

<!-- For other PRs without open issue -->
#### Background
We shouldn't enable lighting with only checking material, the light source may not be available. For now we load lights module first which will enable lighting when lights are OK, here we only disable lighting if no material.
In the future if the module loading order is different, this logic could be broken.
<!-- For all the PRs -->
#### Change List
- not enable lighting in phong lighting module
