### PR TITLE
Fix Histopyramid Unit tests, eanble Transform Unit test.

### DIFF
--- a/modules/core/test/core/transform.spec.js
+++ b/modules/core/test/core/transform.spec.js
@@ -225,7 +225,7 @@ test('WebGL#Transform run (Attribute)', t => {
 });
 
 // TODO - enabling this test breaks histopyramid.spec.js in headless mode
-test.skip('WebGL#Transform run (constant Attribute)', t => {
+test('WebGL#Transform run (constant Attribute)', t => {
   const {gl2} = fixture;
 
   if (!gl2) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1036
<!-- For other PRs without open issue -->
#### Background
`histopyramid#histoPyramid_getTexCoord` was using an unset attribute. Under regular GL context this was fine as it provides a value '0', but under HeadlesGL, previously set constant attribute value is provided causing the failure. Fix the unit test and enable `WebGL#Transform run (constant Attribute)` unit test that was disabled due to this.

Changes are only to the unit tests.

<!-- For all the PRs -->
#### Change List

- Fix Histopyramid Unit tests, eanble Transform Unit test.
