### PR TITLE
Get rid of accessor warnings that are always triggered.

### DIFF
--- a/modules/webgl/src/classes/accessor.js
+++ b/modules/webgl/src/classes/accessor.js
@@ -1,6 +1,6 @@
 import GL from '@luma.gl/constants';
 import {getTypedArrayFromGLType} from '../webgl-utils';
-import {log, checkProps, assert} from '../utils';
+import {checkProps, assert} from '../utils';
 
 const DEFAULT_ACCESSOR_VALUES = {
   offset: 0,
@@ -69,11 +69,7 @@ export default class Accessor {
   _assign(props = {}) {
     props = checkProps('Accessor', props, PROP_CHECKS);
 
-    // TYPE - not expected to be overridden
     if (props.type !== undefined) {
-      if (this.type !== undefined && props.type !== this.type) {
-        log.warn('accessor type mismatch')();
-      }
       this.type = props.type;
 
       // Auto-deduce integer type?
@@ -81,15 +77,9 @@ export default class Accessor {
         this.integer = true;
       }
     }
-
-    // SIZE - not expected to be overridden
     if (props.size !== undefined) {
-      if (this.size !== undefined && this.size !== props.size) {
-        log.warn('accessor size mismatch')();
-      }
       this.size = props.size;
     }
-
     if (props.offset !== undefined) {
       this.offset = props.offset;
     }


### PR DESCRIPTION
For #1042 
