### PR TITLE
Fix isWebGL2 methods.

### DIFF
--- a/modules/shadertools/src/utils/webgl-info.js
+++ b/modules/shadertools/src/utils/webgl-info.js
@@ -4,11 +4,8 @@
 // available in an WebGL1 or WebGL2 environment.
 
 /* eslint-disable no-inline-comments, max-len */
-/* global WebGL2RenderingContext */
 import isOldIE from './is-old-ie';
 import assert from './assert';
-
-const GL_TEXTURE_BINDING_3D = 0x806a;
 
 const GL_VENDOR = 0x1f00;
 const GL_RENDERER = 0x1f01;
@@ -33,11 +30,7 @@ Object.keys(WEBGL_FEATURES).forEach(key => {
 export {FEATURES};
 
 function isWebGL2(gl) {
-  return Boolean(
-    gl &&
-      ((typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) ||
-        gl.TEXTURE_BINDING_3D === GL_TEXTURE_BINDING_3D)
-  );
+  return Boolean(gl && gl._version === 2);
 }
 
 export function getContextInfo(gl) {

--- a/modules/webgl-state-tracker/src/utils/utils.js
+++ b/modules/webgl-state-tracker/src/utils/utils.js
@@ -8,6 +8,5 @@ export function isObjectEmpty(object) {
 
 // Returns true if WebGL2 context (Heuristic)
 export function isWebGL2(gl) {
-  const GL_TEXTURE_BINDING_3D = 0x806a;
-  return gl && gl.TEXTURE_BINDING_3D === GL_TEXTURE_BINDING_3D;
+  return Boolean(gl && gl._version === 2);
 }

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -7,7 +7,7 @@ import {getCanvas} from './create-canvas';
 import {createBrowserContext} from './create-browser-context';
 import {getContextDebugInfo} from '../debug/get-context-debug-info';
 
-import {WebGLRenderingContext, WebGL2RenderingContext} from '../webgl-utils';
+import {WebGL2RenderingContext} from '../webgl-utils';
 
 import {log, isBrowser, assert} from '../utils';
 import {global} from '../utils/globals';
@@ -197,10 +197,9 @@ function logInfo(gl) {
 
 function getVersion(gl) {
   if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
+    // WebGL2 context.
     return 2;
   }
-  if (typeof WebGLRenderingContext !== 'undefined' && gl instanceof WebGLRenderingContext) {
-    return 1;
-  }
-  return null; // Not a WebGL context
+  // Must be a WebGL1 context.
+  return 1;
 }

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -12,29 +12,16 @@ import {WebGLRenderingContext, WebGL2RenderingContext} from '../webgl-utils';
 import {log, isBrowser, assert} from '../utils';
 import {global} from '../utils/globals';
 
-// Heuristic testing of contexts (to indentify debug wrappers around gl contexts)
-const GL_ARRAY_BUFFER = 0x8892;
-const GL_TEXTURE_BINDING_3D = 0x806a;
-
 export const ERR_CONTEXT = 'Invalid WebGLRenderingContext';
 export const ERR_WEBGL = ERR_CONTEXT;
 export const ERR_WEBGL2 = 'Requires WebGL2';
 
-// HACK: avoid use of `gl` parameter name to defeat GL constant inliner, which invalidates check
-export function isWebGL(glContext) {
-  return Boolean(
-    glContext &&
-      (glContext instanceof WebGLRenderingContext || glContext.ARRAY_BUFFER === GL_ARRAY_BUFFER)
-  );
+export function isWebGL(gl) {
+  return Boolean(gl && Number.isFinite(gl._version));
 }
 
-// HACK: avoid use of `gl` parameter name to defeat GL constant inliner, which invalidates check
-export function isWebGL2(glContext) {
-  return Boolean(
-    glContext &&
-      (glContext instanceof WebGL2RenderingContext ||
-        glContext.TEXTURE_BINDING_3D === GL_TEXTURE_BINDING_3D)
-  );
+export function isWebGL2(gl) {
+  return Boolean(gl && gl._version === 2);
 }
 
 export function assertWebGLContext(gl) {
@@ -114,6 +101,13 @@ export function createGLContext(options = {}) {
 }
 
 export function instrumentGLContext(gl, options = {}) {
+  // Avoid multiple instrumentations
+  if (gl._instrumented) {
+    return gl;
+  }
+
+  gl._version = gl._version || getVersion(gl);
+
   options = Object.assign({}, contextDefaults, options);
   const {manageState, debug} = options;
 
@@ -135,6 +129,8 @@ export function instrumentGLContext(gl, options = {}) {
       log.priority = Math.max(log.priority, 1);
     }
   }
+
+  gl._instrumented = true;
 
   return gl;
 }
@@ -197,4 +193,14 @@ function logInfo(gl) {
   const driver = info ? `(${info.vendor},${info.renderer})` : '';
   const debug = gl.debug ? ' debug' : '';
   log.once(1, `${webGL}${debug} context ${driver}`)();
+}
+
+function getVersion(gl) {
+  if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
+    return 2;
+  }
+  if (typeof WebGLRenderingContext !== 'undefined' && gl instanceof WebGLRenderingContext) {
+    return 1;
+  }
+  return null; // Not a WebGL context
 }

--- a/modules/webgl/src/webgl-utils/webgl-checks.js
+++ b/modules/webgl/src/webgl-utils/webgl-checks.js
@@ -1,30 +1,19 @@
-import {WebGLRenderingContext, WebGL2RenderingContext} from './webgl-types';
+// import {WebGLRenderingContext, WebGL2RenderingContext} from './webgl-types';
 import {assert} from '../utils';
 
 // Heuristic testing of contexts (to indentify debug wrappers around gl contexts)
-const GL_ARRAY_BUFFER = 0x8892;
-const GL_TEXTURE_BINDING_3D = 0x806a;
+// const GL_ARRAY_BUFFER = 0x8892;
 
 export const ERR_CONTEXT = 'Invalid WebGLRenderingContext';
 export const ERR_WEBGL = ERR_CONTEXT;
 export const ERR_WEBGL2 = 'Requires WebGL2';
 
-export function isWebGL(glAlias) {
-  return Boolean(
-    glAlias &&
-      (glAlias instanceof WebGLRenderingContext ||
-        // `glAlias` name prevents gl constant inliner from making this always true
-        glAlias.ARRAY_BUFFER === GL_ARRAY_BUFFER)
-  );
+export function isWebGL(gl) {
+  return Boolean(gl && Number.isFinite(gl._version));
 }
 
-export function isWebGL2(glAlias) {
-  return Boolean(
-    glAlias &&
-      (glAlias instanceof WebGL2RenderingContext ||
-        // `glAlias` name prevents gl constant inliner from making this always true
-        glAlias.TEXTURE_BINDING_3D === GL_TEXTURE_BINDING_3D)
-  );
+export function isWebGL2(gl) {
+  return Boolean(gl && gl._version === 2);
 }
 
 export function assertWebGLContext(gl) {

--- a/modules/webgl/test/context/context.spec.js
+++ b/modules/webgl/test/context/context.spec.js
@@ -1,16 +1,55 @@
 const test = require('tape-catch');
-const {createGLContext, glGetDebugInfo, isWebGL} = require('luma.gl');
-
+const {createGLContext, glGetDebugInfo, isWebGL, isWebGL2} = require('luma.gl');
+const {gl, glDebug, gl2, gl2Debug} = getWebGLContexts({webgl2: false});
 test('WebGL#headless context creation', t => {
-  const gl = createGLContext();
   t.ok(isWebGL(gl), 'Context creation ok');
   t.end();
 });
 
 test('WebGL#glGetDebugInfo', t => {
-  const gl = createGLContext();
   const info = glGetDebugInfo(gl);
   t.ok(typeof info.vendor === 'string', 'info.vendor ok');
   t.ok(typeof info.renderer === 'string', 'info.renderer ok');
   t.end();
 });
+
+test('WebGL#isWebGL1', t => {
+  t.ok(isWebGL(gl), 'isWebGL should return true WebGL context');
+  t.ok(isWebGL(glDebug), 'isWebGL should return true on WebGL debug context');
+
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  t.ok(isWebGL2(gl2), 'isWebGL should return true WebGL2 context');
+  t.ok(isWebGL2(gl2Debug), 'isWebGL should return true on WebGL2 debug context');
+
+  t.end();
+});
+
+test('WebGL#isWebGL2', t => {
+  t.notOk(isWebGL2(gl), 'isWebGL2 should return false WebGL context');
+  t.notOk(isWebGL2(glDebug), 'isWebGL2 should return false on WebGL debug context');
+
+  if (!gl2) {
+    t.comment('WebGL2 not available, skipping tests');
+    t.end();
+    return;
+  }
+  t.ok(isWebGL2(gl2), 'isWebGL2 should return true WebGL2 context');
+  t.ok(isWebGL2(gl2Debug), 'isWebGL2 should return true on WebGL2 debug context');
+
+  t.end();
+});
+
+// Helper methods
+
+function getWebGLContexts() {
+  return {
+    gl: createGLContext({webgl1: true, webgl2: false, debug: false}),
+    glDebug: createGLContext({webgl1: true, webgl2: false, debug: true}),
+    gl2: createGLContext({webgl1: false, webgl2: true, debug: false}),
+    gl2Debug: createGLContext({webgl1: false, webgl2: true, debug: true})
+  };
+}

--- a/modules/webgl2-polyfill/src/polyfill-table.js
+++ b/modules/webgl2-polyfill/src/polyfill-table.js
@@ -13,7 +13,7 @@ const ERR_VAO_NOT_SUPPORTED = 'VertexArray requires WebGL2 or OES_vertex_array_o
 
 // Return true if WebGL2 context
 function isWebGL2(gl) {
-  return gl && gl.TEXTURE_BINDING_3D === GL.TEXTURE_BINDING_3D;
+  return Boolean(gl && gl._version === 2);
 }
 
 // Return object with webgl2 flag and an extension

--- a/modules/webgl2-polyfill/src/polyfills/get-parameter-polyfill.js
+++ b/modules/webgl2-polyfill/src/polyfills/get-parameter-polyfill.js
@@ -106,8 +106,7 @@ const WEBGL_PARAMETERS = {
 
 // Return true if WebGL2 context
 function isWebGL2(gl) {
-  const GL_TEXTURE_BINDING_3D = 0x806a;
-  return gl && gl.TEXTURE_BINDING_3D === GL_TEXTURE_BINDING_3D;
+  return Boolean(gl && gl._version === 2);
 }
 
 // A "replacement" gl.getParameter that accepts "enums" from extensions and WebGL2


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1048 
<!-- For other PRs without open issue -->
#### Background
Rename GL context variable to avoid constant inline replacement. This is needed to correctly verify if the context is WebGL2 or not.
<!-- For all the PRs -->
#### Change List
- Fix isWebGL2 methods
