### PR TITLE
Handle GLTF types in draco data parsed by loaders.gl

### DIFF
--- a/modules/core/src/lib/model-utils.js
+++ b/modules/core/src/lib/model-utils.js
@@ -70,7 +70,7 @@ export function inferAttributeAccessor(attributeName, attribute) {
     default:
   }
 
-  // Check for categorys
+  // Check for categories
   switch (category) {
     case 'vectors':
       attribute.size = attribute.size || 3;
@@ -87,6 +87,12 @@ export function inferAttributeAccessor(attributeName, attribute) {
       );
       break;
     default:
+  }
+
+  // loaders.gl draco loader produces these
+  if (attribute.componentType !== undefined) {
+    attribute.type = attribute.componentType;
+    delete attribute.componentType;
   }
 
   assert(Number.isFinite(attribute.size), `attribute ${attributeName} needs size`);

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "gatsby": "2.2.0-rc.2",
     "gatsby-plugin-styletron": "^3.0.5",
-    "ocular-gatsby": "1.0.0-alpha.16",
+    "ocular-gatsby": "1.0.0-alpha.17",
     "sharp": "0.21.1"
   }
 }


### PR DESCRIPTION
Workaround for the GLTF `type` properties that are produced by the loaders.gl draco loader.
