### PR TITLE
Website: fix several demo crashes

### DIFF
--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -173,6 +173,7 @@ class AppAnimationLoop extends AnimationLoop {
 
   onFinalize({gl}) {
     this.cube.delete();
+    super.onFinalize();
   }
 }
 

--- a/examples/core/texture-3d/app.js
+++ b/examples/core/texture-3d/app.js
@@ -150,6 +150,7 @@ class AppAnimationLoop extends AnimationLoop {
 
   onFinalize({gl, cloud}) {
     cloud.delete();
+    super.onFinalize();
   }
 }
 

--- a/modules/core/src/lib/animation-loop.js
+++ b/modules/core/src/lib/animation-loop.js
@@ -236,6 +236,7 @@ export default class AnimationLoop {
   }
 
   onFinalize(...args) {
+    this._initialized = false;
     return this.props.onFinalize(...args);
   }
 

--- a/modules/core/test/lib/animation-loop.spec.js
+++ b/modules/core/test/lib/animation-loop.spec.js
@@ -146,7 +146,7 @@ test('core#AnimationLoop start followed immediately by stop() should stop', t =>
   }, 100);
 });
 
-test('core#AnimationLoop a start/stop/start should not call initialize again', t => {
+test('core#AnimationLoop a start/stop/start should call initialize again', t => {
   if (typeof document === 'undefined') {
     t.comment('browser-only test');
     t.end();
@@ -166,7 +166,7 @@ test('core#AnimationLoop a start/stop/start should not call initialize again', t
   setTimeout(() => animationLoop.stop(), 50);
   setTimeout(() => animationLoop.start(), 100);
   setTimeout(() => {
-    t.is(initializeCalled, 1, 'onInitialize called');
+    t.is(initializeCalled, 2, 'onInitialize called');
     t.end();
   }, 150);
 });

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -37,14 +37,14 @@ export const EXAMPLE_PAGES = [
           code: `${GITHUB_TREE}/examples/core/mandelbrot`
         }
       },
-      {
-        name: 'Picking',
-        content: {
-          demo: 'PickingDemo',
-          code: `${GITHUB_TREE}/examples/core/picking`,
-          path: `${RAW_GITHUB}/examples/core/picking/`
-        }
-      },
+      // {
+      //   name: 'Picking',
+      //   content: {
+      //     demo: 'PickingDemo',
+      //     code: `${GITHUB_TREE}/examples/core/picking`,
+      //     path: `${RAW_GITHUB}/examples/core/picking/`
+      //   }
+      // },
       {
         name: 'Persistence',
         content: {
@@ -244,7 +244,7 @@ export const DOC_PAGES = [
         content: 'README.md'
       },
       {
-        name: 'What\'s New',
+        name: "What's New",
         content: 'whats-new.md'
       },
       {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1059 
<!-- For other PRs without open issue -->
#### Background
- Set `_initialized` to false during `onFinalize`, so when an instance of `AnimationLoop` is stopped and started again, resources are re created.
- Website demos's that are deleting resources and overwriting `onFinalize`, call `super.onFinalize` to properly set internal flags.
- Remove reference to un-used demo from website. (picking)
<!-- For all the PRs -->
#### Change List
- Website: fix several demo crashes
