### PR TITLE
Website demos: Fix crashes, state bleeding and context creation.

### DIFF
--- a/examples/core/cubemap/app.js
+++ b/examples/core/cubemap/app.js
@@ -116,7 +116,7 @@ void main(void) {
   }
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -222,8 +222,6 @@ function drawTexture({ctx, sign, axis, size}) {
   ctx.strokeStyle = color;
   ctx.strokeRect(0, 0, size, size);
 }
-
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/cubemap/app.js
+++ b/examples/core/cubemap/app.js
@@ -117,6 +117,10 @@ void main(void) {
 }
 
 class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   onInitialize({gl, canvas}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
@@ -174,8 +178,6 @@ class AppAnimationLoop extends AnimationLoop {
 
 const animationLoop = new AppAnimationLoop();
 
-animationLoop.getInfo = () => INFO_HTML;
-
 // Create six textures for the cube map sides
 function getFaceTextures({size}) {
   /* global document, OffscreenCanvas */
@@ -221,7 +223,7 @@ function drawTexture({ctx, sign, axis, size}) {
   ctx.strokeRect(0, 0, size, size);
 }
 
-export default animationLoop;
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/cubemap/app.js
+++ b/examples/core/cubemap/app.js
@@ -176,8 +176,6 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 // Create six textures for the cube map sides
 function getFaceTextures({size}) {
   /* global document, OffscreenCanvas */
@@ -225,5 +223,6 @@ function drawTexture({ctx, sign, axis, size}) {
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/dof/app.js
+++ b/examples/core/dof/app.js
@@ -558,9 +558,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/dof/app.js
+++ b/examples/core/dof/app.js
@@ -239,8 +239,12 @@ void main() {
 }
 `;
 
-export const animationLoopOptions = {
-  onInitialize: ({gl, _animationLoop}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({gl, _animationLoop}) {
     isDemoSupported = isWebGL2(gl);
     if (!isDemoSupported) {
       return {isDemoSupported};
@@ -421,9 +425,9 @@ export const animationLoopOptions = {
       dofUniforms,
       dofUniformsLayout
     };
-  },
+  }
 
-  onRender: ({
+  onRender({
     gl,
     tick,
     width,
@@ -438,7 +442,7 @@ export const animationLoopOptions = {
     dofProgram,
     dofUniforms,
     dofUniformsLayout
-  }) => {
+  }) {
     if (!isDemoSupported) {
       return;
     }
@@ -544,19 +548,18 @@ export const animationLoopOptions = {
 
     dofUniforms.unbind();
   }
-};
 
-const animationLoop = new AnimationLoop(animationLoopOptions);
+  isSupported() {
+    return isDemoSupported;
+  }
 
-animationLoop.getInfo = () => INFO_HTML;
-animationLoop.isSupported = () => {
-  return isDemoSupported;
-};
-animationLoop.getAltText = () => {
-  return ALT_TEXT;
-};
+  getAltText() {
+    return ALT_TEXT;
+  }
+}
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/dof/app.js
+++ b/examples/core/dof/app.js
@@ -239,7 +239,7 @@ void main() {
 }
 `;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -559,7 +559,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/fragment/app.js
+++ b/examples/core/fragment/app.js
@@ -1,13 +1,13 @@
-import concentricsAnimationLoop from './concentrics-demo';
+import {animationLoop, AppAnimationLoop} from './concentrics-demo';
 // import randomNoiseAnimationLoop from './random-noise-demo';
 
 // Pick one to fit with demo framework (until it can handle multiple exports)
-export default concentricsAnimationLoop;
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined') {
   window.startApp = function startApp() {
-    concentricsAnimationLoop.start();
+    animationLoop.start();
     // randomNoiseAnimationLoop.start();
   };
 }

--- a/examples/core/fragment/app.js
+++ b/examples/core/fragment/app.js
@@ -1,4 +1,4 @@
-import {animationLoop, AppAnimationLoop} from './concentrics-demo';
+import {default as AppAnimationLoop} from './concentrics-demo';
 // import randomNoiseAnimationLoop from './random-noise-demo';
 
 // Pick one to fit with demo framework (until it can handle multiple exports)
@@ -7,6 +7,7 @@ export default AppAnimationLoop;
 /* global window */
 if (typeof window !== 'undefined') {
   window.startApp = function startApp() {
+    const animationLoop = new AppAnimationLoop();
     animationLoop.start();
     // randomNoiseAnimationLoop.start();
   };

--- a/examples/core/fragment/concentrics-demo.js
+++ b/examples/core/fragment/concentrics-demo.js
@@ -22,8 +22,8 @@ void main(void) {
 }
 `;
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({gl}) => {
+export class AppAnimationLoop extends AnimationLoop {
+  onInitialize({gl}) {
     return {
       clipSpace: new ClipSpace(gl, {
         fs: CONCENTRICS_FRAGMENT_SHADER,
@@ -32,13 +32,15 @@ const animationLoop = new AnimationLoop({
         }
       })
     };
-  },
+  }
 
-  onRender: animationProps => {
+  onRender(animationProps) {
     animationProps.clipSpace.draw({animationProps});
   }
-});
 
-animationLoop.getInfo = () => INFO_HTML;
+  static getInfo() {
+    return INFO_HTML;
+  }
+}
 
-export default animationLoop;
+export const animationLoop = new AppAnimationLoop();

--- a/examples/core/fragment/concentrics-demo.js
+++ b/examples/core/fragment/concentrics-demo.js
@@ -22,7 +22,7 @@ void main(void) {
 }
 `;
 
-export class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   onInitialize({gl}) {
     return {
       clipSpace: new ClipSpace(gl, {
@@ -42,5 +42,3 @@ export class AppAnimationLoop extends AnimationLoop {
     return INFO_HTML;
   }
 }
-
-export const animationLoop = new AppAnimationLoop();

--- a/examples/core/gltf/app.js
+++ b/examples/core/gltf/app.js
@@ -163,8 +163,13 @@ async function loadGLTF(urlOrPromise, gl, options) {
   return {scenes, animator, gltf};
 }
 
-export class DemoApp {
-  constructor({modelFile = null, initialZoom = 2} = {}) {
+class DemoApp extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+  constructor(opts = {}) {
+    super(opts);
+    const {modelFile = null, initialZoom = 2} = opts;
     this.scenes = [];
     this.animator = null;
     this.gl = null;
@@ -191,6 +196,7 @@ export class DemoApp {
 
     this.onInitialize = this.onInitialize.bind(this);
     this.onRender = this.onRender.bind(this);
+    this._setDisplay(new VRDisplay());
   }
 
   initalizeEventHandling(canvas) {
@@ -409,12 +415,8 @@ export class DemoApp {
   }
 }
 
-const animationLoop = new AnimationLoop(new DemoApp());
-
-animationLoop._setDisplay(new VRDisplay());
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+const animationLoop = new DemoApp();
+export default DemoApp;
 
 if (typeof window !== 'undefined' && !window.website) {
   animationLoop.start();

--- a/examples/core/gltf/app.js
+++ b/examples/core/gltf/app.js
@@ -163,7 +163,7 @@ async function loadGLTF(urlOrPromise, gl, options) {
   return {scenes, animator, gltf};
 }
 
-class DemoApp extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -415,10 +415,8 @@ class DemoApp extends AnimationLoop {
   }
 }
 
-const animationLoop = new DemoApp();
-export default DemoApp;
-
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 
   const infoDiv = document.createElement('div');

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -112,7 +112,7 @@ void main(void) {
   }
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   constructor() {
     super({createFramebuffer: true, debug: true});
   }
@@ -205,7 +205,6 @@ function pickInstance(gl, pickX, pickY, model, framebuffer) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -204,9 +204,8 @@ function pickInstance(gl, pickX, pickY, model, framebuffer) {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -117,7 +117,7 @@ class AppAnimationLoop extends AnimationLoop {
     super({createFramebuffer: true, debug: true});
   }
 
-  getInfo() {
+  static getInfo() {
     return INFO_HTML;
   }
 
@@ -205,8 +205,7 @@ function pickInstance(gl, pickX, pickY, model, framebuffer) {
 }
 
 const animationLoop = new AppAnimationLoop();
-
-export default animationLoop;
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/mandelbrot/app.js
+++ b/examples/core/mandelbrot/app.js
@@ -89,7 +89,7 @@ function getZoomedCorners(zoomFactor = 1.01) {
   return corners;
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -118,9 +118,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-
-animationLoop.getInfo = () => INFO_HTML;
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/mandelbrot/app.js
+++ b/examples/core/mandelbrot/app.js
@@ -117,9 +117,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/mandelbrot/app.js
+++ b/examples/core/mandelbrot/app.js
@@ -89,8 +89,12 @@ function getZoomedCorners(zoomFactor = 1.01) {
   return corners;
 }
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({gl, _animationLoop}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({gl, _animationLoop}) {
     const cornersBuffer = new Buffer(gl, 32);
 
     return {
@@ -102,20 +106,21 @@ const animationLoop = new AnimationLoop({
       }),
       cornersBuffer
     };
-  },
+  }
 
-  onRender: ({gl, canvas, tick, clipSpace, cornersBuffer}) => {
+  onRender({gl, canvas, tick, clipSpace, cornersBuffer}) {
     gl.viewport(0, 0, Math.max(canvas.width, canvas.height), Math.max(canvas.width, canvas.height));
 
     cornersBuffer.setData(new Float32Array(getZoomedCorners()));
 
     clipSpace.draw();
   }
-});
+}
+
+const animationLoop = new AppAnimationLoop();
 
 animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/persistence/app.js
+++ b/examples/core/persistence/app.js
@@ -99,7 +99,7 @@ let persistenceQuad;
 let sphere;
 
 /* eslint-disable max-statements */
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -265,7 +265,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/persistence/app.js
+++ b/examples/core/persistence/app.js
@@ -99,8 +99,12 @@ let persistenceQuad;
 let sphere;
 
 /* eslint-disable max-statements */
-const animationLoop = new AnimationLoop({
-  onInitialize: ({gl, width, height}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({gl, width, height}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
       clearDepth: 1,
@@ -179,9 +183,9 @@ const animationLoop = new AnimationLoop({
       pos = pos.normalize().scale(0.5);
       nPos.push(pos);
     }
-  },
+  }
 
-  onRender: ({gl, tick, width, height, aspect}) => {
+  onRender({gl, tick, width, height, aspect}) {
     mainFramebuffer.resize({width, height});
     pingpongFramebuffers[0].resize({width, height});
     pingpongFramebuffers[1].resize({width, height});
@@ -258,11 +262,10 @@ const animationLoop = new AnimationLoop({
       }
     });
   }
-});
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/persistence/app.js
+++ b/examples/core/persistence/app.js
@@ -264,9 +264,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/quasicrystals/app.js
+++ b/examples/core/quasicrystals/app.js
@@ -61,7 +61,7 @@ function readHTMLControls() {
   return {uRatio};
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   onInitialize({gl}) {
     return {clipSpace: new ClipSpace(gl, {fs: FRAGMENT_SHADER})};
   }
@@ -82,7 +82,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/core/quasicrystals/app.js
+++ b/examples/core/quasicrystals/app.js
@@ -81,9 +81,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/quasicrystals/app.js
+++ b/examples/core/quasicrystals/app.js
@@ -8,10 +8,11 @@ const INFO_HTML = `
   Rendered by a custom fragment shader in a luma.gl <code>ClipSpace</code> model.
   A luma.gl port (of the PhiloGL port) of the work of
   <a href="http://www.jasondavies.com/animated-quasicrystals/">Jason Davies</a>
-  <form action="#">
-    <label for="wavefronts">Wavefronts </label>
-    <input id="wavefronts" type="range" value="7.0" min="1" max="10" step="0.1"/>
-  </form>
+</p>
+<div>
+  Wavefronts
+  <input id="wavefronts" type="range" value="7.0" min="1" max="10" step="0.1">
+</div>
 `;
 
 const FRAGMENT_SHADER = `\
@@ -49,28 +50,39 @@ void main(void) {
 }
 `;
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({gl}) => {
-    return {clipSpace: new ClipSpace(gl, {fs: FRAGMENT_SHADER})};
-  },
+function readHTMLControls() {
+  /* global document */
+  if (typeof document === 'undefined') {
+    return {uRatio: 7.0};
+  }
+  const wavefronts = document.getElementById('wavefronts');
 
-  onRender: ({gl, canvas, time, clipSpace}) => {
+  const uRatio = wavefronts ? parseFloat(wavefronts.value) : 7.0;
+  return {uRatio};
+}
+
+class AppAnimationLoop extends AnimationLoop {
+  onInitialize({gl}) {
+    return {clipSpace: new ClipSpace(gl, {fs: FRAGMENT_SHADER})};
+  }
+
+  onRender({gl, canvas, time, clipSpace}) {
+    const {uRatio} = readHTMLControls();
     clipSpace.draw({
       uniforms: {
         uTime: (time / 600) % (Math.PI * 2),
-        uRatio: animationLoop.getHTMLControlValue('wavefronts', 7)
+        uRatio
       }
     });
   }
 
-  // onAddHTML() {
-  //   return INFO_HTML;
-  // }
-});
+  static getInfo() {
+    return INFO_HTML;
+  }
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/core/shadowmap/app.js
+++ b/examples/core/shadowmap/app.js
@@ -186,9 +186,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/shadowmap/app.js
+++ b/examples/core/shadowmap/app.js
@@ -94,7 +94,7 @@ void main(void) {
 //   })
 // };
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -187,7 +187,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/shadowmap/app.js
+++ b/examples/core/shadowmap/app.js
@@ -94,9 +94,13 @@ void main(void) {
 //   })
 // };
 
-export const animationLoopOptions = {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   // gl: createGLContext()})
-  onInitialize: ({gl}) => {
+  onInitialize({gl}) {
     setParameters(gl, {
       depthTest: true,
       depthFunc: GL.LEQUAL
@@ -111,9 +115,9 @@ export const animationLoopOptions = {
         fs: SHADOWMAP_FRAGMENT
       })
     };
-  },
+  }
 
-  onRender: ({gl, tick, width, height, aspect, cube, shadow, fbShadow}) => {
+  onRender({gl, tick, width, height, aspect, cube, shadow, fbShadow}) {
     const model = new Matrix4()
       .translate([0, 6, 0])
       .rotateXYZ([tick * 0.01, 0, 0])
@@ -180,13 +184,10 @@ export const animationLoopOptions = {
       }
     });
   }
-};
+}
 
-const animationLoop = new AnimationLoop(animationLoopOptions);
-
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/texture-3d/app.js
+++ b/examples/core/texture-3d/app.js
@@ -44,7 +44,7 @@ const FAR = 10.0;
 const ALT_TEXT = "THIS DEMO REQUIRES WEBLG2, BUT YOUR BRWOSER DOESN'T SUPPORT IT";
 let isDemoSupported = true;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -171,7 +171,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/texture-3d/app.js
+++ b/examples/core/texture-3d/app.js
@@ -1,4 +1,4 @@
-import {AnimationLoop, setParameters, Model, Texture3D, Buffer} from '@luma.gl/core';
+import {AnimationLoop, setParameters, Model, Texture3D, Buffer, isWebGL2} from '@luma.gl/core';
 import {Matrix4, radians} from 'math.gl';
 import {perlin, lerp, shuffle, range} from './perlin';
 
@@ -41,17 +41,23 @@ void main() {
 
 const NEAR = 0.1;
 const FAR = 10.0;
+const ALT_TEXT = "THIS DEMO REQUIRES WEBLG2, BUT YOUR BRWOSER DOESN'T SUPPORT IT";
+let isDemoSupported = true;
 
 class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   constructor() {
     super({useDevicePixels: false});
   }
 
-  getInfo() {
-    return INFO_HTML;
-  }
-
   onInitialize({gl}) {
+    isDemoSupported = isWebGL2(gl);
+    if (!isDemoSupported) {
+      return {isDemoSupported};
+    }
     const noise = perlin({
       interpolation: lerp,
       permutation: shuffle(range(0, 255), Math.random)
@@ -135,6 +141,9 @@ class AppAnimationLoop extends AnimationLoop {
 
   onRender(animationProps) {
     const {gl, cloud, mvpMat, viewMat, tick, aspect} = animationProps;
+    if (!isDemoSupported) {
+      return;
+    }
 
     mvpMat.perspective({fov: radians(75), aspect, near: NEAR, far: FAR}).multiplyRight(viewMat);
 
@@ -151,11 +160,18 @@ class AppAnimationLoop extends AnimationLoop {
   onFinalize({gl, cloud}) {
     cloud.delete();
   }
+
+  isSupported() {
+    return isDemoSupported;
+  }
+
+  getAltText() {
+    return ALT_TEXT;
+  }
 }
 
 const animationLoop = new AppAnimationLoop();
-
-export default animationLoop;
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/texture-3d/app.js
+++ b/examples/core/texture-3d/app.js
@@ -170,9 +170,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/transform-feedback/app.js
+++ b/examples/core/transform-feedback/app.js
@@ -145,9 +145,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/transform-feedback/app.js
+++ b/examples/core/transform-feedback/app.js
@@ -72,7 +72,7 @@ const POSITIONS = [
 
 let isDemoSupported = true;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -146,7 +146,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/transform-feedback/app.js
+++ b/examples/core/transform-feedback/app.js
@@ -72,11 +72,10 @@ const POSITIONS = [
 
 let isDemoSupported = true;
 
-const animationLoop = new AnimationLoop({
-  glOptions: {
-    webgl2: true,
-    webgl1: false
-  },
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
 
   // eslint-disable-next-line
   onInitialize({canvas, gl}) {
@@ -124,7 +123,7 @@ const animationLoop = new AnimationLoop({
       transformModel,
       renderModel
     };
-  },
+  }
 
   onRender({gl, time, renderModel, transformModel}) {
     if (!isDemoSupported) {
@@ -136,17 +135,18 @@ const animationLoop = new AnimationLoop({
     renderModel.clear({color: [0.0, 0.0, 0.0, 1.0]});
     renderModel.draw();
   }
-});
 
-animationLoop.getInfo = () => INFO_HTML;
-animationLoop.isSupported = () => {
-  return isDemoSupported;
-};
-animationLoop.getAltText = () => {
-  return ALT_TEXT;
-};
+  isSupported() {
+    return isDemoSupported;
+  }
 
-export default animationLoop;
+  getAltText() {
+    return ALT_TEXT;
+  }
+}
+
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -151,14 +151,14 @@ function getDevicePixelRatio() {
   return typeof window !== 'undefined' ? window.devicePixelRatio : 1;
 }
 
-const animationLoop = new AnimationLoop({
-  glOptions: {
-    webgl2: true,
-    webgl1: false
-  },
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
 
-  createFramebuffer: true,
-
+  constructor(props = {}) {
+    super(Object.assign(props, {createFramebuffer: true}));
+  }
   /* eslint-disable max-statements */
   onInitialize({canvas, gl}) {
     isDemoSupported = isWebGL2(gl);
@@ -242,7 +242,7 @@ const animationLoop = new AnimationLoop({
       transform,
       isDemoSupported
     };
-  },
+  }
   /* eslint-enable max-statements */
 
   onRender({
@@ -297,7 +297,7 @@ const animationLoop = new AnimationLoop({
 
       pickInstance(gl, pickX, pickY, renderModel, framebuffer);
     }
-  },
+  }
 
   onFinalize({renderModel, transform}) {
     if (renderModel) {
@@ -307,7 +307,15 @@ const animationLoop = new AnimationLoop({
       transform.delete();
     }
   }
-});
+
+  isSupported() {
+    return isDemoSupported;
+  }
+
+  getAltText() {
+    return ALT_TEXT;
+  }
+}
 
 function pickInstance(gl, pickX, pickY, model, framebuffer) {
   framebuffer.clear({color: true, depth: true});
@@ -338,15 +346,8 @@ function pickInstance(gl, pickX, pickY, model, framebuffer) {
   }
 }
 
-animationLoop.getInfo = () => INFO_HTML;
-animationLoop.isSupported = () => {
-  return isDemoSupported;
-};
-animationLoop.getAltText = () => {
-  return ALT_TEXT;
-};
-
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -346,9 +346,8 @@ function pickInstance(gl, pickX, pickY, model, framebuffer) {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -151,7 +151,7 @@ function getDevicePixelRatio() {
   return typeof window !== 'undefined' ? window.devicePixelRatio : 1;
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -347,7 +347,6 @@ function pickInstance(gl, pickX, pickY, model, framebuffer) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (typeof window !== 'undefined' && !window.website) {

--- a/examples/lessons/01/app.js
+++ b/examples/lessons/01/app.js
@@ -100,9 +100,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/01/app.js
+++ b/examples/lessons/01/app.js
@@ -29,7 +29,7 @@ void main(void) {
 }
 `;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -100,7 +100,6 @@ class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-export default AppAnimationLoop;
 const animationLoop = new AppAnimationLoop();
 
 /* global window */

--- a/examples/lessons/01/app.js
+++ b/examples/lessons/01/app.js
@@ -29,8 +29,15 @@ void main(void) {
 }
 `;
 
-const animationLoop = new AnimationLoop({
-  debug: true,
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  constructor(props = {}) {
+    super(Object.assign(props, {debug: true}));
+  }
+
   onInitialize({gl, canvas, aspect}) {
     const TRIANGLE_VERTS = [0, 1, 0, -1, -1, 0, 1, -1, 0]; // eslint-disable-line
     const SQUARE_VERTS = [1, 1, 0, -1, 1, 0, 1, -1, 0, -1, -1, 0]; // eslint-disable-line
@@ -91,11 +98,10 @@ const animationLoop = new AnimationLoop({
         vertexCount: 4
       });
   }
-});
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+export default AppAnimationLoop;
+const animationLoop = new AppAnimationLoop();
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/02/app.js
+++ b/examples/lessons/02/app.js
@@ -106,9 +106,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/02/app.js
+++ b/examples/lessons/02/app.js
@@ -35,7 +35,7 @@ void main(void) {
 }
 `;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -106,7 +106,6 @@ class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-export default AppAnimationLoop;
 const animationLoop = new AppAnimationLoop();
 
 /* global window */

--- a/examples/lessons/02/app.js
+++ b/examples/lessons/02/app.js
@@ -35,7 +35,10 @@ void main(void) {
 }
 `;
 
-const animationLoop = new AnimationLoop({
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
   onInitialize({gl, aspect, canvas}) {
     const TRIANGLE_VERTS = [0, 1, 0, -1, -1, 0, 1, -1, 0];
     const TRIANGLE_COLORS = [1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1];
@@ -101,11 +104,10 @@ const animationLoop = new AnimationLoop({
         vertexCount: 4
       });
   }
-});
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+export default AppAnimationLoop;
+const animationLoop = new AppAnimationLoop();
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/03/app.js
+++ b/examples/lessons/03/app.js
@@ -55,7 +55,10 @@ const squareGeometry = new Geometry({
   }
 });
 
-const animationLoop = new AnimationLoop({
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
   onInitialize({gl}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
@@ -72,7 +75,7 @@ const animationLoop = new AnimationLoop({
       }),
       square: new ModelNode(gl, {geometry: squareGeometry, vs: VERTEX_SHADER, fs: FRAGMENT_SHADER})
     };
-  },
+  }
 
   onRender(context) {
     const {gl, tick, aspect, triangle, square} = context;
@@ -102,11 +105,10 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+export default AppAnimationLoop;
+const animationLoop = new AppAnimationLoop();
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/03/app.js
+++ b/examples/lessons/03/app.js
@@ -55,7 +55,7 @@ const squareGeometry = new Geometry({
   }
 });
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -107,7 +107,6 @@ class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-export default AppAnimationLoop;
 const animationLoop = new AppAnimationLoop();
 
 /* global window */

--- a/examples/lessons/03/app.js
+++ b/examples/lessons/03/app.js
@@ -107,9 +107,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/04/app.js
+++ b/examples/lessons/04/app.js
@@ -179,9 +179,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/04/app.js
+++ b/examples/lessons/04/app.js
@@ -124,8 +124,11 @@ class ColoredCubeGeometry extends CubeGeometry {
   }
 }
 
-const animationLoop = new AnimationLoop({
+class AppAnimationLoop extends AnimationLoop {
   // .context(() => createGLContext({canvas: 'lesson04-canvas'}))
+  static getInfo() {
+    return INFO_HTML;
+  }
   onInitialize({gl}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
@@ -146,7 +149,7 @@ const animationLoop = new AnimationLoop({
         geometry: new ColoredCubeGeometry()
       })
     };
-  },
+  }
   onRender({gl, tick, aspect, pyramid, cube}) {
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
 
@@ -174,11 +177,10 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+export default AppAnimationLoop;
+const animationLoop = new AppAnimationLoop();
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/04/app.js
+++ b/examples/lessons/04/app.js
@@ -124,7 +124,7 @@ class ColoredCubeGeometry extends CubeGeometry {
   }
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   // .context(() => createGLContext({canvas: 'lesson04-canvas'}))
   static getInfo() {
     return INFO_HTML;
@@ -179,7 +179,6 @@ class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-export default AppAnimationLoop;
 const animationLoop = new AppAnimationLoop();
 
 /* global window */

--- a/examples/lessons/05/app.js
+++ b/examples/lessons/05/app.js
@@ -37,7 +37,7 @@ void main(void) {
 }
 `;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -78,7 +78,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/05/app.js
+++ b/examples/lessons/05/app.js
@@ -37,8 +37,11 @@ void main(void) {
 }
 `;
 
-const animationLoop = new AnimationLoop({
-  // .context(() => createGLContext({canvas: 'lesson05-canvas'}))
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   onInitialize({gl}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
@@ -58,7 +61,7 @@ const animationLoop = new AnimationLoop({
         }
       })
     };
-  },
+  }
   onRender({gl, tick, aspect, cube}) {
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
 
@@ -72,11 +75,10 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/05/app.js
+++ b/examples/lessons/05/app.js
@@ -77,9 +77,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/06/app.js
+++ b/examples/lessons/06/app.js
@@ -74,7 +74,7 @@ function cycleFilter(newFilter) {
   }
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -210,7 +210,7 @@ function addKeyboardHandler(canvas) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
+
 /* global window */
 if (!window.website) {
   animationLoop.start();

--- a/examples/lessons/06/app.js
+++ b/examples/lessons/06/app.js
@@ -74,9 +74,12 @@ function cycleFilter(newFilter) {
   }
 }
 
-const animationLoop = new AnimationLoop({
-  // .context(() => createGLContext({canvas: 'lesson05-canvas'}))
-  onInitialize: ({canvas, gl}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({canvas, gl}) {
     addKeyboardHandler(canvas);
 
     setParameters(gl, {
@@ -133,8 +136,8 @@ const animationLoop = new AnimationLoop({
         })
       }
     };
-  },
-  onRender: ({gl, tick, aspect, cube, textures}) => {
+  }
+  onRender({gl, tick, aspect, cube, textures}) {
     xRot += xSpeed;
     yRot += ySpeed;
 
@@ -169,9 +172,7 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function addKeyboardHandler(canvas) {
   addEvents(canvas, {
@@ -208,8 +209,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-export default animationLoop;
-
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 /* global window */
 if (!window.website) {
   animationLoop.start();

--- a/examples/lessons/06/app.js
+++ b/examples/lessons/06/app.js
@@ -209,9 +209,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/07/app.js
+++ b/examples/lessons/07/app.js
@@ -181,8 +181,12 @@ let yRot = 0;
 let ySpeed = 0.0;
 let z = -5.0;
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({canvas, gl}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({canvas, gl}) {
     addKeyboardHandler(canvas);
 
     setParameters(gl, {
@@ -200,9 +204,9 @@ const animationLoop = new AnimationLoop({
         uniforms: {uSampler: new Texture2D(gl, 'crate.gif')}
       })
     };
-  },
+  }
 
-  onRender: ({gl, tick, aspect, cube}) => {
+  onRender({gl, tick, aspect, cube}) {
     xRot += xSpeed;
     yRot += ySpeed;
 
@@ -230,9 +234,7 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function addKeyboardHandler(canvas) {
   addEvents(canvas, {
@@ -266,7 +268,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/07/app.js
+++ b/examples/lessons/07/app.js
@@ -181,7 +181,7 @@ let yRot = 0;
 let ySpeed = 0.0;
 let z = -5.0;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -269,7 +269,6 @@ function addKeyboardHandler(canvas) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/07/app.js
+++ b/examples/lessons/07/app.js
@@ -268,9 +268,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/08/app.js
+++ b/examples/lessons/08/app.js
@@ -171,7 +171,7 @@ let yRot = 0;
 let ySpeed = 0.0;
 let cubePositionZ = -5.0;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -287,7 +287,6 @@ function addKeyboardHandler(canvas) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/08/app.js
+++ b/examples/lessons/08/app.js
@@ -286,9 +286,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/08/app.js
+++ b/examples/lessons/08/app.js
@@ -171,7 +171,11 @@ let yRot = 0;
 let ySpeed = 0.0;
 let cubePositionZ = -5.0;
 
-const animationLoop = new AnimationLoop({
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   onInitialize({canvas, gl}) {
     addKeyboardHandler(canvas);
 
@@ -198,7 +202,7 @@ const animationLoop = new AnimationLoop({
         uniforms: {uSampler: texture}
       })
     };
-  },
+  }
   onRender({gl, tick, aspect, cube}) {
     xRot += xSpeed;
     yRot += ySpeed;
@@ -248,9 +252,7 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function addKeyboardHandler(canvas) {
   addEvents(canvas, {
@@ -284,7 +286,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/09/app.js
+++ b/examples/lessons/09/app.js
@@ -17,8 +17,12 @@ The classic WebGL Lessons in luma.gl
 let zoom = -15;
 let tilt = 90;
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({canvas, gl}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({canvas, gl}) {
     addKeyboardHandler(canvas);
 
     setParameters(gl, {
@@ -43,8 +47,8 @@ const animationLoop = new AnimationLoop({
     }
 
     return {stars};
-  },
-  onRender: ({gl, tick, aspect, stars}) => {
+  }
+  onRender({gl, tick, aspect, stars}) {
     // Update Camera Position
     const radTilt = (tilt / 180) * Math.PI;
     const cameraY = Math.cos(radTilt) * zoom;
@@ -66,9 +70,7 @@ const animationLoop = new AnimationLoop({
       stars[i].animate();
     }
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function addKeyboardHandler(canvas) {
   addEvents(canvas, {
@@ -92,7 +94,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/09/app.js
+++ b/examples/lessons/09/app.js
@@ -94,9 +94,8 @@ function addKeyboardHandler(canvas) {
   });
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/09/app.js
+++ b/examples/lessons/09/app.js
@@ -17,7 +17,7 @@ The classic WebGL Lessons in luma.gl
 let zoom = -15;
 let tilt = 90;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -95,7 +95,6 @@ function addKeyboardHandler(canvas) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/10/app.js
+++ b/examples/lessons/10/app.js
@@ -190,9 +190,8 @@ function animate() {
   timeLine.lastTime = timeNow;
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/10/app.js
+++ b/examples/lessons/10/app.js
@@ -42,8 +42,12 @@ const timeLine = {
 
 const currentlyPressedKeys = {};
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({canvas, gl}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({canvas, gl}) {
     addKeyboardHandler(canvas, currentlyPressedKeys);
     addMouseHandler(canvas);
 
@@ -70,9 +74,9 @@ const animationLoop = new AnimationLoop({
       });
       return {world};
     });
-  },
+  }
 
-  onRender: ({gl, tick, aspect, world}) => {
+  onRender({gl, tick, aspect, world}) {
     // Update Camera Position
     const eyePos = [cameraInfo.xPos, cameraInfo.yPos, cameraInfo.zPos];
     const centerPos = new Matrix4()
@@ -100,9 +104,7 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function addKeyboardHandler(canvas) {
   addEvents(canvas, {
@@ -188,7 +190,8 @@ function animate() {
   timeLine.lastTime = timeNow;
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/10/app.js
+++ b/examples/lessons/10/app.js
@@ -42,7 +42,7 @@ const timeLine = {
 
 const currentlyPressedKeys = {};
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -191,7 +191,6 @@ function animate() {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/11/app.js
+++ b/examples/lessons/11/app.js
@@ -71,7 +71,11 @@ const appState = {
   moonRotationMatrix: new Matrix4()
 };
 
-const animationLoop = new AnimationLoop({
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   onInitialize({canvas, gl}) {
     addMouseHandler(canvas);
 
@@ -95,7 +99,7 @@ const animationLoop = new AnimationLoop({
         }
       })
     };
-  },
+  }
 
   // eslint-disable-next-line complexity
   onRender({gl, tick, aspect, moon}) {
@@ -136,9 +140,7 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function addMouseHandler(canvas) {
   addEvents(canvas, {
@@ -208,7 +210,8 @@ function getControlValues() {
   return {lighting, ambientColor, lightingDirection, directionalColor};
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/11/app.js
+++ b/examples/lessons/11/app.js
@@ -210,9 +210,8 @@ function getControlValues() {
   return {lighting, ambientColor, lightingDirection, directionalColor};
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/11/app.js
+++ b/examples/lessons/11/app.js
@@ -71,7 +71,7 @@ const appState = {
   moonRotationMatrix: new Matrix4()
 };
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -211,7 +211,6 @@ function getControlValues() {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/12/app.js
+++ b/examples/lessons/12/app.js
@@ -204,9 +204,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/12/app.js
+++ b/examples/lessons/12/app.js
@@ -85,7 +85,7 @@ function animateAppState() {
   appState.lastTime = timeNow;
 }
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -205,7 +205,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/12/app.js
+++ b/examples/lessons/12/app.js
@@ -59,6 +59,15 @@ void main(void) {
 }
 `;
 
+const INFO_HTML = `
+<p>
+  <a href="http://learningwebgl.com/blog/?p=1359" target="_blank">
+  Point lighting
+  </a>
+<p>
+  The classic WebGL Lessons in luma.gl
+`;
+
 const appState = {
   moonRotationMatrix: new Matrix4().rotateY(radians(180)).translate([5, 0, 0]),
   cubeRotationMatrix: new Matrix4().translate([5, 0, 0]),
@@ -76,7 +85,11 @@ function animateAppState() {
   appState.lastTime = timeNow;
 }
 
-const animationLoop = new AnimationLoop({
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   onInitialize({canvas, gl}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
@@ -106,7 +119,7 @@ const animationLoop = new AnimationLoop({
         }
       })
     };
-  },
+  }
 
   onRender({gl, tick, aspect, moon, cube}) {
     // eslint-disable-line complexity
@@ -189,20 +202,10 @@ const animationLoop = new AnimationLoop({
 
     animateAppState();
   }
-});
+}
 
-animationLoop.getInfo = () => {
-  return `
-  <p>
-    <a href="http://learningwebgl.com/blog/?p=1359" target="_blank">
-    Point lighting
-    </a>
-  <p>
-    The classic WebGL Lessons in luma.gl
-    `;
-};
-
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/13/app.js
+++ b/examples/lessons/13/app.js
@@ -84,8 +84,12 @@ const appState = {
   lastTime: 0
 };
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({canvas, gl}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({canvas, gl}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
       clearDepth: 1,
@@ -118,10 +122,10 @@ const animationLoop = new AnimationLoop({
     });
 
     return {moon, cube};
-  },
+  }
 
   // eslint-disable-next-line complexity
-  onRender: ({gl, tick, aspect, moon, cube}) => {
+  onRender({gl, tick, aspect, moon, cube}) {
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
 
     // set camera position
@@ -187,9 +191,7 @@ const animationLoop = new AnimationLoop({
 
     animate(appState);
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function animate(state) {
   const timeNow = new Date().getTime();
@@ -202,7 +204,8 @@ function animate(state) {
   state.lastTime = timeNow;
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/13/app.js
+++ b/examples/lessons/13/app.js
@@ -84,7 +84,7 @@ const appState = {
   lastTime: 0
 };
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -205,7 +205,6 @@ function animate(state) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/13/app.js
+++ b/examples/lessons/13/app.js
@@ -204,9 +204,8 @@ function animate(state) {
   state.lastTime = timeNow;
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/14/app.js
+++ b/examples/lessons/14/app.js
@@ -234,7 +234,7 @@ const LIGHT_UNIFORMS = {
   uPointLightingDiffuseColor: [0.8, 0.8, 0.8]
 };
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -352,7 +352,6 @@ class AppAnimationLoop extends AnimationLoop {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/14/app.js
+++ b/examples/lessons/14/app.js
@@ -351,9 +351,8 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/14/app.js
+++ b/examples/lessons/14/app.js
@@ -234,7 +234,11 @@ const LIGHT_UNIFORMS = {
   uPointLightingDiffuseColor: [0.8, 0.8, 0.8]
 };
 
-const animationLoop = new AnimationLoop({
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
   onInitialize({gl}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
@@ -286,7 +290,7 @@ const animationLoop = new AnimationLoop({
       });
       return {teapot, earthTexture, galvanizedTexture};
     });
-  },
+  }
 
   onRender({gl, tick, aspect, teapot, earthTexture, galvanizedTexture}) {
     gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
@@ -345,11 +349,10 @@ const animationLoop = new AnimationLoop({
       })
       .draw();
   }
-});
+}
 
-animationLoop.getInfo = () => INFO_HTML;
-
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/15/app.js
+++ b/examples/lessons/15/app.js
@@ -86,105 +86,7 @@ void main(void) {
 }
 `;
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({canvas, gl}) => {
-    setParameters(gl, {
-      clearColor: [0, 0, 0, 1],
-      clearDepth: 1,
-      depthTest: true
-    });
-
-    const specularTexture = new Texture2D(gl, {
-      data: 'earth-specular.gif',
-      parameters: {
-        [gl.TEXTURE_MAG_FILTER]: gl.LINEAR,
-        [gl.TEXTURE_MIN_FILTER]: gl.LINEAR_MIPMAP_NEAREST,
-        [gl.TEXTURE_WRAP_S]: gl.REPEAT,
-        [gl.TEXTURE_WRAP_T]: gl.REPEAT
-      },
-      mipmap: true
-    });
-
-    const colorTexture = new Texture2D(gl, {
-      data: 'earth.jpg',
-      parameters: {
-        [gl.TEXTURE_MAG_FILTER]: gl.LINEAR,
-        [gl.TEXTURE_MIN_FILTER]: gl.LINEAR_MIPMAP_NEAREST,
-        [gl.TEXTURE_WRAP_S]: gl.REPEAT,
-        [gl.TEXTURE_WRAP_T]: gl.REPEAT
-      },
-      mipmap: true
-    });
-
-    const earth = new Model(gl, {
-      geometry: new SphereGeometry({
-        nlat: 30,
-        nlong: 30,
-        radius: 13
-      }),
-      fs: FRAGMENT_LIGHTING_FRAGMENT_SHADER,
-      vs: FRAGMENT_LIGHTING_VERTEX_SHADER,
-      uniforms: Object.assign(
-        {
-          uColorMapSampler: colorTexture,
-          uSpecularMapSampler: specularTexture
-        },
-        EARTH_UNIFORMS,
-        LIGHT_UNIFORMS
-      )
-    });
-
-    return {earth, specularTexture, colorTexture};
-  },
-
-  onRender: ({gl, tick, aspect, earth}) => {
-    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
-
-    // set camera position
-    const uVMatrix = new Matrix4().lookAt({eye: [0, 0, 10], center: [0, 0, 0], up: [-0.5, 1, 0]});
-
-    const {
-      useLighting,
-      useSpecularMap,
-      useColorMap,
-      ambientColor,
-      pointLightingLocation,
-      pointLightSpecularColor,
-      pointLightingDiffuseColor
-    } = getControlValues();
-
-    earth.setUniforms({
-      uUseSpecularMap: useSpecularMap,
-      uUseColorMap: useColorMap,
-      uUseLighting: useLighting
-    });
-
-    if (useLighting) {
-      earth.setUniforms({
-        uAmbientColor: ambientColor,
-        uPointLightingLocation: pointLightingLocation,
-        uPointLightingSpecularColor: pointLightSpecularColor,
-        uPointLightingDiffuseColor: pointLightingDiffuseColor
-      });
-    }
-
-    const phi = tick * 0.01;
-    return earth
-      .setUniforms({
-        uMMatrix: new Matrix4().translate([0, 0, -40]).rotateY(phi),
-        uVMatrix,
-        uPMatrix: new Matrix4().perspective({
-          fov: (45 * Math.PI) / 180,
-          aspect,
-          near: 0.1,
-          far: 100
-        })
-      })
-      .draw();
-  }
-});
-
-animationLoop.getInfo = () => `
+const INFO_HTML = `
 <p>
   <a href="http://learningwebgl.com/blog/?p=1778" target="_blank">
     Specular maps
@@ -258,6 +160,108 @@ animationLoop.getInfo = () => `
   The classic WebGL Lessons in luma.gl
 `;
 
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({canvas, gl}) {
+    setParameters(gl, {
+      clearColor: [0, 0, 0, 1],
+      clearDepth: 1,
+      depthTest: true
+    });
+
+    const specularTexture = new Texture2D(gl, {
+      data: 'earth-specular.gif',
+      parameters: {
+        [gl.TEXTURE_MAG_FILTER]: gl.LINEAR,
+        [gl.TEXTURE_MIN_FILTER]: gl.LINEAR_MIPMAP_NEAREST,
+        [gl.TEXTURE_WRAP_S]: gl.REPEAT,
+        [gl.TEXTURE_WRAP_T]: gl.REPEAT
+      },
+      mipmap: true
+    });
+
+    const colorTexture = new Texture2D(gl, {
+      data: 'earth.jpg',
+      parameters: {
+        [gl.TEXTURE_MAG_FILTER]: gl.LINEAR,
+        [gl.TEXTURE_MIN_FILTER]: gl.LINEAR_MIPMAP_NEAREST,
+        [gl.TEXTURE_WRAP_S]: gl.REPEAT,
+        [gl.TEXTURE_WRAP_T]: gl.REPEAT
+      },
+      mipmap: true
+    });
+
+    const earth = new Model(gl, {
+      geometry: new SphereGeometry({
+        nlat: 30,
+        nlong: 30,
+        radius: 13
+      }),
+      fs: FRAGMENT_LIGHTING_FRAGMENT_SHADER,
+      vs: FRAGMENT_LIGHTING_VERTEX_SHADER,
+      uniforms: Object.assign(
+        {
+          uColorMapSampler: colorTexture,
+          uSpecularMapSampler: specularTexture
+        },
+        EARTH_UNIFORMS,
+        LIGHT_UNIFORMS
+      )
+    });
+
+    return {earth, specularTexture, colorTexture};
+  }
+
+  onRender({gl, tick, aspect, earth}) {
+    gl.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
+
+    // set camera position
+    const uVMatrix = new Matrix4().lookAt({eye: [0, 0, 10], center: [0, 0, 0], up: [-0.5, 1, 0]});
+
+    const {
+      useLighting,
+      useSpecularMap,
+      useColorMap,
+      ambientColor,
+      pointLightingLocation,
+      pointLightSpecularColor,
+      pointLightingDiffuseColor
+    } = getControlValues();
+
+    earth.setUniforms({
+      uUseSpecularMap: useSpecularMap,
+      uUseColorMap: useColorMap,
+      uUseLighting: useLighting
+    });
+
+    if (useLighting) {
+      earth.setUniforms({
+        uAmbientColor: ambientColor,
+        uPointLightingLocation: pointLightingLocation,
+        uPointLightingSpecularColor: pointLightSpecularColor,
+        uPointLightingDiffuseColor: pointLightingDiffuseColor
+      });
+    }
+
+    const phi = tick * 0.01;
+    return earth
+      .setUniforms({
+        uMMatrix: new Matrix4().translate([0, 0, -40]).rotateY(phi),
+        uVMatrix,
+        uPMatrix: new Matrix4().perspective({
+          fov: (45 * Math.PI) / 180,
+          aspect,
+          near: 0.1,
+          far: 100
+        })
+      })
+      .draw();
+  }
+}
+
 /* global document */
 const $id = id => document.getElementById(id);
 const $checked = id => ($id(id) ? $id(id).checked : true);
@@ -292,7 +296,8 @@ function getControlValues() {
   };
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/15/app.js
+++ b/examples/lessons/15/app.js
@@ -160,7 +160,7 @@ const INFO_HTML = `
   The classic WebGL Lessons in luma.gl
 `;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -297,7 +297,6 @@ function getControlValues() {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/15/app.js
+++ b/examples/lessons/15/app.js
@@ -296,9 +296,8 @@ function getControlValues() {
   };
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/16/app.js
+++ b/examples/lessons/16/app.js
@@ -523,9 +523,8 @@ function parseJSON(file) {
   }
 }
 
-const animationLoop = new AppAnimationLoop();
-
 /* global window */
 if (!window.website) {
+  const animationLoop = new AppAnimationLoop();
   animationLoop.start();
 }

--- a/examples/lessons/16/app.js
+++ b/examples/lessons/16/app.js
@@ -185,7 +185,7 @@ const moonAngleDelta = 0.01; // * Math.PI / 180.0;
 const cubeAngleDelta = 0.01; // * Math.PI / 180.0;
 const laptopAngleDelta = -0.002; // * Math.PI / 180.0;
 
-class AppAnimationLoop extends AnimationLoop {
+export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
@@ -524,7 +524,6 @@ function parseJSON(file) {
 }
 
 const animationLoop = new AppAnimationLoop();
-export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/examples/lessons/16/app.js
+++ b/examples/lessons/16/app.js
@@ -185,8 +185,12 @@ const moonAngleDelta = 0.01; // * Math.PI / 180.0;
 const cubeAngleDelta = 0.01; // * Math.PI / 180.0;
 const laptopAngleDelta = -0.002; // * Math.PI / 180.0;
 
-const animationLoop = new AnimationLoop({
-  onInitialize: ({canvas, gl}) => {
+class AppAnimationLoop extends AnimationLoop {
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({canvas, gl}) {
     setParameters(gl, {
       clearColor: [0, 0, 0, 1],
       clearDepth: 1,
@@ -257,28 +261,15 @@ const animationLoop = new AnimationLoop({
 
       return {moon, macbook, cube, laptopScreenModel, tCrate, tSquare};
     });
-  },
+  }
 
-  onRender: ({
-    gl,
-    tick,
-    aspect,
-    moon,
-    macbook,
-    cube,
-    laptopScreenModel,
-    canvas,
-    tCrate,
-    tSquare
-  }) => {
+  onRender({gl, tick, aspect, moon, macbook, cube, laptopScreenModel, canvas, tCrate, tSquare}) {
     generateTextureForLaptopScreen(gl, tick, aspect, moon, cube, tSquare);
     if (!DISABLE_FB) {
       drawOuterScene(gl, tick, aspect, macbook, laptopScreenModel, canvas, tCrate);
     }
   }
-});
-
-animationLoop.getInfo = () => INFO_HTML;
+}
 
 function getLaptopUniforms() {
   return {
@@ -532,7 +523,8 @@ function parseJSON(file) {
   }
 }
 
-export default animationLoop;
+const animationLoop = new AppAnimationLoop();
+export default AppAnimationLoop;
 
 /* global window */
 if (!window.website) {

--- a/test/render/example-test-cases.js
+++ b/test/render/example-test-cases.js
@@ -22,7 +22,8 @@ const examples = {
 };
 
 export default Object.keys(examples).map(name => {
-  const animationLoop = examples[name];
+  const AppAnimationLoop = examples[name];
+  const animationLoop = new AppAnimationLoop();
   return {
     name,
     onInitialize: params => {

--- a/website/src/components/demo-runner.js
+++ b/website/src/components/demo-runner.js
@@ -7,6 +7,7 @@ import {updateMeta, useParams} from '../actions/app-actions';
 /* global window */
 window.website = true;
 const Demos = require('../../contents/demos.js');
+let currentDemo = null;
 
 const propTypes = {
   demo: PropTypes.string,
@@ -22,44 +23,45 @@ const DEFAULT_ALT_TEXT = 'THIS DEMO IS NOT SUPPORTED';
 class DemoRunner extends Component {
 
   componentDidMount() {
-    const demo = Demos[this.props.demo];
+    const Demo = Demos[this.props.demo];
+    const demo = new Demo();
     if (demo) {
       demo.start({
         canvas: this.props.canvas
         // debug: true
       });
     }
+    currentDemo = demo;
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.demo !== this.props.demo) {
-      let demo = Demos[this.props.demo];
-      if (demo) {
-        demo.stop();
+      if (currentDemo) {
+        currentDemo.stop();
       }
-      demo = Demos[nextProps.demo];
+      const Demo = Demos[nextProps.demo];
+      const demo = new Demo();
       if (demo) {
         demo.start({canvas: this.props.canvas});
       }
+      currentDemo = demo;
     }
   }
 
   componentWillUnmount() {
-    const demo = Demos[this.props.demo];
-    if (demo) {
-      demo.stop();
+    if (currentDemo) {
+      currentDemo.stop();
     }
   }
 
   render() {
     const {width, height} = this.props;
 
-    const demo = Demos[this.props.demo];
-    if (demo) {
-      const notSupported = demo.isSupported && !demo.isSupported();
+    if (currentDemo) {
+      const notSupported = currentDemo.isSupported && !currentDemo.isSupported();
 
       if (notSupported) {
-        const altText = demo.getAltText ? demo.getAltText() : DEFAULT_ALT_TEXT;
+        const altText = currentDemo.getAltText ? currentDemo.getAltText() : DEFAULT_ALT_TEXT;
         return (
           <div style={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh'}}>
             <h2> {altText} </h2>

--- a/website/src/components/demo-runner.js
+++ b/website/src/components/demo-runner.js
@@ -21,17 +21,15 @@ const defaultProps = {
 const DEFAULT_ALT_TEXT = 'THIS DEMO IS NOT SUPPORTED';
 
 class DemoRunner extends Component {
-
   componentDidMount() {
     const Demo = Demos[this.props.demo];
-    const demo = new Demo();
-    if (demo) {
-      demo.start({
+    currentDemo = new Demo();
+    if (currentDemo) {
+      currentDemo.start({
         canvas: this.props.canvas
         // debug: true
       });
     }
-    currentDemo = demo;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -40,11 +38,10 @@ class DemoRunner extends Component {
         currentDemo.stop();
       }
       const Demo = Demos[nextProps.demo];
-      const demo = new Demo();
-      if (demo) {
-        demo.start({canvas: this.props.canvas});
+      currentDemo = new Demo();
+      if (currentDemo) {
+        currentDemo.start({canvas: this.props.canvas});
       }
-      currentDemo = demo;
     }
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1059 
<!-- For other PRs without open issue -->
#### Background
We are exporting demo instances from examples and not properly initializing when switching between demos, it is causing two issues :

1, During the launch instancing demo is initialized and it is created with 'front-canvas', but during example's page, canvas is different and a different `gl` context is created, but instancing demos is not re-initialized and uses old invalid gl context.
2. Some of the demos are calling `Finalize` to delete resources (Model) when they are stopped, but they are not recreated when re-started, causing crashes, when switch between demo pages.
3. Demos set the state during `onInitialize`, but when switching between the demos don't always trigger `onInitialize` since we are caching demo objects and `onInitialize` is only called when they first created.

Right now, initialize/finalize of `animationLoop` are not synced, to fix this make following changes
1. Export demo classes instead of demo instances, so `gl` context is created with current canvas.
2. Always call `initialize` during during `AnimationLoop.start()`, so when a start/stop is called multiple times, all the state is correctly set before rendering.

<!-- For all the PRs -->
#### Change List
- Website: Export Demo as classes instead of objects.
- Fix browser tests
- cleanup
- More cleanup
