### PR TITLE
Website: Fix WebGL demo crashes when switching

### DIFF
--- a/examples/core/dof/app.js
+++ b/examples/core/dof/app.js
@@ -42,7 +42,6 @@ post-processing effect.
 `;
 
 const ALT_TEXT = "THIS DEMO REQUIRES WEBLG2, BUT YOUR BROWSER DOESN'T SUPPORT IT";
-let isDemoSupported = true;
 
 const QUAD_VERTS = [1, 1, 0, -1, 1, 0, 1, -1, 0, -1, -1, 0]; // eslint-disable-line
 const NUM_ROWS = 5;
@@ -244,10 +243,16 @@ export default class AppAnimationLoop extends AnimationLoop {
     return INFO_HTML;
   }
 
+  constructor(props = {}) {
+    super(props);
+    // Default value is true, so GL context is always created to verify wheter it is WebGL2 or not.
+    this.isDemoSupported = true;
+  }
+
   onInitialize({gl, _animationLoop}) {
-    isDemoSupported = isWebGL2(gl);
-    if (!isDemoSupported) {
-      return {isDemoSupported};
+    this.isDemoSupported = isWebGL2(gl);
+    if (!this.isDemoSupported) {
+      return {};
     }
 
     setParameters(gl, {
@@ -443,7 +448,7 @@ export default class AppAnimationLoop extends AnimationLoop {
     dofUniforms,
     dofUniformsLayout
   }) {
-    if (!isDemoSupported) {
+    if (!this.isDemoSupported) {
       return;
     }
 
@@ -550,7 +555,7 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 
   isSupported() {
-    return isDemoSupported;
+    return this.isDemoSupported;
   }
 
   getAltText() {

--- a/examples/core/texture-3d/app.js
+++ b/examples/core/texture-3d/app.js
@@ -42,21 +42,22 @@ void main() {
 const NEAR = 0.1;
 const FAR = 10.0;
 const ALT_TEXT = "THIS DEMO REQUIRES WEBLG2, BUT YOUR BROWSER DOESN'T SUPPORT IT";
-let isDemoSupported = true;
 
 export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
 
-  constructor() {
-    super({useDevicePixels: false});
+  constructor(props = {}) {
+    super(Object.assign(props, {useDevicePixels: true}));
+    // Default value is true, so GL context is always created to verify wheter it is WebGL2 or not.
+    this.isDemoSupported = true;
   }
 
   onInitialize({gl}) {
-    isDemoSupported = isWebGL2(gl);
-    if (!isDemoSupported) {
-      return {isDemoSupported};
+    this.isDemoSupported = isWebGL2(gl);
+    if (!this.isDemoSupported) {
+      return {};
     }
     const noise = perlin({
       interpolation: lerp,
@@ -141,7 +142,7 @@ export default class AppAnimationLoop extends AnimationLoop {
 
   onRender(animationProps) {
     const {gl, cloud, mvpMat, viewMat, tick, aspect} = animationProps;
-    if (!isDemoSupported) {
+    if (!this.isDemoSupported) {
       return;
     }
 
@@ -164,7 +165,7 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 
   isSupported() {
-    return isDemoSupported;
+    return this.isDemoSupported;
   }
 
   getAltText() {

--- a/examples/core/transform-feedback/app.js
+++ b/examples/core/transform-feedback/app.js
@@ -70,17 +70,21 @@ const POSITIONS = [
   -1.0, -1.0, 0.0, 1.0
 ];
 
-let isDemoSupported = true;
-
 export default class AppAnimationLoop extends AnimationLoop {
   static getInfo() {
     return INFO_HTML;
   }
 
+  constructor(props = {}) {
+    super(props);
+    // Default value is true, so GL context is always created to verify wheter it is WebGL2 or not.
+    this.isDemoSupported = true;
+  }
+
   // eslint-disable-next-line
   onInitialize({canvas, gl}) {
-    isDemoSupported = isWebGL2(gl);
-    if (!isDemoSupported) {
+    this.isDemoSupported = isWebGL2(gl);
+    if (!this.isDemoSupported) {
       log.error(ALT_TEXT)();
       return {};
     }
@@ -126,7 +130,7 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 
   onRender({gl, time, renderModel, transformModel}) {
-    if (!isDemoSupported) {
+    if (!this.isDemoSupported) {
       return;
     }
     transformModel.transform({unbindModels: [renderModel]});
@@ -137,7 +141,7 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 
   isSupported() {
-    return isDemoSupported;
+    return this.isDemoSupported;
   }
 
   getAltText() {

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -134,8 +134,6 @@ void main()
 const NUM_INSTANCES = 1000;
 const log = new Log({id: 'transform'}).enable();
 
-let isDemoSupported = true;
-
 // TODO PIKCING TEMPORARILY DISABLED
 let pickPosition = [0, 0];
 
@@ -158,13 +156,15 @@ export default class AppAnimationLoop extends AnimationLoop {
 
   constructor(props = {}) {
     super(Object.assign(props, {createFramebuffer: true}));
+    // Default value is true, so GL context is always created to verify wheter it is WebGL2 or not.
+    this.isDemoSupported = true;
   }
   /* eslint-disable max-statements */
   onInitialize({canvas, gl}) {
-    isDemoSupported = isWebGL2(gl);
-    if (!isDemoSupported) {
+    this.isDemoSupported = isWebGL2(gl);
+    if (!this.isDemoSupported) {
       log.error(ALT_TEXT)();
-      return {isDemoSupported};
+      return {};
     }
     gl.canvas.addEventListener('mousemove', mousemove);
     gl.canvas.addEventListener('mouseleave', mouseleave);
@@ -256,7 +256,7 @@ export default class AppAnimationLoop extends AnimationLoop {
     useDevicePixels,
     time
   }) {
-    if (!isDemoSupported) {
+    if (!this.isDemoSupported) {
       return;
     }
     transform.run({
@@ -308,7 +308,7 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 
   isSupported() {
-    return isDemoSupported;
+    return this.isDemoSupported;
   }
 
   getAltText() {

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -89,7 +89,7 @@ export const EXAMPLE_PAGES = [
         }
       },
       {
-        name: 'Texture3D',
+        name: 'Texture3D  (WebGL2)',
         content: {
           demo: 'Texture3DDemo',
           code: `${GITHUB_TREE}/examples/core/texture-3d`


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #976 
<!-- For other PRs without open issue -->
#### Background
- Whether the demo is supported or not is calculated after `GL` context is created, hence default value of `isDemoSupported` should always be true to create `GL` context, so move `isDemoSupported` from global scope to instance scope.
- Mark `Texture3D` as WebGL 2 demo to match with others.
<!-- For all the PRs -->
#### Change List
- Website: Fix WebGL demo crashes when switching
