### PR TITLE
Use start/end channel parameters instead of duration

### DIFF
--- a/docs/api-reference/core/timeline.md
+++ b/docs/api-reference/core/timeline.md
@@ -16,13 +16,17 @@ Automatic update usage (assume `update` method is being called once per frame):
 const timeline = animationLoop.timeline;
 const channel1 = timeline.addChannel({
   rate: 0.5,
-  duration: 4000,
-  wrapMode: "loop"
+  start: 1000,
+  end: 4000,
+  wrapStart: "loop"
+  wrapEnd: "loop"
 });
 const channel2 = timeline.addChannel({
   rate: 2,
-  duration: 1000,
-  wrapMode: "clamp"
+  start: 2000,
+  end: 6000,
+  wrapStart: "clamp"
+  wrapEnd: "clamp"
 });
 
 timeline.pause();
@@ -39,13 +43,17 @@ Manual usage:
 const timeline = new Timeline();
 const channel1 = timeline.addChannel({
   rate: 0.5,
-  duration: 4000,
-  wrapMode: "loop"
+  start: 1000,
+  end: 4000,
+  wrapStart: "loop"
+  wrapEnd: "loop"
 });
 const channel2 = timeline.addChannel({
   rate: 2,
-  duration: 1000,
-  wrapMode: "clamp"
+  start: 2000,
+  end: 6000,
+  wrapStart: "clamp"
+  wrapEnd: "clamp"
 });
 timeline.setTime(500);
 
@@ -82,9 +90,10 @@ Set the timeline time to the given value.
 
 Update channel indicated by `handle` with the properties given in `props`. Valid propeties are:
 * `rate` the speed of the channel's time relative to timeline time.
-* `duration` the length of the channel time frame.
-* `wrapMode` what to do when the timeline time moves outside the channels duration. "loop" repeat the channels timeframe, "clamp"
-  will clamp the channel's time to the range (0, duration).
+* `start` when the channel time begins in timeline time.
+* `end` when the channel time end in timeline time.
+* `wrapStart` what to do when the timeline time is less than `start` time. "loop" repeat the channels timeframe, "clamp" will clamp the channel's time the channel's `start` time.
+* `wrapStart` what to do when the timeline time is greater than `end` time. "loop" repeat the channels timeframe, "clamp" will clamp the channel's time to the channel's `end` time.
 
 ### play
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,18 +10,22 @@ The new `Timeline` class supports easily managing multiple timelines elapsing at
 const timeline = animationLoop.timeline;
 const channel1 = timeline.addChannel({
   rate: 0.5,        // Runs at 1/2 base time
-  duration: 4000,
-  wrapMode: "loop"  // Loop every 4s
+  start: 1000,      // Channel time start when base time is at 1s
+  end: 4000,        // Channel time ends when base time is at 4s
+  wrapStart: "loop" // Loop time if base time is outside start and end
+  wrapEnd: "loop"
 });
 const channel2 = timeline.addChannel({
-  rate: 2,          // Runs at twice base time
-  duration: 1000,
-  wrapMode: "clamp" // Stop playing at 1s
+  rate: 2,            // Runs at twice base time
+  start: 2000,
+  end: 6000,
+  wrapStart: "clamp" // Clamp time to the range (start, end) if base time is outside start and end
+  wrapEnd: "clamp"
 });
 
-timeline.play();        // Play with the render loop
+timeline.play();        // Base time moves with the render loop
 timeline.pause();       // Don't play with the render loop
-timeline.setTime(1500); // Set to specific time
+timeline.setTime(1500); // Set base time to specific time
 
 model.setUniforms({
   uValue1: timeline.getTime();                 // Use base timeline time

--- a/examples/core/animation/app.js
+++ b/examples/core/animation/app.js
@@ -27,6 +27,10 @@ controls.innerHTML = `
   <button id="reset">Reset</button><BR>
   Time: <input type="range" id="time" min="0" max="10000" step="1"><BR>
   Transform rate: <input type="range" id="xformRate" min="0" max="0.1" step="0.005" value="0"><BR>
+  Transform start: <input type="range" id="xformStart" min="0" max="3000" step="1" value="0"><BR>
+  Transform end: <input type="range" id="xformEnd" min="5000" max="20000" step="1" value="20000"><BR>
+  Transform clamp start: <input type="checkbox" id="xform-clamp-start"><BR>
+  Transform clamp end: <input type="checkbox" id="xform-clamp-end"><BR>
   Eye X rate: <input type="range" id="eyeXRate" min="0" max="0.005" step="0.00001" value="0"><BR>
   Eye Y rate: <input type="range" id="eyeYRate" min="0" max="0.005" step="0.00001" value="0"><BR>
   Eye Z rate: <input type="range" id="eyeZRate" min="0" max="0.005" step="0.00001" value="0"><BR>
@@ -43,6 +47,10 @@ const pauseButton = document.getElementById('pause');
 const resetButton = document.getElementById('reset');
 const timeSlider = document.getElementById('time');
 const xformSlider = document.getElementById('xformRate');
+const xformStartSlider = document.getElementById('xformStart');
+const xformEndSlider = document.getElementById('xformEnd');
+const xformClampStart = document.getElementById('xform-clamp-start');
+const xformClampEnd = document.getElementById('xform-clamp-end');
 const eyeXSlider = document.getElementById('eyeXRate');
 const eyeYSlider = document.getElementById('eyeYRate');
 const eyeZSlider = document.getElementById('eyeZRate');
@@ -203,6 +211,30 @@ export default class AppAnimationLoop extends AnimationLoop {
     xformSlider.addEventListener('input', event => {
       this.timeline.setChannelProps(timeChannel, {
         rate: parseFloat(event.target.value)
+      });
+    });
+
+    xformStartSlider.addEventListener('input', event => {
+      this.timeline.setChannelProps(timeChannel, {
+        start: parseFloat(event.target.value)
+      });
+    });
+
+    xformEndSlider.addEventListener('input', event => {
+      this.timeline.setChannelProps(timeChannel, {
+        end: parseFloat(event.target.value)
+      });
+    });
+
+    xformClampStart.addEventListener('click', event => {
+      this.timeline.setChannelProps(timeChannel, {
+        wrapStart: event.target.checked ? 'clamp' : 'loop'
+      });
+    });
+
+    xformClampEnd.addEventListener('click', event => {
+      this.timeline.setChannelProps(timeChannel, {
+        wrapEnd: event.target.checked ? 'clamp' : 'loop'
       });
     });
 

--- a/modules/core/src/lib/timeline.js
+++ b/modules/core/src/lib/timeline.js
@@ -10,17 +10,12 @@ let ids = 0;
 export class Timeline {
   constructor() {
     this.time = 0;
-    this.start = 0;
-    this.end = Number.POSITIVE_INFINITY;
-    this.wrapStart = WRAP_LOOP;
-    this.wrapEnd = WRAP_LOOP;
     this.channels = new Map();
-    this.rate = 1;
     this.playing = false;
     this.lastEngineTime = -1;
   }
 
-  addChannel(props) {
+  addChannel(props, parent) {
     const {
       start = 0,
       end = Number.POSITIVE_INFINITY,
@@ -63,7 +58,7 @@ export class Timeline {
   }
 
   setTime(time) {
-    this._setChannelTime(this, time);
+    this.time = time;
     const channels = this.channels.values();
     for (const channel of channels) {
       this._setChannelTime(channel, this.time);


### PR DESCRIPTION
This makes it possible to offset channel timelines from the base timeline. Also added separate wrap modes for start and end.
