### PR TITLE
Fix for chromium GLSL compiler issue

### DIFF
--- a/modules/shadertools/src/utils/shader-utils.js
+++ b/modules/shadertools/src/utils/shader-utils.js
@@ -1,6 +1,11 @@
 import {assert} from '../utils';
-const FS100 = 'void main() {}';
-const FS300 = `#version 300 es\n${FS100}`;
+const FS100 = 'void main() {gl_FragColor = vec4(0);}';
+const FS300 = `\
+#version 300 es
+out vec4 transform_output;
+void main() {
+  transform_output = vec4(0);
+}`;
 
 // Prase given glsl line and return qualifier details or null
 export function getQualifierDetails(line, qualifiers) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1112
<!-- For other PRs without open issue -->
#### Background
Empty Fragment shader used to work : 
```
'void main() {}'
```
But when upgrading chromium fails all Transform related tests with this error :
```
[.WebGL-0x7fa0cf002a00]GL ERROR :GL_INVALID_OPERATION : glDrawArrays: buffer format and fragment output variable type incompatible
```
Change in this PR fixes the problem.
<!-- For all the PRs -->
#### Change List
- Fix for chromium GLSL compiler issue
