### PR TITLE
Fix dependency versions

### DIFF
--- a/modules/addons/package.json
+++ b/modules/addons/package.json
@@ -35,6 +35,6 @@
     "math.gl": "^2.3.0"
   },
   "peerDependencies": {
-    "@luma.gl/core": "^7.0.0-alpha.0"
+    "@luma.gl/core": "^7.1.0-alpha.1"
   }
 }

--- a/modules/script/package.json
+++ b/modules/script/package.json
@@ -24,11 +24,11 @@
     "build": "npm run build-prod"
   },
   "dependencies": {
-    "@luma.gl/constants": "^7.1.0-alpha.1",
-    "@luma.gl/core": "^7.1.0-alpha.1",
-    "@luma.gl/debug": "^7.0.0-beta",
-    "@luma.gl/glfx": "^6.3.0-alpha.0",
-    "@luma.gl/shadertools": "^7.1.0-alpha.1",
-    "math.gl": "^2.3.0-beta.2"
+    "@luma.gl/constants": "7.1.0-alpha.3",
+    "@luma.gl/core": "7.1.0-alpha.3",
+    "@luma.gl/debug": "7.1.0-alpha.3",
+    "@luma.gl/glfx": "7.1.0-alpha.3",
+    "@luma.gl/shadertools": "7.1.0-alpha.3",
+    "math.gl": "^2.3.0"
   }
 }


### PR DESCRIPTION
Internal dependency versions in the `dependencies` field should never be edited manually.