### PR TITLE
Gatsby: Fix image loading paths for examples

### DIFF
--- a/website-gatsby/package.json
+++ b/website-gatsby/package.json
@@ -11,7 +11,7 @@
     "start": "yarn clean-examples && yarn clean && yarn develop",
     "clean": "rm -rf ./.cache ./public",
     "develop": "gatsby develop --port=8001",
-    "build": "yarn copy-examples && gatsby build",
+    "build": "yarn clean-examples && gatsby build",
     "serve": "gatsby serve",
     "deploy": "gh-pages -d public",
     "clean-examples": "rm -rf examples ; (find ../examples -name node_modules -exec rm -rf {} \\; || true)"

--- a/website-gatsby/src/components/animation-loop-runner.jsx
+++ b/website-gatsby/src/components/animation-loop-runner.jsx
@@ -63,7 +63,7 @@ export default class AnimationLoopRunner extends Component {
     // TODO - ideally ocular-gatsby should extract images from example source?
     const {path} = this.props;
     if (path) {
-      const RAW_GITHUB = 'https://raw.githubusercontent.com/uber/loaders.gl/master';
+      const RAW_GITHUB = 'https://raw.githubusercontent.com/uber/luma.gl/master';
       setPathPrefix(`${RAW_GITHUB}/${path}`);
     }
 

--- a/website-gatsby/templates/core/example-dof.jsx
+++ b/website-gatsby/templates/core/example-dof.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import AnimationLoopRunner from '../../src/components/animation-loop-runner';
 import AnimationLoop from '../../../examples/core/dof/app';
+import {setPathPrefix} from '@luma.gl/core'
 
 export default class Example extends React.Component {
+  componentDidMount() {
+    const RAW_GITHUB = 'https://raw.githubusercontent.com/uber/luma.gl/master';
+    setPathPrefix(`${RAW_GITHUB}/examples/core/dof/`);
+  }
+
   render() {
     return (
       <AnimationLoopRunner AnimationLoop={AnimationLoop} />


### PR DESCRIPTION
#### Background
@tgorkin @tsherif When run from the website, the examples must call `setPathPrefix` to make image loading work.

The generic code in `AnimationLoopRunner` is not working since the example props do not make it through. However, putting the `setPathPrefix` call into each example that uses textures works. 

Remaining work is to update the lessons that use textures in the same way.

#### Change List
- 
