### PR TITLE
Consolidate injection APIs

### DIFF
--- a/docs/api-reference/shadertools/assemble-shaders.md
+++ b/docs/api-reference/shadertools/assemble-shaders.md
@@ -98,7 +98,7 @@ And the injection for the picking module would be defined as follows:
 createModuleInjection('picking', {
   hook: 'fs:MYHOOK_fragmentColor',
   injection: 'color = picking_filterColor(color);',
-  priority: Number.POSITIVE_INFINITY
+  order: Number.POSITIVE_INFINITY
 });
 ```
 
@@ -111,7 +111,7 @@ Injecting to a predefined hook would be done as follows:
 createModuleInjection('picking', {
   hook: 'fs:#main-end',
   injection: 'color = picking_filterColor(color);',
-  priority: Number.POSITIVE_INFINITY
+  order: Number.POSITIVE_INFINITY
 });
 ```
 

--- a/docs/api-reference/shadertools/assemble-shaders.md
+++ b/docs/api-reference/shadertools/assemble-shaders.md
@@ -97,7 +97,7 @@ And the injection for the picking module would be defined as follows:
 ```js
 setModuleInjection('fs', 'picking', {
   shaderHook: 'MYHOOK_fragmentColor',
-  injection: 'color = picking_filterColor(color)',
+  injection: 'color = picking_filterColor(color);',
   priority: Number.POSITIVE_INFINITY
 });
 ```
@@ -110,7 +110,7 @@ Injecting to a predefined hook would be done as follows:
 ```js
 setModuleInjection('fs', 'picking', {
   shaderHook: 'fs:#main-end',
-  injection: 'color = picking_filterColor(color)',
+  injection: 'color = picking_filterColor(color);',
   priority: Number.POSITIVE_INFINITY
 });
 ```
@@ -139,18 +139,17 @@ setShaderHook('fs', {
 new Model(gl, {
   vs,
   fs: `void main() {
-    gl_FragColor = vec4(1., 0., 0., 1.);
     MYHOOK_fragmentColor(gl_FragColor);
   }`,
   modules: ['picking']
   inject: {
-    'MYHOOK_fragmentColor': '  color = picking_filterColor(color)'
+    'fs:#main-start': 'gl_FragColor = vec4(1., 0., 0., 1.);';
+    'MYHOOK_fragmentColor': {
+      injection: '  color = picking_filterColor(color);',
+      order: 9999
   }
 });
 ```
-
-
-
 
 
 ### Remarks

--- a/docs/api-reference/shadertools/assemble-shaders.md
+++ b/docs/api-reference/shadertools/assemble-shaders.md
@@ -36,7 +36,6 @@ Returns:
 
 Creates a shader hook function that shader modules can injection code into. Shaders can call these functions, which will be no-ops by default. If a shader module injects code it will be executed upon the hook function call. This mechanism allows the application to create shaders that can be automatically extended by included shader modules.
 
-- `shaderStage`: `vs` or `fs`, the type of shader
 - `hook`: `vs:` or `fs:` followed by the name and arguments of the function, e.g. `vs:MYHOOK_func(inout vec4 value)`. Hook name without arguments
 will also be used as the name of the shader hook
 - `opts.header` (optional): code always included at the beginning of a hook function

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -7,8 +7,8 @@ import {
   readPixelsToArray,
   Buffer,
   CubeGeometry,
-  setShaderHook,
-  setModuleInjection
+  createShaderHook,
+  createModuleInjection
 } from '@luma.gl/core';
 import {Timeline} from '@luma.gl/addons';
 import {Matrix4, radians} from 'math.gl';
@@ -132,29 +132,22 @@ export default class AppAnimationLoop extends AnimationLoop {
       depthFunc: gl.LEQUAL
     });
 
-    setShaderHook('vs', {
-      signature: 'MY_SHADER_HOOK_pickColor(inout vec4 color)'
-    });
+    createShaderHook('vs:MY_SHADER_HOOK_pickColor(inout vec4 color)');
 
-    setShaderHook('fs', {
-      signature: 'MY_SHADER_HOOK_fragmentColor(inout vec4 color)'
-    });
+    createShaderHook('fs:MY_SHADER_HOOK_fragmentColor(inout vec4 color)');
 
-    setModuleInjection('picking', {
-      shaderStage: 'vs',
-      shaderHook: 'MY_SHADER_HOOK_pickColor',
+    createModuleInjection('picking', {
+      hook: 'vs:MY_SHADER_HOOK_pickColor',
       injection: 'picking_setPickingColor(color.rgb);'
     });
 
-    setModuleInjection('dirlight', {
-      shaderStage: 'fs',
-      shaderHook: 'MY_SHADER_HOOK_fragmentColor',
+    createModuleInjection('dirlight', {
+      hook: 'fs:MY_SHADER_HOOK_fragmentColor',
       injection: 'color = dirlight_filterColor(color);'
     });
 
-    setModuleInjection('picking', {
-      shaderStage: 'fs',
-      shaderHook: 'MY_SHADER_HOOK_fragmentColor',
+    createModuleInjection('picking', {
+      hook: 'fs:MY_SHADER_HOOK_fragmentColor',
       injection: 'color = picking_filterColor(color);',
       order: Number.POSITIVE_INFINITY
     });

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -143,19 +143,19 @@ export default class AppAnimationLoop extends AnimationLoop {
     setModuleInjection('picking', {
       shaderStage: 'vs',
       shaderHook: 'MY_SHADER_HOOK_pickColor',
-      injection: 'picking_setPickingColor(color.rgb)'
+      injection: 'picking_setPickingColor(color.rgb);'
     });
 
     setModuleInjection('dirlight', {
       shaderStage: 'fs',
       shaderHook: 'MY_SHADER_HOOK_fragmentColor',
-      injection: 'color = dirlight_filterColor(color)'
+      injection: 'color = dirlight_filterColor(color);'
     });
 
     setModuleInjection('picking', {
       shaderStage: 'fs',
       shaderHook: 'MY_SHADER_HOOK_fragmentColor',
-      injection: 'color = picking_filterColor(color)',
+      injection: 'color = picking_filterColor(color);',
       order: Number.POSITIVE_INFINITY
     });
 
@@ -180,6 +180,9 @@ export default class AppAnimationLoop extends AnimationLoop {
 
     this.cube = new InstancedCube(gl, {
       _animationLoop,
+      // inject: {
+      //   'fs:#main-end': 'gl_FragColor = picking_filterColor(gl_FragColor)'
+      // },
       uniforms: {
         uTime: () => this.timeline.getTime(timeChannel),
         // Basic projection matrix

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -133,8 +133,8 @@ export {
   registerShaderModules,
   setDefaultShaderModules,
   assembleShaders,
-  setShaderHook,
-  setModuleInjection,
+  createShaderHook,
+  createModuleInjection,
   // HELPERS
   combineInjects,
   normalizeShaderModule,

--- a/modules/shadertools/src/index.js
+++ b/modules/shadertools/src/index.js
@@ -8,7 +8,7 @@ import MODULAR_FS from './shaders/modular-fragment.glsl';
 
 // DOCUMENTED APIS
 export {registerShaderModules, setDefaultShaderModules} from './lib/resolve-modules';
-export {assembleShaders, setShaderHook, setModuleInjection} from './lib/assemble-shaders';
+export {assembleShaders, createShaderHook, createModuleInjection} from './lib/assemble-shaders';
 
 // HELPERS
 export {combineInjects} from './lib/inject-shader';

--- a/modules/shadertools/src/lib/assemble-shaders.js
+++ b/modules/shadertools/src/lib/assemble-shaders.js
@@ -112,10 +112,15 @@ ${isVertex ? '' : FRAGMENT_SHADER_PROLOGUE}
   for (const key in inject) {
     const injection =
       typeof inject[key] === 'string' ? {injection: inject[key], order: 0} : inject[key];
-    if (key.match(/^(v|f)s:#/)) {
-      mainInjections[key] = [injection];
+    if (key.match(/^(v|f)s:/)) {
+      if (key[3] === '#') {
+        mainInjections[key] = [injection];
+      } else {
+        hookInjections[key] = [injection];
+      }
     } else {
-      hookInjections[key] = [injection];
+      // Regex injection
+      mainInjections[key] = [injection];
     }
   }
 

--- a/modules/shadertools/src/lib/inject-shader.js
+++ b/modules/shadertools/src/lib/inject-shader.js
@@ -61,6 +61,8 @@ export default function injectShader(source, type, inject, injectStandardStubs) 
         break;
 
       default:
+        // TODO(Tarek): I think this usage should be deprecated.
+
         // inject code after key, leaving key in place
         source = source.replace(key, match => match + fragmentString);
     }

--- a/modules/shadertools/test/lib/assemble-shaders.spec.js
+++ b/modules/shadertools/test/lib/assemble-shaders.spec.js
@@ -137,6 +137,12 @@ test('assembleShaders#shaderhooks', t => {
     order: Number.POSITIVE_INFINITY
   });
 
+  createModuleInjection('picking', {
+    hook: 'fs:#main-end',
+    injection: 'gl_FragColor = picking_filterColor(gl_FragColor);',
+    order: Number.POSITIVE_INFINITY
+  });
+
   let assembleResult = assembleShaders(fixture.gl, {
     vs: VS_GLSL_300,
     fs: FS_GLSL_300
@@ -157,6 +163,11 @@ test('assembleShaders#shaderhooks', t => {
   t.ok(
     assembleResult.fs.indexOf('color = picking_filterColor(color)') === -1,
     'injection code not included in fragment shader without module'
+  );
+
+  t.ok(
+    assembleResult.fs.indexOf('gl_FragColor = picking_filterColor(gl_FragColor)') === -1,
+    'regex injection code not included in fragment shader without module'
   );
 
   assembleResult = assembleShaders(fixture.gl, {
@@ -180,6 +191,28 @@ test('assembleShaders#shaderhooks', t => {
   t.ok(
     assembleResult.fs.indexOf('color = picking_filterColor(color)') > -1,
     'injection code included in fragment shader with module'
+  );
+  t.ok(
+    assembleResult.fs.indexOf('gl_FragColor = picking_filterColor(gl_FragColor)') > -1,
+    'regex injection code included in fragment shader with module'
+  );
+
+  assembleResult = assembleShaders(fixture.gl, {
+    vs: VS_GLSL_300,
+    fs: FS_GLSL_300,
+    inject: {
+      'vs:LUMAGL_pickColor': 'color *= 0.1;',
+      'fs:LUMAGL_fragmentColor': 'color += 0.1;'
+    }
+  });
+
+  t.ok(
+    assembleResult.vs.indexOf('color *= 0.1') > -1,
+    'argument injection code included in shader hook'
+  );
+  t.ok(
+    assembleResult.fs.indexOf('color += 0.1') > -1,
+    'argument injection code included in shader hook'
   );
 
   t.end();

--- a/modules/shadertools/test/lib/assemble-shaders.spec.js
+++ b/modules/shadertools/test/lib/assemble-shaders.spec.js
@@ -134,13 +134,13 @@ test('assembleShaders#shaderhooks', t => {
   setModuleInjection('picking', {
     shaderStage: 'vs',
     shaderHook: 'LUMAGL_pickColor',
-    injection: 'picking_setPickingColor(color.rgb)'
+    injection: 'picking_setPickingColor(color.rgb);'
   });
 
   setModuleInjection('picking', {
     shaderStage: 'fs',
     shaderHook: 'LUMAGL_fragmentColor',
-    injection: 'color = picking_filterColor(color)',
+    injection: 'color = picking_filterColor(color);',
     order: Number.POSITIVE_INFINITY
   });
 

--- a/modules/shadertools/test/lib/assemble-shaders.spec.js
+++ b/modules/shadertools/test/lib/assemble-shaders.spec.js
@@ -2,8 +2,8 @@
 import {createGLContext} from '@luma.gl/core';
 import {
   assembleShaders,
-  setShaderHook,
-  setModuleInjection,
+  createShaderHook,
+  createModuleInjection,
   picking,
   fp64
 } from '@luma.gl/shadertools';
@@ -123,23 +123,16 @@ test('assembleShaders#getUniforms', t => {
 });
 
 test('assembleShaders#shaderhooks', t => {
-  setShaderHook('vs', {
-    signature: 'LUMAGL_pickColor(inout vec4 color)'
-  });
+  createShaderHook('vs:LUMAGL_pickColor(inout vec4 color)');
+  createShaderHook('fs:LUMAGL_fragmentColor(inout vec4 color)');
 
-  setShaderHook('fs', {
-    signature: 'LUMAGL_fragmentColor(inout vec4 color)'
-  });
-
-  setModuleInjection('picking', {
-    shaderStage: 'vs',
-    shaderHook: 'LUMAGL_pickColor',
+  createModuleInjection('picking', {
+    hook: 'vs:LUMAGL_pickColor',
     injection: 'picking_setPickingColor(color.rgb);'
   });
 
-  setModuleInjection('picking', {
-    shaderStage: 'fs',
-    shaderHook: 'LUMAGL_fragmentColor',
+  createModuleInjection('picking', {
+    hook: 'fs:LUMAGL_fragmentColor',
     injection: 'color = picking_filterColor(color);',
     order: Number.POSITIVE_INFINITY
   });
@@ -188,5 +181,6 @@ test('assembleShaders#shaderhooks', t => {
     assembleResult.fs.indexOf('color = picking_filterColor(color)') > -1,
     'injection code included in fragment shader with module'
   );
+
   t.end();
 });

--- a/modules/shadertools/test/lib/assemble-shaders.spec.js
+++ b/modules/shadertools/test/lib/assemble-shaders.spec.js
@@ -122,7 +122,7 @@ test('assembleShaders#getUniforms', t => {
   t.end();
 });
 
-test('assembleShaders#shaderhooks', t => {
+test.only('assembleShaders#shaderhooks', t => {
   createShaderHook('vs:LUMAGL_pickColor(inout vec4 color)');
   createShaderHook('fs:LUMAGL_fragmentColor(inout vec4 color)');
 
@@ -213,6 +213,19 @@ test('assembleShaders#shaderhooks', t => {
   t.ok(
     assembleResult.fs.indexOf('color += 0.1') > -1,
     'argument injection code included in shader hook'
+  );
+
+  assembleResult = assembleShaders(fixture.gl, {
+    vs: VS_GLSL_300,
+    fs: FS_GLSL_300,
+    inject: {
+      'fragmentColor = vec4(1.0, 1.0, 1.0, 1.0);': 'fragmentColor -= 0.1;'
+    }
+  });
+
+  t.ok(
+    assembleResult.fs.indexOf('fragmentColor -= 0.1;') > -1,
+    'regex injection code included in shader hook'
   );
 
   t.end();

--- a/modules/shadertools/test/lib/assemble-shaders.spec.js
+++ b/modules/shadertools/test/lib/assemble-shaders.spec.js
@@ -122,7 +122,7 @@ test('assembleShaders#getUniforms', t => {
   t.end();
 });
 
-test.only('assembleShaders#shaderhooks', t => {
+test('assembleShaders#shaderhooks', t => {
   createShaderHook('vs:LUMAGL_pickColor(inout vec4 color)');
   createShaderHook('fs:LUMAGL_fragmentColor(inout vec4 color)');
 

--- a/modules/shadertools/test/lib/inject-shader.spec.js
+++ b/modules/shadertools/test/lib/inject-shader.spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase */
+/* eslint-disable camelcase, no-console, no-undef */
 import {createGLContext} from '@luma.gl/core';
 import {assembleShaders} from '@luma.gl/shadertools';
 import injectShader, {combineInjects} from '@luma.gl/shadertools/lib/inject-shader';
@@ -85,23 +85,23 @@ test('injectShader#import', t => {
 test('injectShader#injectShader', t => {
   let injectResult;
 
-  injectResult = injectShader(VS_GLSL_TEMPLATE, 'vs', INJECT);
+  injectResult = injectShader(VS_GLSL_TEMPLATE, 'vs', injectionData(INJECT));
   t.ok(
-    injectResult.indexOf(VS_GLSL_RESOLVED_DECL) > -1,
+    fuzzySubstring(injectResult, VS_GLSL_RESOLVED_DECL),
     'declarations correctly injected in vertex shader'
   );
   t.ok(
-    injectResult.indexOf(VS_GLSL_RESOLVED_MAIN) > -1,
+    fuzzySubstring(injectResult, VS_GLSL_RESOLVED_MAIN),
     'main correctly injected in vertex shader'
   );
 
-  injectResult = injectShader(FS_GLSL_TEMPLATE, 'fs', INJECT);
+  injectResult = injectShader(FS_GLSL_TEMPLATE, 'fs', injectionData(INJECT));
   t.ok(
-    injectResult.indexOf(FS_GLSL_RESOLVED_DECL) > -1,
+    fuzzySubstring(injectResult, FS_GLSL_RESOLVED_DECL),
     'declarations correctly injected in vertex shader'
   );
   t.ok(
-    injectResult.indexOf(FS_GLSL_RESOLVED_MAIN) > -1,
+    fuzzySubstring(injectResult, FS_GLSL_RESOLVED_MAIN),
     'main correctly injected in vertex shader'
   );
 
@@ -116,20 +116,20 @@ test('injectShader#assembleShaders', t => {
     prologue: false
   });
   t.ok(
-    assembleResult.vs.indexOf(VS_GLSL_RESOLVED_DECL) > -1,
+    fuzzySubstring(assembleResult.vs, VS_GLSL_RESOLVED_DECL),
     'declarations correctly assembled in vertex shader'
   );
   t.ok(
-    assembleResult.vs.indexOf(VS_GLSL_RESOLVED_MAIN) > -1,
+    fuzzySubstring(assembleResult.vs, VS_GLSL_RESOLVED_MAIN),
     'main correctly assembled in vertex shader'
   );
 
   t.ok(
-    assembleResult.fs.indexOf(FS_GLSL_RESOLVED_DECL) > -1,
+    fuzzySubstring(assembleResult.fs, FS_GLSL_RESOLVED_DECL),
     'declarations correctly assembled in vertex shader'
   );
   t.ok(
-    assembleResult.fs.indexOf(FS_GLSL_RESOLVED_MAIN) > -1,
+    fuzzySubstring(assembleResult.fs, FS_GLSL_RESOLVED_MAIN),
     'main correctly assembled in vertex shader'
   );
 
@@ -140,3 +140,15 @@ test('injectShader#combineInjects', t => {
   t.deepEqual(combineInjects([INJECT, INJECT2]), COMBINED_INJECT, 'injects correctly combined');
   t.end();
 });
+
+function injectionData(data) {
+  const result = {};
+  for (const key in data) {
+    result[key] = [{injection: data[key], order: 0}];
+  }
+  return result;
+}
+
+function fuzzySubstring(string1, string2) {
+  return string1.replace(/\s/g, '').indexOf(string2.replace(/\s/g, '')) > -1;
+}


### PR DESCRIPTION
A bit of a chunky update to the injection APIs to consolidate the `inject` argument hooks and the module injections. Main thing is that module injections can now inject into prebuilt injection points (e.g. `vs:#main-start`) and the `inject` argument to `assembleShaders` can inject into hook functions defined by `createShaderHook`. Also made a few minor changes to the API to make the two types of injections more consistent, e.g. using a `vs` or `fs` prefix for hook function definitions as well:
```js
createShaderHook('vs:MY_SHADER_HOOK_pickColor(inout vec4 color)');

createModuleInjection('picking', {
  hook: 'vs:MY_SHADER_HOOK_pickColor',
  injection: 'color = picking_setPickingColor(color);',
  order: Number.POSITIVE_INFINITY
});
```
