### PR TITLE
Gatsby website example page fixes

### DIFF
--- a/website-gatsby/package.json
+++ b/website-gatsby/package.json
@@ -23,8 +23,7 @@
   },
   "devDependencies": {
     "gatsby": "^2.3.0",
-    "gatsby-plugin-styletron": "^3.0.5",
-    "ocular-gatsby": "1.0.0-alpha.32",
+    "ocular-gatsby": "1.0.0-alpha.35",
     "sharp": "^0.22"
   }
 }

--- a/website-gatsby/src/components/animation-loop-example-page.jsx
+++ b/website-gatsby/src/components/animation-loop-example-page.jsx
@@ -41,7 +41,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  canvas: "example-canvas"
+  canvas: 'example-canvas'
 };
 
 const DEFAULT_ALT_TEXT = 'THIS EXAMPLE IS NOT SUPPORTED';

--- a/website-gatsby/src/components/animation-loop-example-page.jsx
+++ b/website-gatsby/src/components/animation-loop-example-page.jsx
@@ -35,17 +35,18 @@ const STAT_STYLES = {
 };
 
 const propTypes = {
-  example: PropTypes.object,
+  AnimationLoop: PropTypes.func.isRequired,
+  exampleConfig: PropTypes.object.isRequired,
   canvas: PropTypes.string
 };
 
 const defaultProps = {
-  canvas: 'example-canvas'
+  canvas: "example-canvas"
 };
 
 const DEFAULT_ALT_TEXT = 'THIS EXAMPLE IS NOT SUPPORTED';
 
-export default class AnimationLoopRunner extends Component {
+export default class AnimationLoopExamplePage extends Component {
   constructor(props) {
     super(props);
     const {AnimationLoop} = this.props;
@@ -59,10 +60,10 @@ export default class AnimationLoopRunner extends Component {
 
     // Ensure the example can find its images
     // TODO - ideally ocular-gatsby should extract images from example source?
-    const {path} = this.props;
-    if (path) {
+    const {exampleConfig} = this.props;
+    if (exampleConfig && exampleConfig.path) {
       const RAW_GITHUB = 'https://raw.githubusercontent.com/uber/luma.gl/master';
-      setPathPrefix(`${RAW_GITHUB}/${path}`);
+      setPathPrefix(`${RAW_GITHUB}/${exampleConfig.path}`);
     }
 
     // Start the actual example
@@ -171,6 +172,6 @@ export default class AnimationLoopRunner extends Component {
   }
 }
 
-AnimationLoopRunner.propTypes = propTypes;
-AnimationLoopRunner.defaultProps = defaultProps;
-AnimationLoopRunner.displayName = 'AnimationLoop';
+AnimationLoopExamplePage.propTypes = propTypes;
+AnimationLoopExamplePage.defaultProps = defaultProps;
+AnimationLoopExamplePage.displayName = 'AnimationLoop';

--- a/website-gatsby/templates/core/example-cubemap.jsx
+++ b/website-gatsby/templates/core/example-cubemap.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/cubemap/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-dof.jsx
+++ b/website-gatsby/templates/core/example-dof.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/dof/app';
 
 export default class Example extends React.Component {
 
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-fragment.jsx
+++ b/website-gatsby/templates/core/example-fragment.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/fragment/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-gltf.jsx
+++ b/website-gatsby/templates/core/example-gltf.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/gltf/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-instancing.jsx
+++ b/website-gatsby/templates/core/example-instancing.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/instancing/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-mandelbrot.jsx
+++ b/website-gatsby/templates/core/example-mandelbrot.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/mandelbrot/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-persistence.jsx
+++ b/website-gatsby/templates/core/example-persistence.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/persistence/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-quasicrystals.jsx
+++ b/website-gatsby/templates/core/example-quasicrystals.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/quasicrystals/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-shadowmap.jsx
+++ b/website-gatsby/templates/core/example-shadowmap.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/shadowmap/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-texture-3d.jsx
+++ b/website-gatsby/templates/core/example-texture-3d.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/texture-3d/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-transform-feedback.jsx
+++ b/website-gatsby/templates/core/example-transform-feedback.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/transform-feedback/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/core/example-transform.jsx
+++ b/website-gatsby/templates/core/example-transform.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/core/transform/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-01.jsx
+++ b/website-gatsby/templates/lessons/example-01.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/01/app';
 
 export default class Example extends React.Component {
   render() {
+    console.log("example-10 render", AnimationLoop)
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-02.jsx
+++ b/website-gatsby/templates/lessons/example-02.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/02/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-03.jsx
+++ b/website-gatsby/templates/lessons/example-03.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/03/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-04.jsx
+++ b/website-gatsby/templates/lessons/example-04.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/04/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-05.jsx
+++ b/website-gatsby/templates/lessons/example-05.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/05/app';
 
 export default class Example extends React.Component {
 
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-06.jsx
+++ b/website-gatsby/templates/lessons/example-06.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/06/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-07.jsx
+++ b/website-gatsby/templates/lessons/example-07.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/07/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-08.jsx
+++ b/website-gatsby/templates/lessons/example-08.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/08/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-09.jsx
+++ b/website-gatsby/templates/lessons/example-09.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/09/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-10.jsx
+++ b/website-gatsby/templates/lessons/example-10.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/10/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-11.jsx
+++ b/website-gatsby/templates/lessons/example-11.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/11/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-12.jsx
+++ b/website-gatsby/templates/lessons/example-12.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/12/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-13.jsx
+++ b/website-gatsby/templates/lessons/example-13.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/13/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-14.jsx
+++ b/website-gatsby/templates/lessons/example-14.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/14/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-15.jsx
+++ b/website-gatsby/templates/lessons/example-15.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/15/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }

--- a/website-gatsby/templates/lessons/example-16.jsx
+++ b/website-gatsby/templates/lessons/example-16.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import AnimationLoopRunner from '../../src/components/animation-loop-runner';
+import AnimationLoopExamplePage from '../../src/components/animation-loop-example-page';
 import AnimationLoop from '../../../examples/lessons/16/app';
 
 export default class Example extends React.Component {
   render() {
     return (
-      <AnimationLoopRunner AnimationLoop={AnimationLoop} path={this.props.pageContext.exampleConfig.path} />
+      <AnimationLoopExamplePage AnimationLoop={AnimationLoop} exampleConfig={this.props.pageContext.exampleConfig} />
     );
   }
 }


### PR DESCRIPTION
Upgrade to ocular-gatsby alpha.35
Update gatsby website example pages to use example config from page context.
Fix styletron dev dependency conflict.
Rename AnimationLoopRunner to AnimationLoopExamplePage based on PR feedback from #1122 .