### PR TITLE
Add support for specifying custom device pixel ratio.

### DIFF
--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -163,6 +163,10 @@ The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies 
 * The animation loop tracks GPU and CPU render time of each frame the in member properties `cpuTime` and `gpuTime`. If `gpuTime` is set to `-1`, then the timing for the last frame was invalid and should not be used (this rare and might occur, for example, if the GPU was throttled mid-frame).
 
 
+## Experimental API
+
+`useDevicePixels` can accept a custom ratio, instead of `true` or `false`. This allows rendering to a much smaller or higher resolutions. When using high value (usually more than device pixel ratio), it is possible it can get clamped down, this happens due to system memory limitation, in such cases a warning will be logged in console, specifying the clamped down ratio.
+
 ## Remarks
 
 * You can instantiate multiple `AnimationLoop` classes in parallel, rendering into the same or different `WebGLRenderingContext`s.

--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -165,7 +165,7 @@ The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies 
 
 ## Experimental API (`useDevicePixels`)
 
-`useDevicePixels` can accept a custom ratio (Number), instead of `true` or `false`. This allows rendering to a much smaller or higher resolutions. When using high value (usually more than device pixel ratio), it is possible it can get clamped down, this happens due to system memory limitation, in such cases a warning will be logged in console, specifying the clamped down ratio. For additional details check device pixels [`document`]((/docs/api-reference/webgl/device-pixels.md)).
+`useDevicePixels` can accept a custom ratio (Number), instead of `true` or `false`. This allows rendering to a much smaller or higher resolutions. When using high value (usually more than device pixel ratio), it is possible it can get clamped down, this happens due to system memory limitation, in such cases a warning will be logged to the browser console. For additional details check device pixels [`document`]((/docs/api-reference/webgl/device-pixels.md)).
 
 ## Remarks
 

--- a/docs/api-reference/core/animation-loop.md
+++ b/docs/api-reference/core/animation-loop.md
@@ -63,7 +63,7 @@ new AnimationLoop({
 * `props.onFinalize`=`null` (callback) - Called once when animation is stopped. Can be used to delete objects or free any resources created during `onInitialize`.
 * `props.autoResizeViewport`=`true` - If true, calls `gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight)` each frame before `onRender` is called. Set to false to control viewport size.
 * `props.autoResizeDrawingBuffer`=`true` - If true, checks the canvas size every frame and updates the drawing buffer size if needed.
-* `props.useDevicePixels` - Whether to use `window.devicePixelRatio` as a multiplier, e.g. in `autoResizeDrawingBuffer` etc.
+* `props.useDevicePixels` - Whether to use `window.devicePixelRatio` as a multiplier, e.g. in `autoResizeDrawingBuffer` etc. Refer to `Experimental API` section below for more use cases of this prop.
 * `props.gl`=`null` (WebGLContext) - If supplied, will render into this external context instead of creating a new one.
 * `props.glOptions`=`{}` (object) - Options to create the WebGLContext with. See [createGLContext](/docs/api-reference/webgl/context/context.md).
 * `props.debug`=`false` (bool) - Enable debug mode will provide more validations and error messages, but less performant.
@@ -163,9 +163,9 @@ The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies 
 * The animation loop tracks GPU and CPU render time of each frame the in member properties `cpuTime` and `gpuTime`. If `gpuTime` is set to `-1`, then the timing for the last frame was invalid and should not be used (this rare and might occur, for example, if the GPU was throttled mid-frame).
 
 
-## Experimental API
+## Experimental API (`useDevicePixels`)
 
-`useDevicePixels` can accept a custom ratio, instead of `true` or `false`. This allows rendering to a much smaller or higher resolutions. When using high value (usually more than device pixel ratio), it is possible it can get clamped down, this happens due to system memory limitation, in such cases a warning will be logged in console, specifying the clamped down ratio.
+`useDevicePixels` can accept a custom ratio (Number), instead of `true` or `false`. This allows rendering to a much smaller or higher resolutions. When using high value (usually more than device pixel ratio), it is possible it can get clamped down, this happens due to system memory limitation, in such cases a warning will be logged in console, specifying the clamped down ratio. For additional details check device pixels [`document`]((/docs/api-reference/webgl/device-pixels.md)).
 
 ## Remarks
 

--- a/docs/api-reference/webgl/device-pixels.md
+++ b/docs/api-reference/webgl/device-pixels.md
@@ -1,6 +1,6 @@
 # Device Pixels
 
-Most of the modern computers support retina or HD displays, which support either 2X of 4X number of pixels to the size of screen. By rendering to this bigger size window (Device) and then down sampling it to smaller window (CSS), produces sharp images, but at the cost of performance penalty by rendering more pixels.
+Most of the modern computers support retina or HD displays, which support either 2X or 4X number of pixels to the size of screen. By rendering to this bigger size window (Device) and then down sampling it to smaller window (CSS), produces sharp images, but at the cost of performance penalty by rendering more pixels.
 
 ## useDevicePixels
 
@@ -37,4 +37,4 @@ Returns an Object, `{x, y, width, height}` that represents entire range of devic
  * `y` (Number): lower y-coordinate
  * `width` (Number): width in pixels
  * `height` (Number): height in pixels
- When `devicePixelRatio` is <=1, `width` and `height` are be always be equal one, otherwise `width` and `height` are greater than one.
+ When `devicePixelRatio` is <=1, `width` and `height` are equal to `one`, otherwise `width` and `height` are greater than one.

--- a/docs/api-reference/webgl/device-pixels.md
+++ b/docs/api-reference/webgl/device-pixels.md
@@ -24,12 +24,17 @@ Returns a Number, which is the ratio of Device buffer resolution size to CSS buf
 Returns ratio (Number).
 
 
-### cssToDevicePixels(gl, cssPixel, yInvert) : Array
+### cssToDevicePixels(gl, cssPixel, yInvert) : Object
 
-Converts CSS pixel location to Device pixel location.
+Converts CSS pixel location to Device pixel range.
 
 * `gl` (WebGLContext) - WebGL context.
 * `cssPixels` (Array) - Array in [x, y] form, where x and y are location in CSS window.
 * `yInvert` (Boolean, optional, default: true) - when true it will perform y-inversion when converting to Device pixels.
 
-Returns Device pixel location, [x, y].
+Returns an Object, `{x, y, width, height}` that represents entire range of device pixels that correspond to given cssPixel location. Following fields define the rectangle.
+ * `x` (Number): lower x-coordinate
+ * `y` (Number): lower y-coordinate
+ * `width` (Number): width in pixels
+ * `height` (Number): height in pixels
+ When `devicePixelRatio` is <=1, `width` and `height` are be always be equal one, otherwise `width` and `height` are greater than one.

--- a/docs/api-reference/webgl/device-pixels.md
+++ b/docs/api-reference/webgl/device-pixels.md
@@ -4,7 +4,11 @@ Most of the modern computers support retina or HD displays, which support either
 
 ## useDevicePixels
 
-`luma.gl` provides control over this behavior using `AnimationLoop`'s `useDevicePixels` prop. When `useDevicePixels` is set to true (default), it will use device's full retina/HD resolution for rendering, when `useDevicePixels` is false, it will use the same resolution as the screen window (CSS window).
+`luma.gl` provides control over this behavior using `AnimationLoop`'s [`useDevicePixels`](/docs/api-reference/core/animation-loop.md) prop. When `useDevicePixels` is set to true (default), it will use device's full retina/HD resolution for rendering, when `useDevicePixels` is false, it will use the same resolution as the screen window (CSS window).
+
+As an experimental API, a custom ratio (Number) can be set to `useDevicePixels` prop, to use smaller or bigger ratio than actual device pixel ratio. This is for more advanced use cases, using the default value (`true`) is recommended for this prop. For any advanced use cases, when a value higher than actual device pixel ratio is used, `luma.gl` will first try to allocate internal resources to match this ratio, if it fails, it will reduce this ratio by half, until resources are successfully created.
+
+When a custom ratio is used, `window.devicePixel` ratio can't be used for converting between CSS and Device locations, instead following helper methods should be used.
 
 ## Methods
 
@@ -15,7 +19,10 @@ Most of the modern computers support retina or HD displays, which support either
 
 Depending on `useDevicePixels` value, returns current device pixel ratio or 1.
 
-* `useDevicePixels` (Boolean) - whether to use device resolution or not.
+* `useDevicePixels` (Boolean | Number) - whether to use device resolution or not.
+  - `false` : returns `1`
+  - `true` : returns device pixel ratio, `1` if ratio not available
+  - `Number` : returns same number if > 0, else `1`.
 
 Returns ratio of Device pixels to CSS pixels.
 

--- a/docs/api-reference/webgl/device-pixels.md
+++ b/docs/api-reference/webgl/device-pixels.md
@@ -1,0 +1,40 @@
+# Device Pixels
+
+Most of the modern computers support retina or HD displays, which support either 2X of 4X number of pixels to the size of screen. By rendering to this bigger size window (Device) and then down sampling it to smaller window (CSS), produces sharp images, but at the cost of performance penalty by rendering more pixels.
+
+## useDevicePixels
+
+`luma.gl` provides control over this behavior using `AnimationLoop`'s `useDevicePixels` prop. When `useDevicePixels` is set to true (default), it will use device's full retina/HD resolution for rendering, when `useDevicePixels` is false, it will use the same resolution as the screen window (CSS window).
+
+## Methods
+
+`luma.gl` offers following helper methods for converting between CSS and Device pixels.
+
+
+### getDevicePixelRatio (useDevicePixels) : Number
+
+Depending on `useDevicePixels` value, returns current device pixel ratio or 1.
+
+* `useDevicePixels` (Boolean) - whether to use device resolution or not.
+
+Returns ratio of Device pixels to CSS pixels.
+
+### cssToDevicePixels(gl, cssPixel, yInvert) : Array
+
+Converts CSS pixel location to Device pixel location.
+
+* `gl` (WebGLContext) - WebGL context.
+* `cssPixels` (Array) - Array in [x, y] form, where x and y are location in CSS window.
+* `yInvert` (Boolean, optional, default: true) - when true it will perform y-inversion when converting to Device pixels.
+
+Returns Device pixel location, [x, y].
+
+### deviceToCssPixels(gl, devicePixel, yInvert) : Array
+
+Converts Device pixel location to CSS pixel location.
+
+* `gl` (WebGLContext) - WebGL context.
+* `devicePixel` (Array) - Array in [x, y] form, where x and y are location in Device window.
+* `yInvert` (Boolean, optional, default: true) - when true it will perform y-inversion when converting to Device pixels.
+
+Returns CSS pixel location, [x, y].

--- a/docs/api-reference/webgl/device-pixels.md
+++ b/docs/api-reference/webgl/device-pixels.md
@@ -12,19 +12,17 @@ When a custom ratio is used, `window.devicePixel` ratio can't be used for conver
 
 ## Methods
 
-`luma.gl` offers following helper methods for converting between CSS and Device pixels.
+`luma.gl` offers following helper methods for converting from CSS to Device pixels.
 
 
-### getDevicePixelRatio (useDevicePixels) : Number
+### cssToDeviceRatio(gl): Number
 
-Depending on `useDevicePixels` value, returns current device pixel ratio or 1.
+Returns a Number, which is the ratio of Device buffer resolution size to CSS buffer resolution.
 
-* `useDevicePixels` (Boolean | Number) - whether to use device resolution or not.
-  - `false` : returns `1`
-  - `true` : returns device pixel ratio, `1` if ratio not available
-  - `Number` : returns same number if > 0, else `1`.
+* `gl` (WebGLContext) - WebGL context.
 
-Returns ratio of Device pixels to CSS pixels.
+Returns ratio (Number).
+
 
 ### cssToDevicePixels(gl, cssPixel, yInvert) : Array
 
@@ -35,13 +33,3 @@ Converts CSS pixel location to Device pixel location.
 * `yInvert` (Boolean, optional, default: true) - when true it will perform y-inversion when converting to Device pixels.
 
 Returns Device pixel location, [x, y].
-
-### deviceToCssPixels(gl, devicePixel, yInvert) : Array
-
-Converts Device pixel location to CSS pixel location.
-
-* `gl` (WebGLContext) - WebGL context.
-* `devicePixel` (Array) - Array in [x, y] form, where x and y are location in Device window.
-* `yInvert` (Boolean, optional, default: true) - when true it will perform y-inversion when converting to Device pixels.
-
-Returns CSS pixel location, [x, y].

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -11,6 +11,7 @@ import {
   createModuleInjection
 } from '@luma.gl/core';
 import {Timeline} from '@luma.gl/addons';
+import {mapToDevicePosition} from '@luma.gl/webgl';
 import {Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `
@@ -20,10 +21,6 @@ Cube drawn with <b>instanced rendering</b>.
 A luma.gl <code>Cube</code>, rendering 65,536 instances in a
 single GPU draw call using instanced vertex attributes.
 `;
-
-function getDevicePixelRatio() {
-  return typeof window !== 'undefined' ? window.devicePixelRatio : 1;
-}
 
 const SIDE = 256;
 
@@ -200,15 +197,11 @@ export default class AppAnimationLoop extends AnimationLoop {
   onRender(animationProps) {
     const {gl} = animationProps;
 
-    const {framebuffer, useDevicePixels, _mousePosition} = animationProps;
+    const {framebuffer, _mousePosition} = animationProps;
 
     if (_mousePosition) {
-      const dpr = useDevicePixels ? getDevicePixelRatio() : 1;
-
-      const pickX = _mousePosition[0] * dpr;
-      const pickY = gl.canvas.height - _mousePosition[1] * dpr;
-
-      pickInstance(gl, pickX, pickY, this.cube, framebuffer);
+      const devicePosition = mapToDevicePosition(_mousePosition, gl);
+      pickInstance(gl, devicePosition[0], devicePosition[1], this.cube, framebuffer);
     }
 
     // Draw the cubes

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -201,8 +201,8 @@ export default class AppAnimationLoop extends AnimationLoop {
 
     if (_mousePosition) {
       const devicePixels = cssToDevicePixels(gl, _mousePosition);
-      const deviceX = Math.round((devicePixels.low[0] + devicePixels.high[0]) / 2);
-      const deviceY = Math.round((devicePixels.low[1] + devicePixels.high[1]) / 2);
+      const deviceX = devicePixels.x + Math.floor(devicePixels.width / 2);
+      const deviceY = devicePixels.y + Math.floor(devicePixels.height / 2);
 
       pickInstance(gl, deviceX, deviceY, this.cube, framebuffer);
     }

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -200,8 +200,11 @@ export default class AppAnimationLoop extends AnimationLoop {
     const {framebuffer, _mousePosition} = animationProps;
 
     if (_mousePosition) {
-      const devicePosition = cssToDevicePixels(gl, _mousePosition);
-      pickInstance(gl, devicePosition[0], devicePosition[1], this.cube, framebuffer);
+      const devicePixels = cssToDevicePixels(gl, _mousePosition);
+      const deviceX = Math.round((devicePixels.low[0] + devicePixels.high[0]) / 2);
+      const deviceY = Math.round((devicePixels.low[1] + devicePixels.high[1]) / 2);
+
+      pickInstance(gl, deviceX, deviceY, this.cube, framebuffer);
     }
 
     // Draw the cubes

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -200,6 +200,7 @@ export default class AppAnimationLoop extends AnimationLoop {
     const {framebuffer, _mousePosition} = animationProps;
 
     if (_mousePosition) {
+      // use the center pixel location in device pixel range
       const devicePixels = cssToDevicePixels(gl, _mousePosition);
       const deviceX = devicePixels.x + Math.floor(devicePixels.width / 2);
       const deviceY = devicePixels.y + Math.floor(devicePixels.height / 2);

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -11,7 +11,7 @@ import {
   createModuleInjection
 } from '@luma.gl/core';
 import {Timeline} from '@luma.gl/addons';
-import {mapToDevicePosition} from '@luma.gl/webgl';
+import {cssToDevicePixels} from '@luma.gl/webgl';
 import {Matrix4, radians} from 'math.gl';
 
 const INFO_HTML = `

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -200,7 +200,7 @@ export default class AppAnimationLoop extends AnimationLoop {
     const {framebuffer, _mousePosition} = animationProps;
 
     if (_mousePosition) {
-      const devicePosition = mapToDevicePosition(gl, _mousePosition);
+      const devicePosition = cssToDevicePixels(gl, _mousePosition);
       pickInstance(gl, devicePosition[0], devicePosition[1], this.cube, framebuffer);
     }
 

--- a/examples/core/instancing/app.js
+++ b/examples/core/instancing/app.js
@@ -200,7 +200,7 @@ export default class AppAnimationLoop extends AnimationLoop {
     const {framebuffer, _mousePosition} = animationProps;
 
     if (_mousePosition) {
-      const devicePosition = mapToDevicePosition(_mousePosition, gl);
+      const devicePosition = mapToDevicePosition(gl, _mousePosition);
       pickInstance(gl, devicePosition[0], devicePosition[1], this.cube, framebuffer);
     }
 

--- a/examples/core/instancing/package.json
+++ b/examples/core/instancing/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@luma.gl/core": "^7.2.0-beta",
+    "@luma.gl/webgl": "^7.2.0-beta",
     "@luma.gl/addons": "^7.2.0-beta",
     "math.gl": "^3.0.0-beta.3"
   },

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -8,6 +8,7 @@ import {
   isWebGL2,
   readPixelsToArray
 } from '@luma.gl/core';
+import {mapToDevicePosition} from '@luma.gl/webgl';
 import {Log} from 'probe.gl';
 
 const RED = new Uint8Array([255, 0, 0, 255]);
@@ -25,7 +26,7 @@ const INFO_HTML = `
 /* eslint-enable max-len */
 
 // Text to be displayed on environments when this demos is not supported.
-const ALT_TEXT = "THIS DEMO REQUIRES WEBLG2, BUT YOUR BROWSER DOESN'T SUPPORT IT";
+const ALT_TEXT = "THIS DEMO REQUIRES WEBGL2, BUT YOUR BROWSER DOESN'T SUPPORT IT";
 
 const EMIT_VS = `\
 #version 300 es
@@ -143,10 +144,6 @@ function mousemove(e) {
 
 function mouseleave(e) {
   pickPosition = null;
-}
-
-function getDevicePixelRatio() {
-  return typeof window !== 'undefined' ? window.devicePixelRatio : 1;
 }
 
 export default class AppAnimationLoop extends AnimationLoop {
@@ -289,12 +286,8 @@ export default class AppAnimationLoop extends AnimationLoop {
     rotationBuffer.setAccessor({divisor: 0});
 
     if (pickPosition) {
-      const dpr = useDevicePixels ? getDevicePixelRatio() : 1;
-
-      const pickX = pickPosition[0] * dpr;
-      const pickY = gl.canvas.height - pickPosition[1] * dpr;
-
-      pickInstance(gl, pickX, pickY, renderModel, framebuffer);
+      const devicePosition = mapToDevicePosition(pickPosition, gl);
+      pickInstance(gl, devicePosition[0], devicePosition[1], renderModel, framebuffer);
     }
   }
 

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -286,7 +286,7 @@ export default class AppAnimationLoop extends AnimationLoop {
     rotationBuffer.setAccessor({divisor: 0});
 
     if (pickPosition) {
-      const devicePosition = mapToDevicePosition(pickPosition, gl);
+      const devicePosition = mapToDevicePosition(gl, pickPosition);
       pickInstance(gl, devicePosition[0], devicePosition[1], renderModel, framebuffer);
     }
   }

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -286,9 +286,11 @@ export default class AppAnimationLoop extends AnimationLoop {
     rotationBuffer.setAccessor({divisor: 0});
 
     if (pickPosition) {
+      // use the center pixel location in device pixel range
       const devicePixels = cssToDevicePixels(gl, pickPosition);
-      const deviceX = Math.round((devicePixels.low[0] + devicePixels.high[0]) / 2);
-      const deviceY = Math.round((devicePixels.low[1] + devicePixels.high[1]) / 2);
+      const deviceX = devicePixels.x + Math.floor(devicePixels.width / 2);
+      const deviceY = devicePixels.y + Math.floor(devicePixels.height / 2);
+
       pickInstance(gl, deviceX, deviceY, renderModel, framebuffer);
     }
   }

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -286,8 +286,10 @@ export default class AppAnimationLoop extends AnimationLoop {
     rotationBuffer.setAccessor({divisor: 0});
 
     if (pickPosition) {
-      const devicePosition = cssToDevicePixels(gl, pickPosition);
-      pickInstance(gl, devicePosition[0], devicePosition[1], renderModel, framebuffer);
+      const devicePixels = cssToDevicePixels(gl, pickPosition);
+      const deviceX = Math.round((devicePixels.low[0] + devicePixels.high[0]) / 2);
+      const deviceY = Math.round((devicePixels.low[1] + devicePixels.high[1]) / 2);
+      pickInstance(gl, deviceX, deviceY, renderModel, framebuffer);
     }
   }
 

--- a/examples/core/transform/app.js
+++ b/examples/core/transform/app.js
@@ -8,7 +8,7 @@ import {
   isWebGL2,
   readPixelsToArray
 } from '@luma.gl/core';
-import {mapToDevicePosition} from '@luma.gl/webgl';
+import {cssToDevicePixels} from '@luma.gl/webgl';
 import {Log} from 'probe.gl';
 
 const RED = new Uint8Array([255, 0, 0, 255]);
@@ -286,7 +286,7 @@ export default class AppAnimationLoop extends AnimationLoop {
     rotationBuffer.setAccessor({divisor: 0});
 
     if (pickPosition) {
-      const devicePosition = mapToDevicePosition(gl, pickPosition);
+      const devicePosition = cssToDevicePixels(gl, pickPosition);
       pickInstance(gl, devicePosition[0], devicePosition[1], renderModel, framebuffer);
     }
   }

--- a/examples/core/transform/package.json
+++ b/examples/core/transform/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@luma.gl/core": "^7.2.0-beta",
+    "@luma.gl/webgl": "^7.2.0-beta",
     "probe.gl": "^3.1.0-beta.3"
   },
   "devDependencies": {

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -20,6 +20,10 @@ export {
   cloneTextureFrom,
   getKeyValue,
   getKey,
+  cssToDeviceRatio,
+  cssToDevicePixels,
+  deviceToCssRatio,
+  deviceToCssPixels,
   // DEPRECATED
   setGLContextDefaults as setContextDefaults,
   getContextDebugInfo as glGetDebugInfo

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -22,8 +22,6 @@ export {
   getKey,
   cssToDeviceRatio,
   cssToDevicePixels,
-  deviceToCssRatio,
-  deviceToCssPixels,
   // DEPRECATED
   setGLContextDefaults as setContextDefaults,
   getContextDebugInfo as glGetDebugInfo

--- a/modules/core/src/lib/animation-loop-proxy.js
+++ b/modules/core/src/lib/animation-loop-proxy.js
@@ -1,5 +1,5 @@
-/* global Worker */
-import {getPageLoadPromise, getCanvas, getDevicePixelRatio} from '@luma.gl/webgl';
+/* global window, Worker */
+import {getPageLoadPromise, getCanvas} from '@luma.gl/webgl';
 import {requestAnimationFrame, cancelAnimationFrame} from '@luma.gl/webgl';
 import {log, assert} from '../utils';
 
@@ -174,17 +174,14 @@ export default class AnimationLoopProxy {
 
   _onEvent(evt) {
     // TODO: get access to gl context and use 'cssToDevicePixels'
-    const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels);
+    const devicePixelRatio = this.useDevicePixels ? window.devicePixelRatio || 1 : 1;
     const type = evt.type;
 
     const safeEvent = {};
     for (const key in evt) {
       let value = evt[key];
       const valueType = typeof value;
-      if (key === 'offsetX') {
-        value *= devicePixelRatio;
-      }
-      if (key === 'offsetY') {
+      if (key === 'offsetX' || key === 'offsetY') {
         value *= devicePixelRatio;
       }
       if (valueType === 'number' || valueType === 'boolean' || valueType === 'string') {
@@ -230,7 +227,7 @@ export default class AnimationLoopProxy {
   _resizeCanvasDrawingBuffer() {
     if (this.autoResizeDrawingBuffer) {
       // TODO: get access to gl context and use 'cssToDevicePixels'
-      const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels);
+      const devicePixelRatio = this.useDevicePixels ? window.devicePixelRatio || 1 : 1;
       const width = Math.ceil(this.canvas.clientWidth * devicePixelRatio);
       const height = Math.ceil(this.canvas.clientHeight * devicePixelRatio);
 

--- a/modules/core/src/lib/animation-loop-proxy.js
+++ b/modules/core/src/lib/animation-loop-proxy.js
@@ -1,5 +1,5 @@
 /* global window, Worker */
-import {getPageLoadPromise, getCanvas} from '@luma.gl/webgl';
+import {getPageLoadPromise, getCanvas, getDevicePixelRatio} from '@luma.gl/webgl';
 import {requestAnimationFrame, cancelAnimationFrame} from '@luma.gl/webgl';
 import {log, assert} from '../utils';
 
@@ -173,14 +173,18 @@ export default class AnimationLoopProxy {
   }
 
   _onEvent(evt) {
-    const devicePixelRatio = this.useDevicePixels ? window.devicePixelRatio || 1 : 1;
+    // TODO: get access to gl context and use 'mapToDevicePosition'
+    const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels, window.devicePixelRatio);
     const type = evt.type;
 
     const safeEvent = {};
     for (const key in evt) {
       let value = evt[key];
       const valueType = typeof value;
-      if (key === 'offsetX' || key === 'offsetY') {
+      if (key === 'offsetX') {
+        value *= devicePixelRatio;
+      }
+      if (key === 'offsetY') {
         value *= devicePixelRatio;
       }
       if (valueType === 'number' || valueType === 'boolean' || valueType === 'string') {
@@ -225,9 +229,10 @@ export default class AnimationLoopProxy {
 
   _resizeCanvasDrawingBuffer() {
     if (this.autoResizeDrawingBuffer) {
-      const devicePixelRatio = this.useDevicePixels ? window.devicePixelRatio || 1 : 1;
-      const width = this.canvas.clientWidth * devicePixelRatio;
-      const height = this.canvas.clientHeight * devicePixelRatio;
+      // TODO: get access to gl context and use 'mapToDevicePosition'
+      const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels, window.devicePixelRatio);
+      const width = Math.ceil(this.canvas.clientWidth * devicePixelRatio);
+      const height = Math.ceil(this.canvas.clientHeight * devicePixelRatio);
 
       if (this.width !== width || this.height !== height) {
         this.width = width;

--- a/modules/core/src/lib/animation-loop-proxy.js
+++ b/modules/core/src/lib/animation-loop-proxy.js
@@ -1,4 +1,4 @@
-/* global window, Worker */
+/* global Worker */
 import {getPageLoadPromise, getCanvas, getDevicePixelRatio} from '@luma.gl/webgl';
 import {requestAnimationFrame, cancelAnimationFrame} from '@luma.gl/webgl';
 import {log, assert} from '../utils';
@@ -174,7 +174,7 @@ export default class AnimationLoopProxy {
 
   _onEvent(evt) {
     // TODO: get access to gl context and use 'mapToDevicePosition'
-    const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels, window.devicePixelRatio);
+    const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels);
     const type = evt.type;
 
     const safeEvent = {};
@@ -230,7 +230,7 @@ export default class AnimationLoopProxy {
   _resizeCanvasDrawingBuffer() {
     if (this.autoResizeDrawingBuffer) {
       // TODO: get access to gl context and use 'mapToDevicePosition'
-      const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels, window.devicePixelRatio);
+      const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels);
       const width = Math.ceil(this.canvas.clientWidth * devicePixelRatio);
       const height = Math.ceil(this.canvas.clientHeight * devicePixelRatio);
 

--- a/modules/core/src/lib/animation-loop-proxy.js
+++ b/modules/core/src/lib/animation-loop-proxy.js
@@ -173,7 +173,7 @@ export default class AnimationLoopProxy {
   }
 
   _onEvent(evt) {
-    // TODO: get access to gl context and use 'mapToDevicePosition'
+    // TODO: get access to gl context and use 'cssToDevicePixels'
     const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels);
     const type = evt.type;
 
@@ -229,7 +229,7 @@ export default class AnimationLoopProxy {
 
   _resizeCanvasDrawingBuffer() {
     if (this.autoResizeDrawingBuffer) {
-      // TODO: get access to gl context and use 'mapToDevicePosition'
+      // TODO: get access to gl context and use 'cssToDevicePixels'
       const devicePixelRatio = getDevicePixelRatio(this.useDevicePixels);
       const width = Math.ceil(this.canvas.clientWidth * devicePixelRatio);
       const height = Math.ceil(this.canvas.clientHeight * devicePixelRatio);

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -9,7 +9,7 @@ import {getContextDebugInfo} from '../debug/get-context-debug-info';
 
 import {WebGL2RenderingContext} from '../webgl-utils';
 
-import {log, isBrowser, assert} from '../utils';
+import {log, isBrowser, assert, getDevicePixelRatio} from '../utils';
 import {global} from '../utils/globals';
 
 export const ERR_CONTEXT = 'Invalid WebGLRenderingContext';
@@ -167,13 +167,10 @@ export function resizeGLContext(gl, options = {}) {
   // Resize browser context
   if (gl.canvas) {
     /* global window */
-    const devicePixelRatio = options.useDevicePixels ? window.devicePixelRatio || 1 : 1;
-
-    const width = `width` in options ? options.width : gl.canvas.clientWidth;
-    const height = `height` in options ? options.height : gl.canvas.clientHeight;
-
-    gl.canvas.width = width * devicePixelRatio;
-    gl.canvas.height = height * devicePixelRatio;
+    const devicePixelRatio = getDevicePixelRatio(options.useDevicePixels, window.devicePixelRatio);
+    // console.log(`Context: devicePixelRatio: ${devicePixelRatio}`);
+    gl.canvas.width = Math.ceil(gl.canvas.clientWidth * devicePixelRatio);
+    gl.canvas.height = Math.ceil(gl.canvas.clientHeight * devicePixelRatio);
 
     return;
   }

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -166,12 +166,23 @@ export function destroyGLContext(gl) {
 export function resizeGLContext(gl, options = {}) {
   // Resize browser context
   if (gl.canvas) {
-    /* global window */
-    const devicePixelRatio = getDevicePixelRatio(options.useDevicePixels, window.devicePixelRatio);
-    // console.log(`Context: devicePixelRatio: ${devicePixelRatio}`);
-    gl.canvas.width = Math.ceil(gl.canvas.clientWidth * devicePixelRatio);
-    gl.canvas.height = Math.ceil(gl.canvas.clientHeight * devicePixelRatio);
+    let devicePixelRatio = getDevicePixelRatio(options.useDevicePixels);
+    let devicePixelRatioClamped = false;
+    let aspectRatioValid = false;
+    // Note: when devicePixelRatio is too high, it is possible we might hit system limit for
+    // drawing buffer width and hight, in those cases they get clamped and resulting aspect ration may not be maintained
+    // for those cases, reduce devicePixelRatio.
+    do {
+      gl.canvas.width = Math.ceil(gl.canvas.clientWidth * devicePixelRatio);
+      gl.canvas.height = Math.ceil(gl.canvas.clientHeight * devicePixelRatio);
+      aspectRatioValid = gl.drawingBufferWidth / gl.canvas.clientWidth === gl.drawingBufferHeight / gl.canvas.clientHeight;
+      devicePixelRatio = Math.max(devicePixelRatio/2, 1);
+      devicePixelRatioClamped = devicePixelRatioClamped || !aspectRatioValid;
+    } while(!aspectRatioValid);
 
+    if (devicePixelRatioClamped) {
+      log.warn(`System limit is hit, clamped down device pixel ration from ${getDevicePixelRatio(options.useDevicePixels)} to  ${devicePixelRatio * 2}`)();
+    }
     return;
   }
 
@@ -189,7 +200,7 @@ function logInfo(gl) {
   const info = getContextDebugInfo(gl);
   const driver = info ? `(${info.vendor},${info.renderer})` : '';
   const debug = gl.debug ? ' debug' : '';
-  log.once(1, `${webGL}${debug} context ${driver}`)();
+  log.once(0, `${webGL}${debug} context ${driver}`)();
 }
 
 function getVersion(gl) {

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -166,29 +166,8 @@ export function destroyGLContext(gl) {
 export function resizeGLContext(gl, options = {}) {
   // Resize browser context
   if (gl.canvas) {
-    let devicePixelRatio = getDevicePixelRatio(options.useDevicePixels);
-    let devicePixelRatioClamped = false;
-    let aspectRatioValid = false;
-    // Note: when devicePixelRatio is too high, it is possible we might hit system limit for
-    // drawing buffer width and hight, in those cases they get clamped and resulting aspect ration may not be maintained
-    // for those cases, reduce devicePixelRatio.
-    do {
-      gl.canvas.width = Math.ceil(gl.canvas.clientWidth * devicePixelRatio);
-      gl.canvas.height = Math.ceil(gl.canvas.clientHeight * devicePixelRatio);
-      aspectRatioValid =
-        gl.drawingBufferWidth / gl.canvas.clientWidth ===
-        gl.drawingBufferHeight / gl.canvas.clientHeight;
-      devicePixelRatio = Math.max(devicePixelRatio / 2, 1);
-      devicePixelRatioClamped = devicePixelRatioClamped || !aspectRatioValid;
-    } while (!aspectRatioValid);
-
-    if (devicePixelRatioClamped) {
-      log.warn(
-        `System limit is hit, clamped down device pixel ration from ${getDevicePixelRatio(
-          options.useDevicePixels
-        )} to  ${devicePixelRatio * 2}`
-      )();
-    }
+    const devicePixelRatio = getDevicePixelRatio(options.useDevicePixels);
+    setDevicePixelRatio(gl, devicePixelRatio);
     return;
   }
 
@@ -206,7 +185,7 @@ function logInfo(gl) {
   const info = getContextDebugInfo(gl);
   const driver = info ? `(${info.vendor},${info.renderer})` : '';
   const debug = gl.debug ? ' debug' : '';
-  log.once(0, `${webGL}${debug} context ${driver}`)();
+  log.info(1, `${webGL}${debug} context ${driver}`)();
 }
 
 function getVersion(gl) {
@@ -216,4 +195,26 @@ function getVersion(gl) {
   }
   // Must be a WebGL1 context.
   return 1;
+}
+
+// use devicePixelRatio to set canvas width and height
+function setDevicePixelRatio(gl, devicePixelRatio) {
+  let devicePixelRatioClamped = false;
+  let aspectRatioValid = false;
+  // Note: when devicePixelRatio is too high, it is possible we might hit system limit for
+  // drawing buffer width and hight, in those cases they get clamped and resulting aspect ration may not be maintained
+  // for those cases, reduce devicePixelRatio.
+  do {
+    gl.canvas.width = Math.ceil(gl.canvas.clientWidth * devicePixelRatio);
+    gl.canvas.height = Math.ceil(gl.canvas.clientHeight * devicePixelRatio);
+    aspectRatioValid =
+      gl.drawingBufferWidth / gl.canvas.clientWidth ===
+      gl.drawingBufferHeight / gl.canvas.clientHeight;
+    devicePixelRatio = Math.max(devicePixelRatio / 2, 1);
+    devicePixelRatioClamped = devicePixelRatioClamped || !aspectRatioValid;
+  } while (!aspectRatioValid);
+
+  if (devicePixelRatioClamped) {
+    log.warn(`Device pixel ratio clamped`)();
+  }
 }

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -175,13 +175,19 @@ export function resizeGLContext(gl, options = {}) {
     do {
       gl.canvas.width = Math.ceil(gl.canvas.clientWidth * devicePixelRatio);
       gl.canvas.height = Math.ceil(gl.canvas.clientHeight * devicePixelRatio);
-      aspectRatioValid = gl.drawingBufferWidth / gl.canvas.clientWidth === gl.drawingBufferHeight / gl.canvas.clientHeight;
-      devicePixelRatio = Math.max(devicePixelRatio/2, 1);
+      aspectRatioValid =
+        gl.drawingBufferWidth / gl.canvas.clientWidth ===
+        gl.drawingBufferHeight / gl.canvas.clientHeight;
+      devicePixelRatio = Math.max(devicePixelRatio / 2, 1);
       devicePixelRatioClamped = devicePixelRatioClamped || !aspectRatioValid;
-    } while(!aspectRatioValid);
+    } while (!aspectRatioValid);
 
     if (devicePixelRatioClamped) {
-      log.warn(`System limit is hit, clamped down device pixel ration from ${getDevicePixelRatio(options.useDevicePixels)} to  ${devicePixelRatio * 2}`)();
+      log.warn(
+        `System limit is hit, clamped down device pixel ration from ${getDevicePixelRatio(
+          options.useDevicePixels
+        )} to  ${devicePixelRatio * 2}`
+      )();
     }
     return;
   }

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -203,13 +203,10 @@ function setDevicePixelRatio(gl, devicePixelRatio, options) {
   let aspectRatioValid = false;
 
   // NOTE: if options.width and options.height not used remove in v8
-  let clientWidth = 'width' in options ? options.width : gl.canvas.clientWidth || gl.canvas.width;
-  let clientHeight =
-    'height' in options ? options.height : gl.canvas.clientHeight || gl.canvas.height;
-
-  // Fallback to sane values
-  clientWidth = clientWidth >= 1 ? clientWidth : 1;
-  clientHeight = clientHeight >= 1 ? clientHeight : 1;
+  const clientWidth =
+    'width' in options ? options.width : gl.canvas.clientWidth || gl.canvas.width || 1;
+  const clientHeight =
+    'height' in options ? options.height : gl.canvas.clientHeight || gl.canvas.height || 1;
 
   // Note: when devicePixelRatio is too high, it is possible we might hit system limit for
   // drawing buffer width and hight, in those cases they get clamped and resulting aspect ration may not be maintained

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -201,18 +201,23 @@ function getVersion(gl) {
 function setDevicePixelRatio(gl, devicePixelRatio) {
   let devicePixelRatioClamped = false;
   let aspectRatioValid = false;
+  let clientSizeValid = false;
+
   // Note: when devicePixelRatio is too high, it is possible we might hit system limit for
   // drawing buffer width and hight, in those cases they get clamped and resulting aspect ration may not be maintained
   // for those cases, reduce devicePixelRatio.
   do {
-    gl.canvas.width = Math.ceil(gl.canvas.clientWidth * devicePixelRatio);
-    gl.canvas.height = Math.ceil(gl.canvas.clientHeight * devicePixelRatio);
+    const {clientWidth, clientHeight} = gl.canvas;
+    gl.canvas.width = Math.ceil(clientWidth * devicePixelRatio);
+    gl.canvas.height = Math.ceil(clientHeight * devicePixelRatio);
     aspectRatioValid =
-      gl.drawingBufferWidth / gl.canvas.clientWidth ===
-      gl.drawingBufferHeight / gl.canvas.clientHeight;
+      gl.drawingBufferWidth / clientWidth === gl.drawingBufferHeight / clientHeight;
     devicePixelRatio = Math.max(devicePixelRatio / 2, 1);
     devicePixelRatioClamped = devicePixelRatioClamped || !aspectRatioValid;
-  } while (!aspectRatioValid);
+
+    // matches old behavior when clientWidth or clientHeight is 0.
+    clientSizeValid = clientWidth > 0 && clientHeight > 0;
+  } while (!aspectRatioValid && clientSizeValid);
 
   if (devicePixelRatioClamped) {
     log.warn(`Device pixel ratio clamped`)();

--- a/modules/webgl/src/index.js
+++ b/modules/webgl/src/index.js
@@ -106,8 +106,6 @@ export {self, window, global, document} from './utils/globals';
 export {default as isBrowser} from './utils/is-browser';
 export {
   getDevicePixelRatio,
-  mapToDevicePositionX,
-  mapToDevicePositionY,
   mapToDevicePosition
 } from './utils/device-pixels';
 

--- a/modules/webgl/src/index.js
+++ b/modules/webgl/src/index.js
@@ -106,7 +106,8 @@ export {self, window, global, document} from './utils/globals';
 export {default as isBrowser} from './utils/is-browser';
 export {
   getDevicePixelRatio,
-  cssToDevicePixels
+  cssToDevicePixels,
+  deviceToCssPixels
 } from './utils/device-pixels';
 
 // INTERNAL

--- a/modules/webgl/src/index.js
+++ b/modules/webgl/src/index.js
@@ -104,7 +104,13 @@ export {default as assert} from './utils/assert';
 export {uid, isObjectEmpty} from './utils/utils';
 export {self, window, global, document} from './utils/globals';
 export {default as isBrowser} from './utils/is-browser';
-export {getDevicePixelRatio, cssToDevicePixels, deviceToCssPixels} from './utils/device-pixels';
+export {
+  getDevicePixelRatio,
+  cssToDeviceRatio,
+  cssToDevicePixels,
+  deviceToCssRatio,
+  deviceToCssPixels
+} from './utils/device-pixels';
 
 // INTERNAL
 export {parseUniformName, getUniformSetter} from './classes/uniforms';

--- a/modules/webgl/src/index.js
+++ b/modules/webgl/src/index.js
@@ -104,6 +104,12 @@ export {default as assert} from './utils/assert';
 export {uid, isObjectEmpty} from './utils/utils';
 export {self, window, global, document} from './utils/globals';
 export {default as isBrowser} from './utils/is-browser';
+export {
+  getDevicePixelRatio,
+  mapToDevicePositionX,
+  mapToDevicePositionY,
+  mapToDevicePosition
+} from './utils/device-pixels';
 
 // INTERNAL
 export {parseUniformName, getUniformSetter} from './classes/uniforms';

--- a/modules/webgl/src/index.js
+++ b/modules/webgl/src/index.js
@@ -104,11 +104,7 @@ export {default as assert} from './utils/assert';
 export {uid, isObjectEmpty} from './utils/utils';
 export {self, window, global, document} from './utils/globals';
 export {default as isBrowser} from './utils/is-browser';
-export {
-  getDevicePixelRatio,
-  cssToDevicePixels,
-  deviceToCssPixels
-} from './utils/device-pixels';
+export {getDevicePixelRatio, cssToDevicePixels, deviceToCssPixels} from './utils/device-pixels';
 
 // INTERNAL
 export {parseUniformName, getUniformSetter} from './classes/uniforms';

--- a/modules/webgl/src/index.js
+++ b/modules/webgl/src/index.js
@@ -106,7 +106,7 @@ export {self, window, global, document} from './utils/globals';
 export {default as isBrowser} from './utils/is-browser';
 export {
   getDevicePixelRatio,
-  mapToDevicePosition
+  cssToDevicePixels
 } from './utils/device-pixels';
 
 // INTERNAL

--- a/modules/webgl/src/index.js
+++ b/modules/webgl/src/index.js
@@ -104,13 +104,7 @@ export {default as assert} from './utils/assert';
 export {uid, isObjectEmpty} from './utils/utils';
 export {self, window, global, document} from './utils/globals';
 export {default as isBrowser} from './utils/is-browser';
-export {
-  getDevicePixelRatio,
-  cssToDeviceRatio,
-  cssToDevicePixels,
-  deviceToCssRatio,
-  deviceToCssPixels
-} from './utils/device-pixels';
+export {cssToDeviceRatio, cssToDevicePixels} from './utils/device-pixels';
 
 // INTERNAL
 export {parseUniformName, getUniformSetter} from './classes/uniforms';

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -1,0 +1,36 @@
+/**
+ * Calulates device pixel ratio
+ *
+ * @param {boolean or Number} useDevicePixels - gl context
+ * @param {Number} windowPixelRatio - device supported pixel ratio
+ * @return {Number} - device pixel ratio
+ */
+export function getDevicePixelRatio(useDevicePixels, windowPixelRatio) {
+  const windowRatio = windowPixelRatio || 1;
+  if (Number.isFinite(useDevicePixels)) {
+    return useDevicePixels <= 0 ? 1 : useDevicePixels;
+  }
+  return useDevicePixels ? windowRatio : 1;
+}
+
+// Converts window pixel x position to device pixel x position
+export function mapToDevicePositionX(x, gl) {
+  const dpr = gl.drawingBufferWidth / gl.canvas.clientWidth;
+  // since we are rounding to nearest, when dpr < 1, edge pixels may point to out of bounds value, clamp to the limit
+  return Math.min(Math.round(x * dpr), gl.drawingBufferWidth - 1);
+}
+
+// Converts window y position to device y position
+export function mapToDevicePositionY(y, gl, yInvert = true) {
+  const dpr = gl.drawingBufferHeight / gl.canvas.clientHeight;
+  let deviceY = Math.round(y * dpr);
+  if (yInvert) {
+    deviceY = Math.max(0, gl.drawingBufferHeight - Math.ceil(dpr) - Math.round(y * dpr));
+  }
+  return Math.min(deviceY, gl.drawingBufferHeight - 1);
+}
+
+// Maps window postion to device position
+export function mapToDevicePosition(position, gl, yInvert = true) {
+  return [mapToDevicePositionX(position[0], gl), mapToDevicePositionY(position[1], gl, yInvert)];
+}

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -15,15 +15,30 @@ export function getDevicePixelRatio(useDevicePixels) {
 }
 
 
-// Maps window postion to device position
-export function cssToDevicePixels(gl, position, yInvert = true) {
-  const dpr = gl.drawingBufferWidth / gl.canvas.clientWidth;
+// Maps CSS pixel position to device pixel position
+export function cssToDevicePixels(gl, cssPixel, yInvert = true) {
+  const ratio = gl.drawingBufferWidth / gl.canvas.clientWidth;
+  const width = gl.drawingBufferWidth;
+  const height = gl.drawingBufferHeight;
+  return scalePixels(cssPixel, ratio, width, height, yInvert);
+}
 
+// Maps Device pixel position to CSS pixel position
+export function deviceToCssPixels(gl, cssPixel, yInvert = true) {
+  const ratio = gl.canvas.clientWidth / gl.drawingBufferWidth;
+  const width = gl.canvas.clientWidth;
+  const height = gl.canvas.clientHeight;
+  return scalePixels(cssPixel, ratio, width, height, yInvert);
+}
+
+// PRIVATE
+
+function scalePixels(pixel, ratio, width, height, yInvert) {
   // since we are rounding to nearest, when dpr > 1, edge pixels may point to out of bounds value, clamp to the limit
-  const x = Math.min(Math.round(position[0] * dpr), gl.drawingBufferWidth - 1);
+  const x = Math.min(Math.round(pixel[0] * ratio), width - 1);
   const y = yInvert
-    ? Math.max(0, gl.drawingBufferHeight - Math.ceil(dpr) - Math.round(position[1] * dpr))
-    : Math.min(Math.round(position[1] * dpr), gl.drawingBufferHeight - 1);
+    ? Math.max(0, height - Math.ceil(ratio) - Math.round(pixel[1] * ratio))
+    : Math.min(Math.round(pixel[1] * ratio), height - 1);
 
   return [x, y];
 }

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -16,17 +16,14 @@ export function getDevicePixelRatio(useDevicePixels) {
 
 
 // Maps window postion to device position
-export function mapToDevicePosition(position, gl, yInvert = true) {
+export function mapToDevicePosition(gl, position, yInvert = true) {
   const dpr = gl.drawingBufferWidth / gl.canvas.clientWidth;
 
   // since we are rounding to nearest, when dpr > 1, edge pixels may point to out of bounds value, clamp to the limit
   const x = Math.min(Math.round(position[0] * dpr), gl.drawingBufferWidth - 1);
-
-  let y = Math.round(position[1] * dpr);
-  if (yInvert) {
-    y = Math.max(0, gl.drawingBufferHeight - Math.ceil(dpr) - Math.round(y * dpr));
-  }
-  y = Math.min(y, gl.drawingBufferHeight - 1);
+  const y = yInvert
+    ? Math.max(0, gl.drawingBufferHeight - Math.ceil(dpr) - Math.round(position[1] * dpr))
+    : Math.min(Math.round(position[1] * dpr), gl.drawingBufferHeight - 1);
 
   return [x, y];
 }

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -1,19 +1,5 @@
 /* global window */
 
-/**
- * Calulates device pixel ratio
- *
- * @param {boolean or Number} useDevicePixels - boolean or a Number
- * @return {Number} - device pixel ratio
- */
-export function getDevicePixelRatio(useDevicePixels) {
-  const windowRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
-  if (Number.isFinite(useDevicePixels)) {
-    return useDevicePixels <= 0 ? 1 : useDevicePixels;
-  }
-  return useDevicePixels ? windowRatio : 1;
-}
-
 // multiplier need to convert CSS size to Device size
 export function cssToDeviceRatio(gl) {
   return gl.drawingBufferWidth / (gl.canvas.clientWidth || gl.canvas.width);
@@ -27,17 +13,20 @@ export function cssToDevicePixels(gl, cssPixel, yInvert = true) {
   return scalePixels(cssPixel, ratio, width, height, yInvert);
 }
 
-// multiplier need to convert Device size to CSS size
-export function deviceToCssRatio(gl) {
-  return (gl.canvas.clientWidth || gl.canvas.width) / gl.drawingBufferWidth;
-}
+// HELPER METHODS
 
-// Maps Device pixel position to CSS pixel position
-export function deviceToCssPixels(gl, devicePixel, yInvert = true) {
-  const ratio = deviceToCssRatio(gl);
-  const width = gl.canvas.clientWidth || gl.canvas.width;
-  const height = gl.canvas.clientHeight || gl.canvas.height;
-  return scalePixels(devicePixel, ratio, width, height, yInvert);
+/**
+ * Calulates device pixel ratio, used during context creation
+ *
+ * @param {boolean or Number} useDevicePixels - boolean or a Number
+ * @return {Number} - device pixel ratio
+ */
+export function getDevicePixelRatio(useDevicePixels) {
+  const windowRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
+  if (Number.isFinite(useDevicePixels)) {
+    return useDevicePixels <= 0 ? 1 : useDevicePixels;
+  }
+  return useDevicePixels ? windowRatio : 1;
 }
 
 // PRIVATE

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -16,7 +16,7 @@ export function getDevicePixelRatio(useDevicePixels) {
 
 
 // Maps window postion to device position
-export function mapToDevicePosition(gl, position, yInvert = true) {
+export function cssToDevicePixels(gl, position, yInvert = true) {
   const dpr = gl.drawingBufferWidth / gl.canvas.clientWidth;
 
   // since we are rounding to nearest, when dpr > 1, edge pixels may point to out of bounds value, clamp to the limit

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -16,7 +16,7 @@ export function getDevicePixelRatio(useDevicePixels) {
 
 // multiplier need to convert CSS size to Device size
 export function cssToDeviceRatio(gl) {
-  return gl.drawingBufferWidth / gl.canvas.clientWidth;
+  return gl.drawingBufferWidth / (gl.canvas.clientWidth || gl.canvas.width);
 }
 
 // Maps CSS pixel position to device pixel position
@@ -29,14 +29,14 @@ export function cssToDevicePixels(gl, cssPixel, yInvert = true) {
 
 // multiplier need to convert Device size to CSS size
 export function deviceToCssRatio(gl) {
-  return gl.canvas.clientWidth / gl.drawingBufferWidth;
+  return (gl.canvas.clientWidth || gl.canvas.width) / gl.drawingBufferWidth;
 }
 
 // Maps Device pixel position to CSS pixel position
 export function deviceToCssPixels(gl, devicePixel, yInvert = true) {
   const ratio = deviceToCssRatio(gl);
-  const width = gl.canvas.clientWidth;
-  const height = gl.canvas.clientHeight;
+  const width = gl.canvas.clientWidth || gl.canvas.width;
+  const height = gl.canvas.clientHeight || gl.canvas.height;
   return scalePixels(devicePixel, ratio, width, height, yInvert);
 }
 

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -1,14 +1,15 @@
+/* global window */
+
 /**
  * Calulates device pixel ratio
  *
- * @param {boolean or Number} useDevicePixels - gl context
- * @param {Number} windowPixelRatio - device supported pixel ratio
+ * @param {boolean or Number} useDevicePixels - boolean or a Number
  * @return {Number} - device pixel ratio
  */
-export function getDevicePixelRatio(useDevicePixels, windowPixelRatio) {
-  const windowRatio = windowPixelRatio || 1;
+export function getDevicePixelRatio(useDevicePixels) {
+  const windowRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
   if (Number.isFinite(useDevicePixels)) {
-    return useDevicePixels <= 0 ? 1 : useDevicePixels;
+    return useDevicePixels <= 0 ? windowRatio : useDevicePixels;
   }
   return useDevicePixels ? windowRatio : 1;
 }

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -14,7 +14,6 @@ export function getDevicePixelRatio(useDevicePixels) {
   return useDevicePixels ? windowRatio : 1;
 }
 
-
 // Maps CSS pixel position to device pixel position
 export function cssToDevicePixels(gl, cssPixel, yInvert = true) {
   const ratio = gl.drawingBufferWidth / gl.canvas.clientWidth;
@@ -24,11 +23,11 @@ export function cssToDevicePixels(gl, cssPixel, yInvert = true) {
 }
 
 // Maps Device pixel position to CSS pixel position
-export function deviceToCssPixels(gl, cssPixel, yInvert = true) {
+export function deviceToCssPixels(gl, devicePixel, yInvert = true) {
   const ratio = gl.canvas.clientWidth / gl.drawingBufferWidth;
   const width = gl.canvas.clientWidth;
   const height = gl.canvas.clientHeight;
-  return scalePixels(cssPixel, ratio, width, height, yInvert);
+  return scalePixels(devicePixel, ratio, width, height, yInvert);
 }
 
 // PRIVATE

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -14,24 +14,19 @@ export function getDevicePixelRatio(useDevicePixels) {
   return useDevicePixels ? windowRatio : 1;
 }
 
-// Converts window pixel x position to device pixel x position
-export function mapToDevicePositionX(x, gl) {
-  const dpr = gl.drawingBufferWidth / gl.canvas.clientWidth;
-  // since we are rounding to nearest, when dpr < 1, edge pixels may point to out of bounds value, clamp to the limit
-  return Math.min(Math.round(x * dpr), gl.drawingBufferWidth - 1);
-}
-
-// Converts window y position to device y position
-export function mapToDevicePositionY(y, gl, yInvert = true) {
-  const dpr = gl.drawingBufferHeight / gl.canvas.clientHeight;
-  let deviceY = Math.round(y * dpr);
-  if (yInvert) {
-    deviceY = Math.max(0, gl.drawingBufferHeight - Math.ceil(dpr) - Math.round(y * dpr));
-  }
-  return Math.min(deviceY, gl.drawingBufferHeight - 1);
-}
 
 // Maps window postion to device position
 export function mapToDevicePosition(position, gl, yInvert = true) {
-  return [mapToDevicePositionX(position[0], gl), mapToDevicePositionY(position[1], gl, yInvert)];
+  const dpr = gl.drawingBufferWidth / gl.canvas.clientWidth;
+
+  // since we are rounding to nearest, when dpr > 1, edge pixels may point to out of bounds value, clamp to the limit
+  const x = Math.min(Math.round(position[0] * dpr), gl.drawingBufferWidth - 1);
+
+  let y = Math.round(position[1] * dpr);
+  if (yInvert) {
+    y = Math.max(0, gl.drawingBufferHeight - Math.ceil(dpr) - Math.round(y * dpr));
+  }
+  y = Math.min(y, gl.drawingBufferHeight - 1);
+
+  return [x, y];
 }

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -14,17 +14,27 @@ export function getDevicePixelRatio(useDevicePixels) {
   return useDevicePixels ? windowRatio : 1;
 }
 
+// multiplier need to convert CSS size to Device size
+export function cssToDeviceRatio(gl) {
+  return gl.drawingBufferWidth / gl.canvas.clientWidth;
+}
+
 // Maps CSS pixel position to device pixel position
 export function cssToDevicePixels(gl, cssPixel, yInvert = true) {
-  const ratio = gl.drawingBufferWidth / gl.canvas.clientWidth;
+  const ratio = cssToDeviceRatio(gl);
   const width = gl.drawingBufferWidth;
   const height = gl.drawingBufferHeight;
   return scalePixels(cssPixel, ratio, width, height, yInvert);
 }
 
+// multiplier need to convert Device size to CSS size
+export function deviceToCssRatio(gl) {
+  return gl.canvas.clientWidth / gl.drawingBufferWidth;
+}
+
 // Maps Device pixel position to CSS pixel position
 export function deviceToCssPixels(gl, devicePixel, yInvert = true) {
-  const ratio = gl.canvas.clientWidth / gl.drawingBufferWidth;
+  const ratio = deviceToCssRatio(gl);
   const width = gl.canvas.clientWidth;
   const height = gl.canvas.clientHeight;
   return scalePixels(devicePixel, ratio, width, height, yInvert);

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -9,7 +9,7 @@
 export function getDevicePixelRatio(useDevicePixels) {
   const windowRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
   if (Number.isFinite(useDevicePixels)) {
-    return useDevicePixels <= 0 ? windowRatio : useDevicePixels;
+    return useDevicePixels <= 0 ? 1 : useDevicePixels;
   }
   return useDevicePixels ? windowRatio : 1;
 }

--- a/modules/webgl/src/utils/index.js
+++ b/modules/webgl/src/utils/index.js
@@ -6,3 +6,9 @@ export {uid, isPowerOfTwo, isObjectEmpty} from './utils';
 export {formatValue} from './format-value';
 export {stubRemovedMethods} from './stub-methods';
 export {checkProps} from './check-props';
+export {
+  getDevicePixelRatio,
+  mapToDevicePositionX,
+  mapToDevicePositionY,
+  mapToDevicePosition
+} from './device-pixels';

--- a/modules/webgl/src/utils/index.js
+++ b/modules/webgl/src/utils/index.js
@@ -6,4 +6,4 @@ export {uid, isPowerOfTwo, isObjectEmpty} from './utils';
 export {formatValue} from './format-value';
 export {stubRemovedMethods} from './stub-methods';
 export {checkProps} from './check-props';
-export {getDevicePixelRatio, cssToDevicePixels, deviceToCssPixels} from './device-pixels';
+export {cssToDevicePixels, cssToDeviceRatio, getDevicePixelRatio} from './device-pixels';

--- a/modules/webgl/src/utils/index.js
+++ b/modules/webgl/src/utils/index.js
@@ -8,5 +8,5 @@ export {stubRemovedMethods} from './stub-methods';
 export {checkProps} from './check-props';
 export {
   getDevicePixelRatio,
-  mapToDevicePosition
+  cssToDevicePixels
 } from './device-pixels';

--- a/modules/webgl/src/utils/index.js
+++ b/modules/webgl/src/utils/index.js
@@ -8,7 +8,5 @@ export {stubRemovedMethods} from './stub-methods';
 export {checkProps} from './check-props';
 export {
   getDevicePixelRatio,
-  mapToDevicePositionX,
-  mapToDevicePositionY,
   mapToDevicePosition
 } from './device-pixels';

--- a/modules/webgl/src/utils/index.js
+++ b/modules/webgl/src/utils/index.js
@@ -6,8 +6,4 @@ export {uid, isPowerOfTwo, isObjectEmpty} from './utils';
 export {formatValue} from './format-value';
 export {stubRemovedMethods} from './stub-methods';
 export {checkProps} from './check-props';
-export {
-  getDevicePixelRatio,
-  cssToDevicePixels,
-  deviceToCssPixels
-} from './device-pixels';
+export {getDevicePixelRatio, cssToDevicePixels, deviceToCssPixels} from './device-pixels';

--- a/modules/webgl/src/utils/index.js
+++ b/modules/webgl/src/utils/index.js
@@ -8,5 +8,6 @@ export {stubRemovedMethods} from './stub-methods';
 export {checkProps} from './check-props';
 export {
   getDevicePixelRatio,
-  cssToDevicePixels
+  cssToDevicePixels,
+  deviceToCssPixels
 } from './device-pixels';

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -1,0 +1,125 @@
+import {getDevicePixelRatio, mapToDevicePosition} from '@luma.gl/webgl';
+import test from 'tape-catch';
+
+test('webgl#getDevicePixelRatio', t => {
+  const TEST_CAES = [
+    {
+      name: 'Undefined windowPixelRatio, should use 1',
+      useDevicePixels: true,
+      expected: 1
+    },
+    {
+      name: 'Use windowPixelRatio, should use it',
+      useDevicePixels: true,
+      windowPixelRatio: 2,
+      expected: 2
+    },
+    {
+      name: 'Use default pixel ratio, should use 1',
+      useDevicePixels: false,
+      windowPixelRatio: 2,
+      expected: 1
+    },
+    {
+      name: 'Non Finite useDevicePixels, should use 1',
+      useDevicePixels: null,
+      windowPixelRatio: 2,
+      expected: 1
+    },
+    {
+      name: 'Non valid useDevicePixels, should use 1',
+      useDevicePixels: 0,
+      windowPixelRatio: 2,
+      expected: 1
+    },
+    {
+      name: 'Non valid useDevicePixels, should use 1',
+      useDevicePixels: -3.2,
+      windowPixelRatio: 2,
+      expected: 1
+    },
+    {
+      name: 'Valid useDevicePixels, should use it',
+      useDevicePixels: 4.5,
+      windowPixelRatio: 2,
+      expected: 4.5
+    }
+  ];
+
+  TEST_CAES.forEach(tc => {
+    t.equal(tc.expected, getDevicePixelRatio(tc.useDevicePixels, tc.windowPixelRatio), tc.name);
+  });
+  t.end();
+});
+
+test('webgl#mapToDevicePosition', t => {
+  const LOW_DPR = 0.5;
+  const HIGH_DPR = 4;
+  const TEST_CASES = [
+    {
+      name: 'device pixel ratio 1',
+      gl: {
+        drawingBufferWidth: 10,
+        drawingBufferHeight: 10,
+        canvas: {
+          clientWidth: 10,
+          clientHeight: 10
+        }
+      },
+      ratio: 1,
+      windowPositions: [[0, 0], [2, 2], [9, 9]],
+      devicePositionsInverted: [[0, 9], [2, 7], [9, 0]],
+      devicePositions: [[0, 0], [2, 2], [9, 9]]
+    },
+    {
+      name: 'device pixel ratio > 1',
+      gl: {
+        drawingBufferWidth: 10 * HIGH_DPR,
+        drawingBufferHeight: 10 * HIGH_DPR,
+        canvas: {
+          clientWidth: 10,
+          clientHeight: 10
+        }
+      },
+      ratio: HIGH_DPR,
+      yInvert: true,
+      windowPositions: [[0, 0], [2, 2], [9, 9]],
+      devicePositionsInverted: [[0, 36], [8, 28], [36, 0]],
+      devicePositions: [[0, 0], [8, 8], [36, 36]]
+    },
+    {
+      name: 'device pixel ratio < 1',
+      gl: {
+        drawingBufferWidth: 10 * LOW_DPR,
+        drawingBufferHeight: 10 * LOW_DPR,
+        canvas: {
+          clientWidth: 10,
+          clientHeight: 10
+        }
+      },
+      ratio: LOW_DPR,
+      yInvert: true,
+      windowPositions: [[0, 0], [2, 2], [9, 9]],
+      devicePositionsInverted: [[0, 4], [1, 3], [4, 0]],
+      devicePositions: [[0, 0], [1, 1], [4, 4]]
+    }
+  ];
+  TEST_CASES.forEach(tc => {
+    tc.windowPositions.forEach((wPos, i) => {
+      // by default yInvert is true
+      t.deepEqual(
+        mapToDevicePosition(tc.windowPositions[i], tc.gl),
+        tc.devicePositionsInverted[i],
+        `${tc.name}(yInvert=true): device pixel should be ${
+          tc.devicePositionsInverted[i]
+        } for window position ${tc.windowPositions[i]}`
+      );
+      t.deepEqual(
+        mapToDevicePosition(tc.windowPositions[i], tc.gl, false),
+        tc.devicePositions[i],
+        `${tc.name}(yInvert=false): device pixel should match`
+      );
+    });
+  });
+  t.end();
+});

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -1,11 +1,5 @@
 /* global window */
-import {
-  getDevicePixelRatio,
-  cssToDevicePixels,
-  deviceToCssPixels,
-  cssToDeviceRatio,
-  deviceToCssRatio
-} from '@luma.gl/webgl';
+import {cssToDevicePixels, cssToDeviceRatio, getDevicePixelRatio} from '@luma.gl/webgl/utils';
 import test from 'tape-catch';
 const LOW_DPR = 0.5;
 const HIGH_DPR = 4;
@@ -119,7 +113,7 @@ test('webgl#getDevicePixelRatio', t => {
   t.end();
 });
 
-test.only('webgl#cssToDevicePixels', t => {
+test('webgl#cssToDevicePixels', t => {
   MAP_TEST_CASES.forEach(tc => {
     tc.windowPositions.forEach((wPos, i) => {
       // by default yInvert is true
@@ -136,34 +130,6 @@ test.only('webgl#cssToDevicePixels', t => {
         `${tc.name}(yInvert=false): device pixel should match`
       );
     });
-  });
-  t.end();
-});
-
-test('webgl#deviceToCssPixels', t => {
-  MAP_TEST_CASES.forEach(tc => {
-    tc.devicePositionsInverted.forEach((dPos, i) => {
-      // by default yInvert is true
-      t.deepEqual(
-        deviceToCssPixels(tc.gl, dPos),
-        tc.windowPositions[i],
-        `${tc.name}(yInvert=true): device pixel should be ${
-          tc.windowPositions[i]
-        } for device position ${dPos}`
-      );
-      t.deepEqual(
-        deviceToCssPixels(tc.gl, tc.devicePositions[i], false),
-        tc.windowPositions[i],
-        `${tc.name}(yInvert=false): device pixel should match`
-      );
-    });
-  });
-  t.end();
-});
-
-test('webgl#deviceToCssRatio', t => {
-  MAP_TEST_CASES.forEach(tc => {
-    t.equal(deviceToCssRatio(tc.gl), 1 / tc.ratio, 'deviceToCssRatio should return correct value');
   });
   t.end();
 });

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -2,8 +2,7 @@
 import {getDevicePixelRatio, mapToDevicePosition} from '@luma.gl/webgl';
 import test from 'tape-catch';
 
-test.only('webgl#getDevicePixelRatio', t => {
-  console.log(`typeof window === 'undefined': ${typeof window === 'undefined'}`);
+test('webgl#getDevicePixelRatio', t => {
   const windowPixelRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
   const TEST_CAES = [
     {
@@ -39,7 +38,6 @@ test.only('webgl#getDevicePixelRatio', t => {
   ];
 
   TEST_CAES.forEach(tc => {
-    console.log(`tc.expected: ${tc.expected}`);
     t.equal(tc.expected, getDevicePixelRatio(tc.useDevicePixels), tc.name);
   });
   t.end();
@@ -101,14 +99,14 @@ test('webgl#mapToDevicePosition', t => {
     tc.windowPositions.forEach((wPos, i) => {
       // by default yInvert is true
       t.deepEqual(
-        mapToDevicePosition(tc.windowPositions[i], tc.gl),
+        mapToDevicePosition(tc.gl, tc.windowPositions[i]),
         tc.devicePositionsInverted[i],
         `${tc.name}(yInvert=true): device pixel should be ${
           tc.devicePositionsInverted[i]
         } for window position ${tc.windowPositions[i]}`
       );
       t.deepEqual(
-        mapToDevicePosition(tc.windowPositions[i], tc.gl, false),
+        mapToDevicePosition(tc.gl, tc.windowPositions[i], false),
         tc.devicePositions[i],
         `${tc.name}(yInvert=false): device pixel should match`
       );

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -1,5 +1,5 @@
 /* global window */
-import {getDevicePixelRatio, mapToDevicePosition} from '@luma.gl/webgl';
+import {getDevicePixelRatio, cssToDevicePixels} from '@luma.gl/webgl';
 import test from 'tape-catch';
 
 test('webgl#getDevicePixelRatio', t => {
@@ -43,7 +43,7 @@ test('webgl#getDevicePixelRatio', t => {
   t.end();
 });
 
-test('webgl#mapToDevicePosition', t => {
+test('webgl#cssToDevicePixels', t => {
   const LOW_DPR = 0.5;
   const HIGH_DPR = 4;
   const TEST_CASES = [
@@ -99,14 +99,14 @@ test('webgl#mapToDevicePosition', t => {
     tc.windowPositions.forEach((wPos, i) => {
       // by default yInvert is true
       t.deepEqual(
-        mapToDevicePosition(tc.gl, tc.windowPositions[i]),
+        cssToDevicePixels(tc.gl, tc.windowPositions[i]),
         tc.devicePositionsInverted[i],
         `${tc.name}(yInvert=true): device pixel should be ${
           tc.devicePositionsInverted[i]
         } for window position ${tc.windowPositions[i]}`
       );
       t.deepEqual(
-        mapToDevicePosition(tc.gl, tc.windowPositions[i], false),
+        cssToDevicePixels(tc.gl, tc.windowPositions[i], false),
         tc.devicePositions[i],
         `${tc.name}(yInvert=false): device pixel should match`
       );

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -3,6 +3,7 @@ import {cssToDevicePixels, cssToDeviceRatio, getDevicePixelRatio} from '@luma.gl
 import test from 'tape-catch';
 const LOW_DPR = 0.5;
 const HIGH_DPR = 4;
+const HIGH_DPR_FRACTION = 2.5;
 const MAP_TEST_CASES = [
   {
     name: 'device pixel ratio 1',
@@ -16,8 +17,34 @@ const MAP_TEST_CASES = [
     },
     ratio: 1,
     windowPositions: [[0, 0], [2, 2], [9, 9]],
-    devicePositionsInverted: [[0, 9], [2, 7], [9, 0]],
-    devicePositions: [[0, 0], [2, 2], [9, 9]]
+    devicePositionsInverted: [
+      {
+        low: [0, 9],
+        high: [0, 9]
+      },
+      {
+        low: [2, 7],
+        high: [2, 7]
+      },
+      {
+        low: [9, 0],
+        high: [9, 0]
+      }
+    ],
+    devicePositions: [
+      {
+        low: [0, 0],
+        high: [0, 0]
+      },
+      {
+        low: [2, 2],
+        high: [2, 2]
+      },
+      {
+        low: [9, 9],
+        high: [9, 9]
+      }
+    ]
   },
   {
     name: 'device pixel ratio 1, 1X1 window',
@@ -31,10 +58,19 @@ const MAP_TEST_CASES = [
     },
     ratio: 1,
     windowPositions: [[0, 0]],
-    devicePositionsInverted: [[0, 0]],
-    devicePositions: [[0, 0]]
+    devicePositionsInverted: [
+      {
+        low: [0, 0],
+        high: [0, 0]
+      }
+    ],
+    devicePositions: [
+      {
+        low: [0, 0],
+        high: [0, 0]
+      }
+    ]
   },
-
   {
     name: 'device pixel ratio > 1',
     gl: {
@@ -48,8 +84,84 @@ const MAP_TEST_CASES = [
     ratio: HIGH_DPR,
     yInvert: true,
     windowPositions: [[0, 0], [2, 2], [9, 9]],
-    devicePositionsInverted: [[0, 36], [8, 28], [36, 0]],
-    devicePositions: [[0, 0], [8, 8], [36, 36]]
+    // 0 4 8 12 16 20 24 28 32 36 40
+    // 0 1 2 3  4  5  6  7  8  9
+    devicePositionsInverted: [
+      {
+        low: [0, 39],
+        high: [3, 36]
+      },
+      {
+        low: [8, 31],
+        high: [11, 28]
+      },
+      {
+        low: [36, 3],
+        high: [39, 0]
+      }
+    ],
+    devicePositions: [
+      {
+        low: [0, 0],
+        high: [3, 3]
+      },
+      {
+        low: [8, 8],
+        high: [11, 11]
+      },
+      {
+        low: [36, 36],
+        high: [39, 39]
+      }
+    ]
+  },
+  {
+    name: 'device pixel ratio > 1 (fraction)',
+    gl: {
+      drawingBufferWidth: 10 * HIGH_DPR_FRACTION,
+      drawingBufferHeight: 10 * HIGH_DPR_FRACTION,
+      canvas: {
+        clientWidth: 10,
+        clientHeight: 10
+      }
+    },
+    ratio: HIGH_DPR_FRACTION,
+    yInvert: true,
+    windowPositions: [[0, 0], [2, 2], [9, 9]],
+    // round (2.5) = 3
+    // CSS size :   10X10
+    // Device size: 25X25
+    // CSS:           0  1    2   3    4   5   6  7   8  9   10
+    // Device:        0  3    5   8   10  13   15 18  20 23  25
+    // Device Ynvert: 24 21   19  16  14  11   9  6   4  1   -1
+    devicePositionsInverted: [
+      {
+        low: [0, 24],
+        high: [2, 22]
+      },
+      {
+        low: [5, 19],
+        high: [7, 17]
+      },
+      {
+        low: [23, 1],
+        high: [24, 0]
+      }
+    ],
+    devicePositions: [
+      {
+        low: [0, 0],
+        high: [2, 2]
+      },
+      {
+        low: [5, 5],
+        high: [7, 7]
+      },
+      {
+        low: [23, 23],
+        high: [24, 24]
+      }
+    ]
   },
   {
     name: 'device pixel ratio < 1',
@@ -63,12 +175,35 @@ const MAP_TEST_CASES = [
     },
     ratio: LOW_DPR,
     yInvert: true,
-    // css to device 0 - 8/9 => 0 - 4
-    // device to css 0 - 4  => 0 - 8
-    // Inverted device to css 0 - 4  => 8 - 0
     windowPositions: [[0, 0], [2, 2], [8, 8]],
-    devicePositionsInverted: [[0, 4], [1, 3], [4, 0]],
-    devicePositions: [[0, 0], [1, 1], [4, 4]]
+    devicePositionsInverted: [
+      {
+        low: [0, 4],
+        high: [0, 4]
+      },
+      {
+        low: [1, 3],
+        high: [1, 3]
+      },
+      {
+        low: [4, 0],
+        high: [4, 0]
+      }
+    ],
+    devicePositions: [
+      {
+        low: [0, 0],
+        high: [0, 0]
+      },
+      {
+        low: [1, 1],
+        high: [1, 1]
+      },
+      {
+        low: [4, 4],
+        high: [4, 4]
+      }
+    ]
   }
 ];
 

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -19,30 +19,42 @@ const MAP_TEST_CASES = [
     windowPositions: [[0, 0], [2, 2], [9, 9]],
     devicePositionsInverted: [
       {
-        low: [0, 9],
-        high: [0, 9]
+        x: 0,
+        y: 9,
+        width: 1,
+        height: 1
       },
       {
-        low: [2, 7],
-        high: [2, 7]
+        x: 2,
+        y: 7,
+        width: 1,
+        height: 1
       },
       {
-        low: [9, 0],
-        high: [9, 0]
+        x: 9,
+        y: 0,
+        width: 1,
+        height: 1
       }
     ],
     devicePositions: [
       {
-        low: [0, 0],
-        high: [0, 0]
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1
       },
       {
-        low: [2, 2],
-        high: [2, 2]
+        x: 2,
+        y: 2,
+        width: 1,
+        height: 1
       },
       {
-        low: [9, 9],
-        high: [9, 9]
+        x: 9,
+        y: 9,
+        width: 1,
+        height: 1
       }
     ]
   },
@@ -60,14 +72,18 @@ const MAP_TEST_CASES = [
     windowPositions: [[0, 0]],
     devicePositionsInverted: [
       {
-        low: [0, 0],
-        high: [0, 0]
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1
       }
     ],
     devicePositions: [
       {
-        low: [0, 0],
-        high: [0, 0]
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1
       }
     ]
   },
@@ -88,30 +104,42 @@ const MAP_TEST_CASES = [
     // 0 1 2 3  4  5  6  7  8  9
     devicePositionsInverted: [
       {
-        low: [0, 39],
-        high: [3, 36]
+        x: 0,
+        y: 36,
+        width: 4,
+        height: 4
       },
       {
-        low: [8, 31],
-        high: [11, 28]
+        x: 8,
+        y: 28,
+        width: 4,
+        height: 4
       },
       {
-        low: [36, 3],
-        high: [39, 0]
+        x: 36,
+        y: 0,
+        width: 4,
+        height: 4
       }
     ],
     devicePositions: [
       {
-        low: [0, 0],
-        high: [3, 3]
+        x: 0,
+        y: 0,
+        width: 4,
+        height: 4
       },
       {
-        low: [8, 8],
-        high: [11, 11]
+        x: 8,
+        y: 8,
+        width: 4,
+        height: 4
       },
       {
-        low: [36, 36],
-        high: [39, 39]
+        x: 36,
+        y: 36,
+        width: 4,
+        height: 4
       }
     ]
   },
@@ -136,30 +164,42 @@ const MAP_TEST_CASES = [
     // Device Ynvert: 24 21   19  16  14  11   9  6   4  1   -1
     devicePositionsInverted: [
       {
-        low: [0, 24],
-        high: [2, 22]
+        x: 0,
+        y: 22,
+        width: 3,
+        height: 3
       },
       {
-        low: [5, 19],
-        high: [7, 17]
+        x: 5,
+        y: 17,
+        width: 3,
+        height: 3
       },
       {
-        low: [23, 1],
-        high: [24, 0]
+        x: 23,
+        y: 0,
+        width: 2,
+        height: 2
       }
     ],
     devicePositions: [
       {
-        low: [0, 0],
-        high: [2, 2]
+        x: 0,
+        y: 0,
+        width: 3,
+        height: 3
       },
       {
-        low: [5, 5],
-        high: [7, 7]
+        x: 5,
+        y: 5,
+        width: 3,
+        height: 3
       },
       {
-        low: [23, 23],
-        high: [24, 24]
+        x: 23,
+        y: 23,
+        width: 2,
+        height: 2
       }
     ]
   },
@@ -175,33 +215,58 @@ const MAP_TEST_CASES = [
     },
     ratio: LOW_DPR,
     yInvert: true,
-    windowPositions: [[0, 0], [2, 2], [8, 8]],
+    windowPositions: [[0, 0], [1, 1], [2, 2], [8, 8]],
     devicePositionsInverted: [
       {
-        low: [0, 4],
-        high: [0, 4]
+        x: 0,
+        y: 4,
+        width: 1,
+        height: 1
       },
       {
-        low: [1, 3],
-        high: [1, 3]
+        x: 1,
+        y: 4,
+        width: 1,
+        height: 1
       },
       {
-        low: [4, 0],
-        high: [4, 0]
+        x: 1,
+        y: 3,
+        width: 1,
+        height: 1
+      },
+      {
+        x: 4,
+        y: 0,
+        width: 1,
+        height: 1
       }
     ],
     devicePositions: [
       {
-        low: [0, 0],
-        high: [0, 0]
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1
+      },
+      // [1, 1] and [2, 2] point to the same pixel
+      {
+        x: 1,
+        y: 1,
+        width: 1,
+        height: 1
       },
       {
-        low: [1, 1],
-        high: [1, 1]
+        x: 1,
+        y: 1,
+        width: 1,
+        height: 1
       },
       {
-        low: [4, 4],
-        high: [4, 4]
+        x: 4,
+        y: 4,
+        width: 1,
+        height: 1
       }
     ]
   }

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -56,7 +56,7 @@ const MAP_TEST_CASES = [
   }
 ];
 
-test('webgl#getDevicePixelRatio', t => {
+test.only('webgl#getDevicePixelRatio', t => {
   const windowPixelRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
   const TEST_CAES = [
     {
@@ -65,24 +65,24 @@ test('webgl#getDevicePixelRatio', t => {
       expected: windowPixelRatio
     },
     {
-      name: 'Use default pixel ratio: should use 1',
+      name: 'useDevicePixels: false: should use 1',
       useDevicePixels: false,
       expected: 1
     },
     {
-      name: 'Non Finite useDevicePixels: should use window.devicePixelRatio or 1',
+      name: 'Non Finite useDevicePixels: should use 1',
       useDevicePixels: null,
-      expected: windowPixelRatio
+      expected: 1
     },
     {
-      name: 'Non valid useDevicePixels: should use window.devicePixelRatio or 1',
+      name: 'Non valid useDevicePixels: should use 1',
       useDevicePixels: 0,
-      expected: windowPixelRatio
+      expected: 1
     },
     {
-      name: 'Non valid useDevicePixels: should use window.devicePixelRatio or 1',
+      name: 'Non valid useDevicePixels: should use 1',
       useDevicePixels: -3.2,
-      expected: windowPixelRatio
+      expected: 1
     },
     {
       name: 'Valid useDevicePixels, should use it',

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -1,5 +1,11 @@
 /* global window */
-import {getDevicePixelRatio, cssToDevicePixels, deviceToCssPixels} from '@luma.gl/webgl';
+import {
+  getDevicePixelRatio,
+  cssToDevicePixels,
+  deviceToCssPixels,
+  cssToDeviceRatio,
+  deviceToCssRatio
+} from '@luma.gl/webgl';
 import test from 'tape-catch';
 const LOW_DPR = 0.5;
 const HIGH_DPR = 4;
@@ -19,6 +25,22 @@ const MAP_TEST_CASES = [
     devicePositionsInverted: [[0, 9], [2, 7], [9, 0]],
     devicePositions: [[0, 0], [2, 2], [9, 9]]
   },
+  {
+    name: 'device pixel ratio 1, 1X1 window',
+    gl: {
+      drawingBufferWidth: 1,
+      drawingBufferHeight: 1,
+      canvas: {
+        clientWidth: 1,
+        clientHeight: 1
+      }
+    },
+    ratio: 1,
+    windowPositions: [[0, 0]],
+    devicePositionsInverted: [[0, 0]],
+    devicePositions: [[0, 0]]
+  },
+
   {
     name: 'device pixel ratio > 1',
     gl: {
@@ -56,7 +78,7 @@ const MAP_TEST_CASES = [
   }
 ];
 
-test.only('webgl#getDevicePixelRatio', t => {
+test('webgl#getDevicePixelRatio', t => {
   const windowPixelRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
   const TEST_CAES = [
     {
@@ -97,7 +119,7 @@ test.only('webgl#getDevicePixelRatio', t => {
   t.end();
 });
 
-test('webgl#cssToDevicePixels', t => {
+test.only('webgl#cssToDevicePixels', t => {
   MAP_TEST_CASES.forEach(tc => {
     tc.windowPositions.forEach((wPos, i) => {
       // by default yInvert is true
@@ -135,6 +157,20 @@ test('webgl#deviceToCssPixels', t => {
         `${tc.name}(yInvert=false): device pixel should match`
       );
     });
+  });
+  t.end();
+});
+
+test('webgl#deviceToCssRatio', t => {
+  MAP_TEST_CASES.forEach(tc => {
+    t.equal(deviceToCssRatio(tc.gl), 1 / tc.ratio, 'deviceToCssRatio should return correct value');
+  });
+  t.end();
+});
+
+test('webgl#cssToDeviceRatio', t => {
+  MAP_TEST_CASES.forEach(tc => {
+    t.equal(cssToDeviceRatio(tc.gl), tc.ratio, 'cssToDeviceRatio should return correct value');
   });
   t.end();
 });

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -1,53 +1,46 @@
+/* global window */
 import {getDevicePixelRatio, mapToDevicePosition} from '@luma.gl/webgl';
 import test from 'tape-catch';
 
-test('webgl#getDevicePixelRatio', t => {
+test.only('webgl#getDevicePixelRatio', t => {
+  console.log(`typeof window === 'undefined': ${typeof window === 'undefined'}`);
+  const windowPixelRatio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
   const TEST_CAES = [
     {
-      name: 'Undefined windowPixelRatio, should use 1',
+      name: 'useDevicePixels: true: should use window.devicePixelRatio or 1',
       useDevicePixels: true,
-      expected: 1
+      expected: windowPixelRatio
     },
     {
-      name: 'Use windowPixelRatio, should use it',
-      useDevicePixels: true,
-      windowPixelRatio: 2,
-      expected: 2
-    },
-    {
-      name: 'Use default pixel ratio, should use 1',
+      name: 'Use default pixel ratio: should use 1',
       useDevicePixels: false,
-      windowPixelRatio: 2,
       expected: 1
     },
     {
-      name: 'Non Finite useDevicePixels, should use 1',
+      name: 'Non Finite useDevicePixels: should use window.devicePixelRatio or 1',
       useDevicePixels: null,
-      windowPixelRatio: 2,
-      expected: 1
+      expected: windowPixelRatio
     },
     {
-      name: 'Non valid useDevicePixels, should use 1',
+      name: 'Non valid useDevicePixels: should use window.devicePixelRatio or 1',
       useDevicePixels: 0,
-      windowPixelRatio: 2,
-      expected: 1
+      expected: windowPixelRatio
     },
     {
-      name: 'Non valid useDevicePixels, should use 1',
+      name: 'Non valid useDevicePixels: should use window.devicePixelRatio or 1',
       useDevicePixels: -3.2,
-      windowPixelRatio: 2,
-      expected: 1
+      expected: windowPixelRatio
     },
     {
       name: 'Valid useDevicePixels, should use it',
-      useDevicePixels: 4.5,
-      windowPixelRatio: 2,
-      expected: 4.5
+      useDevicePixels: 1.5,
+      expected: 1.5
     }
   ];
 
   TEST_CAES.forEach(tc => {
-    t.equal(tc.expected, getDevicePixelRatio(tc.useDevicePixels, tc.windowPixelRatio), tc.name);
+    console.log(`tc.expected: ${tc.expected}`);
+    t.equal(tc.expected, getDevicePixelRatio(tc.useDevicePixels), tc.name);
   });
   t.end();
 });

--- a/modules/webgl/test/utils/index.js
+++ b/modules/webgl/test/utils/index.js
@@ -4,3 +4,4 @@ import './is-old-ie.spec';
 import './texture-utils.spec';
 import './utils.spec';
 import './format-value.spec';
+import './device-pixels.spec';

--- a/website/contents/pages.js
+++ b/website/contents/pages.js
@@ -684,6 +684,10 @@ export const DOC_PAGES = [
           {
             name: 'withParameters',
             content: getDocUrl('api-reference/webgl/context/with-parameters.md')
+          },
+          {
+            name: 'Device Pixels',
+            content: getDocUrl('api-reference/webgl/device-pixels.md')
           }
         ]
       },

--- a/wip/src/pick-models.js
+++ b/wip/src/pick-models.js
@@ -1,11 +1,7 @@
 /* global window */
-import {isWebGL, clear, readPixelsToArray} from '@luma.gl/webgl';
+import {isWebGL, clear, readPixelsToArray, mapToDevicePosition} from '@luma.gl/webgl';
 import GroupNode from './nodes/group-node';
 import {assert} from '../utils';
-
-function getDevicePixelRatio() {
-  return typeof window !== 'undefined' ? window.devicePixelRatio : 1;
-}
 
 export default function pickModels(gl, props) {
   const {
@@ -28,10 +24,8 @@ export default function pickModels(gl, props) {
 
   // Compensate for devicePixelRatio
   // Note: this assumes the canvas framebuffer has been matched
-  const dpr = useDevicePixels ? getDevicePixelRatio() : 1;
-  // Reverse the y coordinate
-  const deviceX = x * dpr;
-  const deviceY = gl.canvas.height - y * dpr;
+  const devicePosition = mapToDevicePosition(position, gl);
+
 
   // return withParameters(gl, {
   //   // framebuffer,
@@ -52,8 +46,8 @@ export default function pickModels(gl, props) {
 
       // Sample Read color in the central pixel, to be mapped as a picking color
       const color = readPixelsToArray(framebuffer, {
-        sourceX: deviceX,
-        sourceY: deviceY,
+        sourceX: devicePosition[0],
+        sourceY: devicePosition[1],
         sourceWidth: 1,
         sourceHeight: 1,
         sourceFormat: gl.RGBA,
@@ -69,8 +63,8 @@ export default function pickModels(gl, props) {
           color,
           x,
           y,
-          deviceX,
-          deviceY
+          deviceX: devicePosition[0],
+          deviceY: devicePosition[1]
         };
       }
     }

--- a/wip/src/pick-models.js
+++ b/wip/src/pick-models.js
@@ -24,7 +24,8 @@ export default function pickModels(gl, props) {
 
   // Compensate for devicePixelRatio
   // Note: this assumes the canvas framebuffer has been matched
-  const devicePosition = cssToDevicePixels(gl, position);
+  // use the center pixel location in device pixel range
+  const devicePosition = [devicePixels.x + Math.floor(devicePixels.width / 2), devicePixels.y + Math.floor(devicePixels.height / 2)];
 
 
   // return withParameters(gl, {

--- a/wip/src/pick-models.js
+++ b/wip/src/pick-models.js
@@ -24,7 +24,7 @@ export default function pickModels(gl, props) {
 
   // Compensate for devicePixelRatio
   // Note: this assumes the canvas framebuffer has been matched
-  const devicePosition = mapToDevicePosition(position, gl);
+  const devicePosition = mapToDevicePosition(gl, position);
 
 
   // return withParameters(gl, {

--- a/wip/src/pick-models.js
+++ b/wip/src/pick-models.js
@@ -1,5 +1,5 @@
 /* global window */
-import {isWebGL, clear, readPixelsToArray, mapToDevicePosition} from '@luma.gl/webgl';
+import {isWebGL, clear, readPixelsToArray, cssToDevicePixels} from '@luma.gl/webgl';
 import GroupNode from './nodes/group-node';
 import {assert} from '../utils';
 
@@ -24,7 +24,7 @@ export default function pickModels(gl, props) {
 
   // Compensate for devicePixelRatio
   // Note: this assumes the canvas framebuffer has been matched
-  const devicePosition = mapToDevicePosition(gl, position);
+  const devicePosition = cssToDevicePixels(gl, position);
 
 
   // return withParameters(gl, {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1154 
<!-- For other PRs without open issue -->
#### Background
- Add support to specify custom device pixel ratio, to enable applications to perform anti aliasing through down sampling. Also helps users to improve performance by setting ratio to a value less than 1
- Group all related code into a single file, add unit tests.
- This is for advanced use case, hence overloading `useDevicePixels` prop, also not documenting intentionally, in future we can make it public API.
- Notes
   - When device pixel ration is high, [depending on implementation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawingBufferWidth), drawing buffer size gets clamped and may not match with canvas size, hence when mapping from window to device pixels, we need to use allocated drawBufferSize, instead of what pixel ratio we used.
   - When drawing buffer size is clamped, it may or may not maintain aspect ratio, hence we need x and y ratios separately to exactly map window to device pixels (like for picking cases).
<!-- For all the PRs -->
#### Change List
- Fix typos
- Add support for custom device pixel ratio
