### PR TITLE
fix texture2D type/dataFormat inference

### DIFF
--- a/docs/api-reference/webgl/texture.md
+++ b/docs/api-reference/webgl/texture.md
@@ -285,7 +285,7 @@ Describes the layout of each color component in memory.
 ### Texture Format Combinations
 
 This a simplified table illustrating what combinations of internal formats
-work with what formats and types. Note that luma.gl deduces `format` and `type` from `internalFormat` by taking the first value from the format and type entries in this table.
+work with what data formats and types. Note that luma.gl deduces `dataFormat` and `type` from `format` by taking the first value from the data format and data type entries in this table.
 
 For more details, see tables in:
 * [WebGL2 spec](https://www.khronos.org/registry/webgl/specs/latest/2.0/)

--- a/modules/webgl/src/classes/texture.js
+++ b/modules/webgl/src/classes/texture.js
@@ -90,7 +90,6 @@ export default class Texture extends Resource {
     const {
       pixels = null,
       format = GL.RGBA,
-      type = GL.UNSIGNED_BYTE,
       border = 0,
       recreate = false,
       parameters = {},
@@ -110,11 +109,11 @@ export default class Texture extends Resource {
       data = pixels;
     }
 
-    let {width, height, dataFormat} = props;
+    let {width, height, dataFormat, type} = props;
     const {depth = 0} = props;
 
     // Deduce width and height
-    ({width, height, dataFormat} = this._deduceParameters({
+    ({width, height, dataFormat, type} = this._deduceParameters({
       format,
       type,
       dataFormat,

--- a/modules/webgl/test/classes/texture.spec.js
+++ b/modules/webgl/test/classes/texture.spec.js
@@ -148,6 +148,38 @@ function testFormatCreation(t, glContext, withData = false) {
   }
 }
 
+function testFormatDeduction(t, glContext) {
+  for (const format in TEXTURE_FORMATS) {
+    const formatInfo = TEXTURE_FORMATS[format];
+    const expectedType = formatInfo.types[0];
+    const expectedDataFormat = formatInfo.dataFormat;
+    const options = {
+      format,
+      height: 1,
+      width: 1
+    };
+    if (Texture2D.isSupported(glContext, {format})) {
+      const texture = new Texture2D(glContext, options);
+      const msg = `Texture2D({format: ${getKey(GL, format)}}) created`;
+      t.equals(texture.format, format, msg);
+      t.equals(texture.type, expectedType, msg);
+      t.equals(texture.dataFormat, expectedDataFormat, msg);
+      texture.delete();
+    }
+  }
+}
+
+test('WebGL#Texture2D format deduction', t => {
+  const {gl, gl2} = fixture;
+  testFormatDeduction(t, gl);
+  if (gl2) {
+    testFormatDeduction(t, gl2);
+  } else {
+    t.comment('WebGL2 not available, skipping tests');
+  }
+  t.end();
+});
+
 test('WebGL#Texture2D format creation', t => {
   const {gl, gl2} = fixture;
   testFormatCreation(t, gl);


### PR DESCRIPTION
From the [Texture docs](https://luma.gl/#/documentation/api-reference/webgl-2-classes/texture):
> Note that luma.gl deduces `format` and `type` from `internalFormat`

This seems to be working for the texture's data type, but not for its data format. This PR fixes that bug and tweaks the wording slightly here as `internalFormat` is not a supported property name (it's meant to be `format`), and `format`, here, should actually be `dataFormat`.

I think the docs are still a bit confusing, even after this update, as the term "internal format" is used quite a bit and is easily confused with "data format". I'm open to suggestions on wording tweaks to make this clearer with more consistent terminology.