### PR TITLE
remove Texture class's hasFloatTexture property

### DIFF
--- a/modules/webgl/src/classes/texture.js
+++ b/modules/webgl/src/classes/texture.js
@@ -48,7 +48,6 @@ export default class Texture extends Resource {
     super(gl, {id, handle});
 
     this.target = target;
-    this.hasFloatTexture = gl.getExtension('OES_texture_float');
     this.textureUnit = undefined;
 
     // Program.draw() checks the loaded flag of all textures to avoid


### PR DESCRIPTION
Looks like this `texture.hasFloatTexture` property [used to be relied on](https://github.com/uber/luma.gl/commit/1b5bcda390d86532ca4f04c29d81132976806608), but is no longer being used in the codebase. In WebGL2,`gl.getExtension('OES_texture_float')` evaluates to `null`, which is quite misleading when debugging float textures. I vote for dropping this property altogether since it's not being used anywhere and is Just Another Piece of State To Maintain™️ 