### PR TITLE
Implement program manager

### DIFF
--- a/docs/api-reference/core/resource-management/program-manager.md
+++ b/docs/api-reference/core/resource-management/program-manager.md
@@ -1,0 +1,104 @@
+# ProgramManager
+
+The `ProgramManger` manages the creation and caching of programs. It allows the application to request a program based on a vertex shader, fragment shader and set of defines, modules and code injections. The `ProgramManager` will return the requested program, creating it the first time, and re-using a cached version if it is requested more than once. It also allows for the definition of hook functions and module code injections to be inserted into shaders.
+
+
+## Usage
+
+```js
+const pm = new ProgramManager(gl);
+
+const vs = `
+attribute vec4 position;
+
+void main() {
+#ifdef MY_DEFINE
+  gl_Position = position;
+#else
+  gl_Position = position.wzyx;
+#endif
+}
+`;
+
+const fs = `
+void main() {
+  gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+  MY_SHADER_HOOK(gl_FragColor);
+}
+`;
+
+pm.addShaderHook('fs:MY_SHADER_HOOK(inout vec4 color)');
+
+pm.addModuleInjection(picking, {
+  hook: 'fs:#MY_SHADER_HOOK',
+  injection: 'color = picking_filterColor(color);',
+  order: Number.POSITIVE_INFINITY
+});
+
+const program1 = pm.get(vs, fs);   // Basic, no modules or defines
+const program2 = pm.get(vs, fs);   // Cached, same as program 1, use count 2
+const program3 = pm.get(vs, fs, {  // New program, with different source based on define
+  defines: {
+    MY_DEFINE: true
+  }
+});
+const program4 = pm.get(vs, fs, {  // New program, with different source based on module and its injection
+  defines: {
+    MY_DEFINE: true
+  },
+  modules: [picking]
+});
+const program5 = pm.get(vs, fs, {  // Cached, same as program 4, use count 2
+  defines: {
+    MY_DEFINE: true
+  },
+  modules: [picking]
+});
+
+pm.release(program1); // Cached program still available, use count 1
+pm.release(program2); // Cached program deleted
+pm.release(program3); // Cached program deleted
+pm.release(program4); // Cached program still available, use count 1
+pm.release(program5); // Cached program deleted
+```
+
+
+## Methods
+
+### get(vs : String, fs : String, [opts : Object]) : Program
+
+Get a program that fits the parameters provided. If one is already cached, return it, otherwise create and cache a new one.
+`opts` can include the following (see `assembleShaders` for details):
+* `defines`: Object indicating `#define` constants to include in the shaders.
+* `modules`: Array of module objects to include in the shaders.
+* `inject`: Object of hook injections to include in the shaders.
+
+### `addShaderHook(hook : String, [opts : Object])`
+
+Creates a shader hook function that shader modules can injection code into. Shaders can call these functions, which will be no-ops by default. If a shader module injects code it will be executed upon the hook function call. This mechanism allows the application to create shaders that can be automatically extended by included shader modules.
+
+- `hook`: `vs:` or `fs:` followed by the name and arguments of the function, e.g. `vs:MYHOOK_func(inout vec4 value)`. Hook name without arguments
+will also be used as the name of the shader hook
+- `opts.header` (optional): code always included at the beginning of a hook function
+- `opts.footer` (optional): code always included at the end of a hook function
+
+### `addModuleInjection(module : Object, opts : Object)`
+
+Define a code injection for a particular hook function (defined by `addShaderHook`) and shader module. The injection code will be inserted into the hook function whenever the shader module is included.
+
+- `module`: module object for which the injection is being defined
+- `opts.hook`: the shader hook to inject into. This can be a hook function defined by `addShaderHook` or a predefined injection key (see below),
+prefixed by `vs:` for the vertex shader or `fs:` for the fragment shader.
+- `opts.injection`: the injection code
+- `opts.order` (optional): the priority with which to inject code into the shader hook. Lower priority numbers will
+be injected first
+
+### getUniforms(program : Program) : Object
+
+Returns an object containing all the uniforms defined for the program. Returns `null` if `program` isn't managed by the `ProgramManager`.
+
+### release(program : Program)
+
+Indicate that a program is no longer in use. When all references to a program are released, the program is deleted.
+
+

--- a/examples/core/program-management/app.js
+++ b/examples/core/program-management/app.js
@@ -1,0 +1,148 @@
+import {
+  AnimationLoop,
+  setParameters,
+  ModelNode,
+  dirlight,
+  CubeGeometry,
+  ProgramManager
+} from '@luma.gl/core';
+import {Matrix4, radians} from 'math.gl';
+
+const INFO_HTML = `
+Using a ProgramManager to cache and share programs between models.
+`;
+
+const vs = `\
+attribute vec3 positions;
+attribute vec3 normals;
+
+uniform vec3 uColor;
+uniform mat4 uModel;
+uniform mat4 uView;
+uniform mat4 uProjection;
+
+varying vec3 color;
+
+void main(void) {
+  vec3 normal = vec3(uModel * vec4(normals, 0.0));
+
+  // Set up data for modules
+  color = uColor;
+  LUMAGL_normal(normal);
+  gl_Position = uProjection * uView * uModel * vec4(positions, 1.0);
+}
+`;
+
+const fs = `\
+precision highp float;
+
+varying vec3 color;
+
+void main(void) {
+  gl_FragColor = vec4(color, 1.);
+  LUMAGL_fragmentColor(gl_FragColor);
+}
+`;
+
+export default class AppAnimationLoop extends AnimationLoop {
+  constructor() {
+    super({debug: true});
+  }
+
+  static getInfo() {
+    return INFO_HTML;
+  }
+
+  onInitialize({gl, aspect}) {
+    setParameters(gl, {
+      clearColor: [0, 0, 0, 1],
+      clearDepth: 1,
+      depthTest: true,
+      depthFunc: gl.LEQUAL
+    });
+
+    const programManager = new ProgramManager(gl);
+    programManager.addShaderHook('vs:LUMAGL_normal(inout vec3 normal)');
+    programManager.addShaderHook('fs:LUMAGL_fragmentColor(inout vec4 color)');
+    programManager.addModuleInjection(dirlight, {
+      hook: 'vs:LUMAGL_normal',
+      injection: 'project_setNormal(normal);'
+    });
+    programManager.addModuleInjection(dirlight, {
+      hook: 'fs:LUMAGL_fragmentColor',
+      injection: 'color = dirlight_filterColor(color);'
+    });
+
+    const translations = [[2, -2, 0], [2, 2, 0], [-2, 2, 0], [-2, -2, 0]];
+
+    const rotations = [
+      [Math.random(), Math.random(), Math.random()],
+      [Math.random(), Math.random(), Math.random()],
+      [Math.random(), Math.random(), Math.random()],
+      [Math.random(), Math.random(), Math.random()]
+    ];
+
+    const colors = [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 0]];
+
+    this.cubes = new Array(4);
+
+    for (let i = 0; i < 4; ++i) {
+      this.cubes[i] = {
+        translation: translations[i],
+        rotation: rotations[i],
+        model: new ModelNode(gl, {
+          programManager,
+          vs,
+          fs,
+          modules: i % 2 === 0 ? [dirlight] : [],
+          geometry: new CubeGeometry(),
+          uniforms: {
+            uProjection: new Matrix4().perspective({fov: radians(60), aspect, near: 1, far: 20.0}),
+            uView: new Matrix4().lookAt({
+              center: [0, 0, 0],
+              eye: [0, 0, -8]
+            }),
+            uColor: colors[i]
+          }
+        })
+      };
+    }
+  }
+
+  onRender(animationProps) {
+    const {gl} = animationProps;
+
+    const modelMatrix = new Matrix4();
+
+    // Draw the cubes
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    for (let i = 0; i < 4; ++i) {
+      const cube = this.cubes[i];
+      cube.rotation[0] += 0.01;
+      cube.rotation[1] += 0.01;
+      cube.rotation[2] += 0.01;
+      modelMatrix
+        .identity()
+        .translate(cube.translation)
+        .rotateXYZ(cube.rotation);
+      cube.model
+        .setUniforms({
+          uModel: modelMatrix
+        })
+        .draw();
+    }
+  }
+
+  onFinalize({gl}) {
+    for (let i = 0; i < 4; ++i) {
+      this.cubes[i].model.delete();
+    }
+  }
+}
+
+/* global window */
+if (typeof window !== 'undefined' && !window.website) {
+  const animationLoop = new AppAnimationLoop();
+  animationLoop.start();
+}

--- a/examples/core/program-management/app.js
+++ b/examples/core/program-management/app.js
@@ -110,7 +110,18 @@ export default class AppAnimationLoop extends AnimationLoop {
   }
 
   onRender(animationProps) {
-    const {gl} = animationProps;
+    const {gl, tick} = animationProps;
+
+    if (tick % 120) {
+      const even = Number(tick % 240 < 120);
+      for (let i = 0; i < 4; ++i) {
+        this.cubes[i].model.model.setProgram({
+          vs,
+          fs,
+          modules: i % 2 === even ? [dirlight] : []
+        });
+      }
+    }
 
     const modelMatrix = new Matrix4();
 

--- a/examples/core/program-management/package.json
+++ b/examples/core/program-management/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open -d",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open -d",
+    "build": "webpack --env.local --env.analyze --profile --json > stats.json"
+  },
+  "dependencies": {
+    "@luma.gl/core": "^7.2.0-beta",
+    "math.gl": "^2.3.1"
+  },
+  "devDependencies": {
+    "html-webpack-plugin": "^3.2.0",
+    "webpack": "^4.3.0",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/examples/core/program-management/webpack.config.js
+++ b/examples/core/program-management/webpack.config.js
@@ -1,0 +1,16 @@
+const {resolve} = require('path');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: resolve('./app.js')
+  },
+
+  plugins: [new HtmlWebpackPlugin({title: 'Program Management'})]
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../../webpack.config.local')(CONFIG)(env) : CONFIG);

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -86,6 +86,9 @@ export {default as Model} from './lib/model';
 export {default as Transform} from './lib/transform';
 export {default as ClipSpace} from './lib/clip-space';
 
+// Resource Management
+export {default as ProgramManager} from './resource-management/program-manager';
+
 // Experimental core exports
 export {default as _ShaderCache} from './lib/shader-cache';
 export {default as _AnimationLoopProxy} from './lib/animation-loop-proxy';

--- a/modules/core/src/lib/base-model.js
+++ b/modules/core/src/lib/base-model.js
@@ -46,6 +46,7 @@ export default class BaseModel {
     this.attributes = {}; // User defined attributes
 
     // Model manages uniform animation
+    this.uniforms = {};
     this.animatedUniforms = {};
     this.animated = false;
     this.animationLoop = null; // if set, used as source for animationProps
@@ -130,7 +131,7 @@ export default class BaseModel {
   }
 
   getUniforms() {
-    return this.program.uniforms;
+    return this.uniforms;
   }
 
   // SETTERS
@@ -144,7 +145,7 @@ export default class BaseModel {
     // Resolve any animated uniforms so that we have an initial value
     uniforms = this._extractAnimatedUniforms(uniforms);
 
-    this.program.setUniforms(uniforms);
+    Object.assign(this.uniforms, uniforms);
 
     return this;
   }
@@ -202,6 +203,8 @@ export default class BaseModel {
     onBeforeRender();
 
     this._timerQueryStart();
+
+    this.program.setUniforms(this.uniforms);
 
     const didDraw = this.program.draw(
       Object.assign({}, opts, {

--- a/modules/core/src/lib/model.js
+++ b/modules/core/src/lib/model.js
@@ -190,7 +190,7 @@ export default class Model extends BaseModel {
     if (this.animated) {
       assert(animationProps, 'Model.draw(): animated uniforms but no animationProps');
       const animatedUniforms = this._evaluateAnimateUniforms(animationProps);
-      this.program.setUniforms(animatedUniforms);
+      Object.assign(this.uniforms, animatedUniforms);
     }
   }
 

--- a/modules/core/src/resource-management/program-manager.js
+++ b/modules/core/src/resource-management/program-manager.js
@@ -20,7 +20,8 @@ export default class ProgramManager {
     this._useCounts = {};
   }
 
-  addModuleInjection(moduleName, opts) {
+  addModuleInjection(module, opts) {
+    const moduleName = module.name;
     const {hook, injection, order = 0} = opts;
     const shaderStage = hook.slice(0, 2);
 

--- a/modules/core/src/resource-management/program-manager.js
+++ b/modules/core/src/resource-management/program-manager.js
@@ -49,15 +49,18 @@ export default class ProgramManager {
     const fsHash = this._getHash(fs);
     const moduleHashes = modules.map(m => this._getHash(m.name));
     const varyingHashes = varyings.map(v => this._getHash(v));
+
+    const defineKeys = Object.keys(defines).sort();
+    const injectKeys = Object.keys(inject).sort();
     const defineHashes = [];
     const injectHashes = [];
 
-    for (const key in defines) {
+    for (const key of defineKeys) {
       defineHashes.push(this._getHash(key));
       defineHashes.push(this._getHash(defines[key]));
     }
 
-    for (const key in inject) {
+    for (const key of injectKeys) {
       defineHashes.push(this._getHash(key));
       defineHashes.push(this._getHash(inject[key]));
     }

--- a/modules/core/src/resource-management/program-manager.js
+++ b/modules/core/src/resource-management/program-manager.js
@@ -6,6 +6,7 @@ export default class ProgramManager {
     this.gl = gl;
 
     this._programCache = {};
+    this._getUniforms = {};
     this._moduleInjections = {
       vs: {},
       fs: {}
@@ -82,11 +83,16 @@ export default class ProgramManager {
         varyings,
         bufferMode
       });
+      this._getUniforms[hash] = assembled.getUniforms || (x => {});
       this._useCounts[hash] = 0;
     }
 
     this._useCounts[hash]++;
     return this._programCache[hash];
+  }
+
+  getUniforms(program) {
+    return this._getUniforms[program.hash] || null;
   }
 
   release(program) {
@@ -96,6 +102,7 @@ export default class ProgramManager {
     if (this._useCounts[hash] === 0) {
       this._programCache[hash].delete();
       delete this._programCache[hash];
+      delete this._getUniforms[hash];
       delete this._useCounts[hash];
     }
   }

--- a/modules/core/src/resource-management/program-manager.js
+++ b/modules/core/src/resource-management/program-manager.js
@@ -47,7 +47,7 @@ export default class ProgramManager {
 
     const vsHash = this._getHash(vs);
     const fsHash = this._getHash(fs);
-    const moduleHashes = modules.map(m => this._getHash(m.name));
+    const moduleHashes = modules.map(m => this._getHash(m.name)).sort();
     const varyingHashes = varyings.map(v => this._getHash(v));
 
     const defineKeys = Object.keys(defines).sort();

--- a/modules/core/test/lib/index.js
+++ b/modules/core/test/lib/index.js
@@ -4,3 +4,4 @@ import './transform.spec';
 import './animation-loop.spec';
 import './animation-loop-proxy.spec';
 import './transform-shader-utils.spec';
+import './program-manager.spec';

--- a/modules/core/test/lib/model.spec.js
+++ b/modules/core/test/lib/model.spec.js
@@ -118,8 +118,10 @@ test('Model#program management', t => {
   const pm = new ProgramManager(gl);
 
   const vs = `
+    uniform float x;
+
     void main() {
-      gl_Position = vec4(0.0);
+      gl_Position = vec4(x);
     }
   `;
 
@@ -132,16 +134,41 @@ test('Model#program management', t => {
   const model1 = new Model(gl, {
     programManager: pm,
     vs,
-    fs
+    fs,
+    uniforms: {
+      x: 0.5
+    }
   });
 
   const model2 = new Model(gl, {
     programManager: pm,
     vs,
-    fs
+    fs,
+    uniforms: {
+      x: -0.5
+    }
   });
 
   t.ok(model1.program === model2.program, 'Programs are shared.');
+
+  model1.draw();
+  t.deepEqual(model1.getUniforms(), model1.program.uniforms, 'Program uniforms set');
+
+  model2.draw();
+  t.deepEqual(model2.getUniforms(), model2.program.uniforms, 'Program uniforms set');
+
+  model2.setProgram({
+    vs,
+    fs,
+    defines: {
+      MY_DEFINE: true
+    }
+  });
+
+  t.ok(model1.program !== model2.program, 'Program was updated.');
+
+  model2.draw();
+  t.deepEqual(model2.getUniforms(), model2.program.uniforms, 'Program uniforms set');
 
   t.end();
 });

--- a/modules/core/test/lib/model.spec.js
+++ b/modules/core/test/lib/model.spec.js
@@ -1,7 +1,7 @@
 import GL from '@luma.gl/constants';
 import luma from '@luma.gl/webgl/init';
 // TODO - Model test should not depend on Cube
-import {Buffer, Model, CubeGeometry} from '@luma.gl/core';
+import {Buffer, Model, CubeGeometry, ProgramManager} from '@luma.gl/core';
 import test from 'tape-catch';
 import {fixture} from 'test/setup';
 
@@ -108,6 +108,40 @@ test('Model#draw', t => {
     isPickingActive: 1
   });
   t.deepEqual(model.getUniforms(), {isPickingActive: 1}, 'uniforms are set');
+
+  t.end();
+});
+
+test('Model#program management', t => {
+  const {gl} = fixture;
+
+  const pm = new ProgramManager(gl);
+
+  const vs = `
+    void main() {
+      gl_Position = vec4(0.0);
+    }
+  `;
+
+  const fs = `
+    void main() {
+      gl_FragColor = vec4(1.0);
+    }
+  `;
+
+  const model1 = new Model(gl, {
+    programManager: pm,
+    vs,
+    fs
+  });
+
+  const model2 = new Model(gl, {
+    programManager: pm,
+    vs,
+    fs
+  });
+
+  t.ok(model1.program === model2.program, 'Programs are shared.');
 
   t.end();
 });

--- a/modules/core/test/lib/program-manager.spec.js
+++ b/modules/core/test/lib/program-manager.spec.js
@@ -1,0 +1,68 @@
+/* eslint-disable camelcase */
+import {ProgramManager} from '@luma.gl/core';
+import {picking} from '@luma.gl/shadertools';
+import {fixture} from 'test/setup';
+import test from 'tape-catch';
+
+const vs = `\
+attribute vec4 positions;
+
+void main(void) {
+  gl_Position = positions;
+}
+`;
+const fs = `\
+precision highp float;
+
+void main(void) {
+  gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+}
+`;
+
+test('ProgramManager#import', t => {
+  t.ok(ProgramManager !== undefined, 'ProgramManager import successful');
+  t.end();
+});
+
+test('ProgramManager#basic', t => {
+  const {gl} = fixture;
+  const pm = new ProgramManager(gl);
+
+  const program1 = pm.get(vs, fs);
+
+  t.ok(program1, 'Got a program');
+
+  const program2 = pm.get(vs, fs);
+
+  t.ok(program1 === program2, 'Got cached program');
+
+  const defineProgram1 = pm.get(vs, fs, {
+    defines: {
+      MY_DEFINE: true
+    }
+  });
+
+  t.ok(program1 !== defineProgram1, 'Define triggers new program');
+
+  const defineProgram2 = pm.get(vs, fs, {
+    defines: {
+      MY_DEFINE: true
+    }
+  });
+
+  t.ok(defineProgram1 === defineProgram2, 'Got cached program with defines');
+
+  const moduleProgram1 = pm.get(vs, fs, {
+    modules: [picking]
+  });
+
+  t.ok(program1 !== moduleProgram1, 'Module triggers new program');
+
+  const moduleProgram2 = pm.get(vs, fs, {
+    modules: [picking]
+  });
+
+  t.ok(moduleProgram1 === moduleProgram2, 'Got cached program with modules');
+
+  t.end();
+});

--- a/modules/core/test/lib/program-manager.spec.js
+++ b/modules/core/test/lib/program-manager.spec.js
@@ -57,12 +57,136 @@ test('ProgramManager#basic', t => {
   });
 
   t.ok(program1 !== moduleProgram1, 'Module triggers new program');
+  t.ok(defineProgram1 !== moduleProgram1, 'Module triggers new program');
 
   const moduleProgram2 = pm.get(vs, fs, {
     modules: [picking]
   });
 
   t.ok(moduleProgram1 === moduleProgram2, 'Got cached program with modules');
+
+  const defineModuleProgram1 = pm.get(vs, fs, {
+    modules: [picking],
+    defines: {
+      MY_DEFINE: true
+    }
+  });
+
+  t.ok(program1 !== defineModuleProgram1, 'Module and define triggers new program');
+  t.ok(defineProgram1 !== defineModuleProgram1, 'Module and define triggers new program');
+  t.ok(moduleProgram1 !== defineModuleProgram1, 'Module and define triggers new program');
+
+  const defineModuleProgram2 = pm.get(vs, fs, {
+    modules: [picking],
+    defines: {
+      MY_DEFINE: true
+    }
+  });
+
+  t.ok(
+    defineModuleProgram1 === defineModuleProgram2,
+    'Got cached program with modules and defines'
+  );
+
+  t.end();
+});
+
+test('ProgramManager#hooks', t => {
+  const {gl} = fixture;
+  const pm = new ProgramManager(gl);
+
+  pm.addShaderHook('vs:LUMAGL_pickColor(inout vec4 color)');
+  pm.addShaderHook('fs:LUMAGL_fragmentColor(inout vec4 color)', {
+    header: 'if (color.a == 0.0) discard;\n',
+    footer: 'color.a *= 1.2;\n'
+  });
+  pm.addModuleInjection(picking, {
+    hook: 'vs:LUMAGL_pickColor',
+    injection: 'picking_setPickingColor(color.rgb);'
+  });
+  pm.addModuleInjection(picking, {
+    hook: 'fs:LUMAGL_fragmentColor',
+    injection: 'color = picking_filterColor(color);',
+    order: Number.POSITIVE_INFINITY
+  });
+
+  const moModuleProgram = pm.get(vs, fs);
+  const moModuleVs = moModuleProgram.vs.source;
+  const moModuleFs = moModuleProgram.fs.source;
+
+  t.ok(moModuleVs.indexOf('LUMAGL_pickColor') > -1, 'hook function injected into vertex shader');
+  t.ok(
+    moModuleFs.indexOf('LUMAGL_fragmentColor') > -1,
+    'hook function injected into fragment shader'
+  );
+
+  t.ok(
+    moModuleVs.indexOf('picking_setPickingColor(color.rgb)') === -1,
+    'injection code not included in vertex shader without module'
+  );
+  t.ok(
+    moModuleFs.indexOf('color = picking_filterColor(color)') === -1,
+    'injection code not included in fragment shader without module'
+  );
+
+  const modulesProgram = pm.get(vs, fs, {
+    modules: [picking]
+  });
+  const modulesVs = modulesProgram.vs.source;
+  const modulesFs = modulesProgram.fs.source;
+
+  t.ok(modulesVs.indexOf('LUMAGL_pickColor') > -1, 'hook function injected into vertex shader');
+  t.ok(
+    modulesFs.indexOf('LUMAGL_fragmentColor') > -1,
+    'hook function injected into fragment shader'
+  );
+
+  t.ok(
+    modulesVs.indexOf('picking_setPickingColor(color.rgb)') > -1,
+    'injection code included in vertex shader with module'
+  );
+  t.ok(
+    modulesFs.indexOf('color = picking_filterColor(color)') > -1,
+    'injection code included in fragment shader with module'
+  );
+  t.ok(
+    modulesFs.indexOf('if (color.a == 0.0) discard;') > -1,
+    'hook header injected into fragment shader'
+  );
+  t.ok(
+    modulesFs.indexOf('color.a *= 1.2;') > modulesFs.indexOf('color = picking_filterColor(color)'),
+    'hook footer injected after injection code'
+  );
+
+  const injectProgram = pm.get(vs, fs, {
+    inject: {
+      'vs:LUMAGL_pickColor': 'color *= 0.1;',
+      'fs:LUMAGL_fragmentColor': 'color += 0.1;'
+    }
+  });
+  const injectVs = injectProgram.vs.source;
+  const injectFs = injectProgram.fs.source;
+
+  t.ok(injectVs.indexOf('color *= 0.1') > -1, 'argument injection code included in shader hook');
+  t.ok(injectFs.indexOf('color += 0.1') > -1, 'argument injection code included in shader hook');
+
+  t.end();
+});
+
+test('ProgramManager#release', t => {
+  const {gl} = fixture;
+  const pm = new ProgramManager(gl);
+
+  const program1 = pm.get(vs, fs);
+  const program2 = pm.get(vs, fs);
+
+  pm.release(program1);
+
+  t.ok(program1.handle !== null, 'Program not deleted when still referenced.');
+
+  pm.release(program2);
+
+  t.ok(program2.handle === null, 'Program deleted when all references released.');
 
   t.end();
 });

--- a/modules/webgl/src/classes/program.js
+++ b/modules/webgl/src/classes/program.js
@@ -54,7 +54,10 @@ export default class Program extends Resource {
   }
 
   initialize(props = {}) {
-    const {vs, fs, varyings, bufferMode = GL_SEPARATE_ATTRIBS} = props;
+    const {hash, vs, fs, varyings, bufferMode = GL_SEPARATE_ATTRIBS} = props;
+
+    this.hash = hash || null; // Used by ProgramManager
+
     // Create shaders if needed
     this.vs =
       typeof vs === 'string' ? new VertexShader(this.gl, {id: `${props.id}-vs`, source: vs}) : vs;
@@ -67,7 +70,7 @@ export default class Program extends Resource {
     this.uniforms = {};
 
     // Setup varyings if supplied
-    if (varyings) {
+    if (varyings && varyings.length > 0) {
       assertWebGL2Context(this.gl);
       this.varyings = varyings;
       this.gl.transformFeedbackVaryings(this.handle, varyings, bufferMode);

--- a/modules/webgl/src/classes/vertex-array.js
+++ b/modules/webgl/src/classes/vertex-array.js
@@ -42,6 +42,8 @@ export default class VertexArray {
     this.drawParams = null;
     this.buffer = null; // For attribute 0 on desktops, and created when unbinding buffers
 
+    this.attributes = {};
+
     this.vertexArrayObject = VertexArrayObject.isSupported(gl)
       ? new VertexArrayObject(gl)
       : VertexArrayObject.getDefaultArray(gl);
@@ -99,6 +101,9 @@ export default class VertexArray {
     if ('bindOnUse' in props) {
       props = props.bindOnUse;
     }
+    if ('copyFrom' in props) {
+      this.setAttributes(props.copyFrom.attributes);
+    }
     return this;
   }
 
@@ -123,6 +128,7 @@ export default class VertexArray {
   //     {attributeName: [buffer, accessor]}
   //     {attributeName: (typed) array} => constant
   setAttributes(attributes) {
+    Object.assign(this.attributes, attributes);
     this.vertexArrayObject.bind(() => {
       for (const locationOrName in attributes) {
         const value = attributes[locationOrName];


### PR DESCRIPTION
- Implement `ProgramManager` class proposed in [Program Management RFC](https://github.com/uber/luma.gl/blob/master/dev-docs/RFCs/v7.3/program-manager-rfc.md)
- `BaseModel` updates
  - Support acquiring program from a `ProgramManager`.
  - Support program sharing
  - Support updating program via `setProgram` method
- `ProgramManager` example
