### PR TITLE
ensure assembleShader always sets the GLSL version

### DIFF
--- a/modules/shadertools/src/lib/assemble-shaders.js
+++ b/modules/shadertools/src/lib/assemble-shaders.js
@@ -81,6 +81,8 @@ function assembleShader(
     glslVersion = 300; // TODO - regexp that matches atual version number
     versionLine = sourceLines[0];
     coreSource = sourceLines.slice(1).join('\n');
+  } else {
+    versionLine = `#version ${glslVersion}`;
   }
 
   // Combine Module and Application Defines

--- a/modules/shadertools/src/utils/shader-utils.js
+++ b/modules/shadertools/src/utils/shader-utils.js
@@ -1,9 +1,5 @@
 import {assert} from '../utils';
-const FS100 = `\
-#version 100
-void main() {
-  gl_FragColor = vec4(0);
-}`;
+const FS100 = `void main() {gl_FragColor = vec4(0);}`;
 const FS_GLES = `\
 out vec4 transform_output;
 void main() {
@@ -51,7 +47,6 @@ void main() {
   }
   // WebGL 1.0
   return `\
-#version 100
 varying ${inputType} ${input};
 void main() {
   gl_FragColor = ${outputValue};

--- a/modules/shadertools/src/utils/shader-utils.js
+++ b/modules/shadertools/src/utils/shader-utils.js
@@ -1,11 +1,15 @@
 import {assert} from '../utils';
-const FS100 = 'void main() {gl_FragColor = vec4(0);}';
-const FS300 = `\
-#version 300 es
+const FS100 = `\
+#version 100
+void main() {
+  gl_FragColor = vec4(0);
+}`;
+const FS_GLES = `\
 out vec4 transform_output;
 void main() {
   transform_output = vec4(0);
 }`;
+const FS300 = `#version 300 es\n${FS_GLES}`;
 
 // Prase given glsl line and return qualifier details or null
 export function getQualifierDetails(line, qualifiers) {
@@ -24,20 +28,31 @@ export function getQualifierDetails(line, qualifiers) {
 // builds and return a pass through fragment shader.
 export function getPassthroughFS({version = 100, input, inputType, output} = {}) {
   if (!input) {
-    return version === 300 ? FS300 : FS100;
+    if (version === 300) {
+      // Fast-path for WebGL 2.0
+      return FS300;
+    } else if (version > 300) {
+      // Use the supplied version for OpenGL/ES 3.2+
+      return `#version ${version}\n${FS_GLES}`;
+    } else {
+      // Fast-path for WebGL 1.0
+      return FS100;
+    }
   }
   const outputValue = convertToVec4(input, inputType);
-  if (version === 300) {
+  if (version >= 300) {
+    // If version is 300, assume WebGL 2.0
     return `\
-#version 300 es
+#version ${version} ${version === 300 ? 'es' : ''}
 in ${inputType} ${input};
 out vec4 ${output};
 void main() {
   ${output} = ${outputValue};
 }`;
   }
-  // version 100
+  // WebGL 1.0
   return `\
+#version 100
 varying ${inputType} ${input};
 void main() {
   gl_FragColor = ${outputValue};

--- a/modules/shadertools/src/utils/shader-utils.js
+++ b/modules/shadertools/src/utils/shader-utils.js
@@ -34,10 +34,9 @@ export function getPassthroughFS({version = 100, input, inputType, output} = {})
     } else if (version > 300) {
       // Use the supplied version for OpenGL/ES 3.2+
       return `#version ${version}\n${FS_GLES}`;
-    } else {
-      // Fast-path for WebGL 1.0
-      return FS100;
     }
+    // Fast-path for WebGL 1.0
+    return FS100;
   }
   const outputValue = convertToVec4(input, inputType);
   if (version >= 300) {

--- a/modules/webgl/src/classes/shader.js
+++ b/modules/webgl/src/classes/shader.js
@@ -76,7 +76,11 @@ export class Shader extends Resource {
   }
 
   // PRIVATE METHODS
-  _compile() {
+  _compile(source = this.source) {
+    if (!source.startsWith('#version ')) {
+      source = `#version 100\n${source}`;
+    }
+    this.source = source;
     this.gl.shaderSource(this.handle, this.source);
     this.gl.compileShader(this.handle);
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1205
<!-- For other PRs without open issue -->
#### Background
@raub and I are working on some [native addons](https://github.com/trxcllnt/node-3d) to provide an OpenGL-backed WebGL context in node, so browser-based WebGL apps can run unmodified in GLFW and render via OpenGL.

Linux and Windows' GL 4.6 are working fine as-is, but MacOS's GL 4.1 is strictly enforces the shader version definition, so the luma.gl lesson examples are choking on shader compilation.
<!-- For all the PRs -->
#### Change List
- Ensure `assembleShader` always sets the GLSL version when one isn't specified.
