### PR TITLE
Add DOUBLE to gl constants

### DIFF
--- a/modules/constants/src/index.js
+++ b/modules/constants/src/index.js
@@ -196,6 +196,7 @@ module.exports = {
   INT: 0x1404,
   UNSIGNED_INT: 0x1405,
   FLOAT: 0x1406,
+  DOUBLE: 0x140a,
 
   // Pixel formats
 


### PR DESCRIPTION

For https://github.com/uber/deck.gl/pull/3468#discussion_r315899498

Source: https://www.khronos.org/registry/OpenGL/api/GL/glcorearb.h

#### Change List
- Add `DOUBLE` to `@luma.gl/constants`
