### PR TITLE
webgl: Avoid crashing debug log if attribute is null

### DIFF
--- a/modules/webgl/src/debug/debug-vertex-array.js
+++ b/modules/webgl/src/debug/debug-vertex-array.js
@@ -42,8 +42,14 @@ export function getDebugTableForVertexArray({vertexArray, header = 'Attributes'}
 
 /* eslint-disable max-statements */
 function getDebugTableRow(vertexArray, attribute, accessor, header) {
-  // const round = xnum => Math.round(num * 10) / 10;
   const {gl} = vertexArray;
+
+  if (!attribute) {
+    return {
+      [header]: 'null',
+      'Format ': 'N/A'
+    };
+  }
 
   let type = 'NOT PROVIDED';
   let size = 'N/A';
@@ -63,13 +69,6 @@ function getDebugTableRow(vertexArray, attribute, accessor, header) {
 
     // Look for 'nt' to detect integer types, e.g. Int32Array, Uint32Array
     isInteger = type.indexOf('nt') !== -1;
-  }
-
-  if (!attribute) {
-    return {
-      [header]: 'null',
-      'Format ': 'N/A'
-    };
   }
 
   if (attribute instanceof Buffer) {
@@ -117,8 +116,5 @@ function getDebugTableRow(vertexArray, attribute, accessor, header) {
 function getGLSLDeclaration(name, accessor) {
   const {type, size} = accessor;
   const typeAndName = getCompositeGLType(type, size);
-  if (typeAndName) {
-    return `${name} (${typeAndName.name})`;
-  }
-  return name;
+  return typeAndName ? `${name} (${typeAndName.name})` : name;
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->

#### Background
- Crashes during 3d-tiles debugging, deck somehow sets (fails to set) `instance64lo` attribute to `null`.
- While this condition is pathological, it is better to avoid crashing during logging as that creates uncertainty about whether it is logging itself that is broken.

#### Change List
- Check if attribute is null and print `null` row.
