### PR TITLE
Transform: Fix update of Buffers and elementCount.

### DIFF
--- a/modules/core/test/lib/transform.spec.js
+++ b/modules/core/test/lib/transform.spec.js
@@ -410,7 +410,7 @@ test('WebGL#Transform swap without varyings', t => {
 });
 
 /* eslint-disable max-statements */
-test('WebGL#Transform update', t => {
+test.only('WebGL#Transform update', t => {
   const {gl2} = fixture;
 
   if (!gl2) {
@@ -425,18 +425,27 @@ test('WebGL#Transform update', t => {
   let outData;
 
   const transform = new Transform(gl2, {
-    sourceBuffers: {
-      inValue: sourceBuffer
-    },
     vs: VS,
-    feedbackMap: {
-      inValue: 'outValue'
-    },
     varyings: ['outValue'],
     elementCount: 5
   });
 
+  t.ok(transform, 'should construct without buffers');
+
+  transform.update({
+    sourceBuffers: {
+      inValue: sourceBuffer
+    },
+    feedbackMap: {
+      inValue: 'outValue'
+    }
+  });
+
   transform.run();
+
+  expectedData = sourceData.map(x => x * 2);
+  outData = transform.getData({varyingName: 'outValue'});
+  t.deepEqual(outData, expectedData, 'Transform.getData: is successful');
 
   sourceData = new Float32Array([1, 2, 3, 0, -5]);
   sourceBuffer.delete();

--- a/modules/core/test/lib/transform.spec.js
+++ b/modules/core/test/lib/transform.spec.js
@@ -410,7 +410,7 @@ test('WebGL#Transform swap without varyings', t => {
 });
 
 /* eslint-disable max-statements */
-test.only('WebGL#Transform update', t => {
+test('WebGL#Transform update', t => {
   const {gl2} = fixture;
 
   if (!gl2) {
@@ -426,8 +426,7 @@ test.only('WebGL#Transform update', t => {
 
   const transform = new Transform(gl2, {
     vs: VS,
-    varyings: ['outValue'],
-    elementCount: 5
+    varyings: ['outValue']
   });
 
   t.ok(transform, 'should construct without buffers');
@@ -438,7 +437,8 @@ test.only('WebGL#Transform update', t => {
     },
     feedbackMap: {
       inValue: 'outValue'
-    }
+    },
+    elementCount: 5
   });
 
   transform.run();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1218 
<!-- For other PRs without open issue -->
#### Background
- Move all Buffer setting code to `_setBuffers`, that is used during `construction` and `update`, this allows `Transform` to be constructed without any `Buffer`s  and they be set later using `update`.
- Fix `elementCount` update, so `Transform` can be constructed without specifying it. It must be provided before calling `run`.

<!-- For all the PRs -->
#### Change List
- Transform: Fix update of Buffers and elementCount.
