### PR TITLE
Fix Framebuffer isSupported test

### DIFF
--- a/modules/webgl/src/classes/framebuffer.js
+++ b/modules/webgl/src/classes/framebuffer.js
@@ -23,12 +23,24 @@ export default class Framebuffer extends Resource {
     } = {}
   ) {
     let supported = true;
-    supported =
-      colorBufferFloat &&
-      gl.getExtension(isWebGL2(gl) ? 'EXT_color_buffer_float' : 'WEBGL.color_buffer_float');
-    supported =
-      colorBufferHalfFloat &&
-      gl.getExtension(isWebGL2(gl) ? 'EXT_color_buffer_float' : 'EXT_color_buffer_half_float');
+
+    if (colorBufferFloat) {
+      supported = Boolean(
+        gl.getExtension('EXT_color_buffer_float') ||
+          gl.getExtension('WEBGL_color_buffer_float') ||
+          gl.getExtension('OES_texture_float')
+      );
+    }
+
+    if (colorBufferHalfFloat) {
+      supported =
+        supported &&
+        Boolean(
+          gl.getExtension('EXT_color_buffer_float') ||
+            gl.getExtension('EXT_color_buffer_half_float')
+        );
+    }
+
     return supported;
   }
 

--- a/modules/webgl/src/classes/framebuffer.js
+++ b/modules/webgl/src/classes/framebuffer.js
@@ -26,8 +26,11 @@ export default class Framebuffer extends Resource {
 
     if (colorBufferFloat) {
       supported = Boolean(
+        // WebGL 2
         gl.getExtension('EXT_color_buffer_float') ||
+          // WebGL 1, not exposed on all platforms
           gl.getExtension('WEBGL_color_buffer_float') ||
+          // WebGL 1, implicitly enables float render targets https://www.khronos.org/registry/webgl/extensions/OES_texture_float/
           gl.getExtension('OES_texture_float')
       );
     }
@@ -36,7 +39,9 @@ export default class Framebuffer extends Resource {
       supported =
         supported &&
         Boolean(
+          // WebGL 2
           gl.getExtension('EXT_color_buffer_float') ||
+            // WebGL 1
             gl.getExtension('EXT_color_buffer_half_float')
         );
     }


### PR DESCRIPTION
- Fix `WEBGL.color_buffer_float` typo
- Fix logic (half float check would overwrite float check)
- Check `OES_texture_float` to support WebGL 1 contexts that don't report `WEBGL_color_buffer_float` (e.g. Safari)