### PR TITLE
CSS to Device: Handle cases when canvas is not defined

### DIFF
--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -2,7 +2,11 @@
 
 // multiplier need to convert CSS size to Device size
 export function cssToDeviceRatio(gl) {
-  return gl.drawingBufferWidth / (gl.canvas.clientWidth || gl.canvas.width);
+  if (gl.canvas) {
+    return gl.drawingBufferWidth / (gl.canvas.clientWidth || gl.canvas.width || 1);
+  }
+  // use default device pixel ratio
+  return 1;
 }
 
 // Maps CSS pixel position to device pixel position

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -338,5 +338,12 @@ test('webgl#cssToDeviceRatio', t => {
   MAP_TEST_CASES.forEach(tc => {
     t.equal(cssToDeviceRatio(tc.gl), tc.ratio, 'cssToDeviceRatio should return correct value');
   });
+
+  const glWithNoCanvas = {};
+  t.equal(
+    cssToDeviceRatio(glWithNoCanvas),
+    1,
+    'cssToDeviceRatio should return 1 when there is no canvas'
+  );
   t.end();
 });


### PR DESCRIPTION
Use default ratio of `1` when `gl.canvas` is not defined.
