### PR TITLE
#1208 - Do to clear the VertexArray elements buffer when unbinding a shared VertexArrayObject.

### DIFF
--- a/modules/webgl/src/classes/vertex-array-object.js
+++ b/modules/webgl/src/classes/vertex-array-object.js
@@ -27,7 +27,7 @@ export default class VertexArrayObject extends Resource {
   static getDefaultArray(gl) {
     gl.luma = gl.luma || {};
     if (!gl.luma.defaultVertexArray) {
-      gl.luma.defaultVertexArray = new VertexArrayObject(gl, {handle: null});
+      gl.luma.defaultVertexArray = new VertexArrayObject(gl, {handle: null, isDefaultArray: true});
     }
     return gl.luma.defaultVertexArray;
   }
@@ -68,6 +68,7 @@ export default class VertexArrayObject extends Resource {
     this.hasVertexArrays = VertexArrayObject.isSupported(gl);
     this.buffer = null;
     this.bufferValue = null;
+    this.isDefaultArray = opts.isDefaultArray !== undefined ? opts.isDefaultArray : false;
 
     this.initialize(opts);
 

--- a/modules/webgl/src/classes/vertex-array.js
+++ b/modules/webgl/src/classes/vertex-array.js
@@ -215,7 +215,12 @@ export default class VertexArray {
   unbindBuffers() {
     this.vertexArrayObject.bind(() => {
       if (this.elements) {
-        this.setElementBuffer(null);
+        this.clearDrawParams();
+
+        // Update vertexArray immediately if we have our own array
+        if (!this.vertexArrayObject.isDefaultArray) {
+          this.vertexArrayObject.setElementBuffer(null);
+        }
       }
 
       // Chrome does not like buffers that are bound to several binding points,


### PR DESCRIPTION
#### Background

When a browser only has support for shared `VertexArrayObjects`, the `VertexArray` must bind to the shared buffer before drawing and then unbind after. During the unbind step, the `elements` buffer was cleared from the `VertexArray`. This causes subsequent draws to fail as there were no elements to draw.

#### Change List

* When unbinding buffers, do not clear the list of elements from the VertexArray.
* Ensure that the shared `VertexArrayObject` is still cleared during the unbind process
