### PR TITLE
Don't set VertexArrayObject.isDefaultArray

### DIFF
--- a/modules/webgl/src/classes/vertex-array-object.js
+++ b/modules/webgl/src/classes/vertex-array-object.js
@@ -68,7 +68,7 @@ export default class VertexArrayObject extends Resource {
     this.hasVertexArrays = VertexArrayObject.isSupported(gl);
     this.buffer = null;
     this.bufferValue = null;
-    this.isDefaultArray = opts.isDefaultArray || false;
+    // this.isDefaultArray = opts.isDefaultArray || false;
 
     this.initialize(opts);
 

--- a/modules/webgl/src/classes/vertex-array.js
+++ b/modules/webgl/src/classes/vertex-array.js
@@ -215,8 +215,6 @@ export default class VertexArray {
   unbindBuffers() {
     this.vertexArrayObject.bind(() => {
       if (this.elements) {
-        this.clearDrawParams();
-
         // Update vertexArray immediately if we have our own array
         if (!this.vertexArrayObject.isDefaultArray) {
           this.vertexArrayObject.setElementBuffer(null);

--- a/modules/webgl/test/classes/vertex-array.spec.js
+++ b/modules/webgl/test/classes/vertex-array.spec.js
@@ -142,7 +142,10 @@ test('WebGL#VertexArray#default VAO unbinding', t => {
       })
     }
   });
-  t.ok(vertexArray.vertexArrayObject.isDefaultArray, 'Using default VertexArrayObject');
+  t.ok(
+    vertexArray.vertexArrayObject === VertexArrayObject.getDefaultArray(gl),
+    'Using default VertexArrayObject'
+  );
   t.ok(vertexArray.elements, 'VertexArray has elements');
 
   vertexArray.bindBuffers();


### PR DESCRIPTION
Property wasn't being properly set, was fixed in #1238 and that ended up breaking everything. This fix isn't ideal, but I believe it's the lightest touch to get things working again, essentially reverting the prior fix. This logic should be revisited in the future.