### PR TITLE
--prefix-paths option for gatsby build

### DIFF
--- a/website-gatsby/package.json
+++ b/website-gatsby/package.json
@@ -11,7 +11,7 @@
     "start": "yarn clean-examples && yarn clean && yarn develop",
     "clean": "rm -rf ./.cache ./public",
     "develop": "gatsby develop --port=8001",
-    "build": "yarn clean-examples && yarn clean && gatsby build",
+    "build": "yarn clean-examples && yarn clean && gatsby build --prefix-paths",
     "serve": "gatsby serve",
     "deploy": "gh-pages -d public",
     "clean-examples": "rm -rf examples ; (find ../examples -name node_modules -exec rm -rf {} \\; || true)"


### PR DESCRIPTION
This will ensure the `PATH_PREFIX` option is respected.
