### PR TITLE
Fix usage with rollup

### DIFF
--- a/modules/webgl/src/webgl-utils/webgl-types.js
+++ b/modules/webgl/src/webgl-utils/webgl-types.js
@@ -18,7 +18,12 @@ typical configuration for isorender applications running on the server.`;
 // TODO(Tarek): OOGLY HACK to avoid webpack requiring headless
 //   browser bundles. Will be removed in 8.0 when we
 //   remove automatic headless context creation
-const m = module;
+let m;
+try {
+  m = module;
+} catch(e) {
+  m = null;
+}
 
 // Load headless gl dynamically, if available
 export let headlessTypes = null;

--- a/modules/webgl/src/webgl-utils/webgl-types.js
+++ b/modules/webgl/src/webgl-utils/webgl-types.js
@@ -21,7 +21,7 @@ typical configuration for isorender applications running on the server.`;
 let m;
 try {
   m = module;
-} catch(e) {
+} catch (e) {
   m = null;
 }
 

--- a/modules/webgl/src/webgl-utils/webgl-types.js
+++ b/modules/webgl/src/webgl-utils/webgl-types.js
@@ -18,6 +18,10 @@ typical configuration for isorender applications running on the server.`;
 // TODO(Tarek): OOGLY HACK to avoid webpack requiring headless
 //   browser bundles. Will be removed in 8.0 when we
 //   remove automatic headless context creation
+// NOTE: Rollup does not process the line `const m = module;`
+//   and writes it out verbatim in its final output, which ends
+//   up falling over in browser environments at runtime. Added
+//   a `try/catch` block to fix usage in rollup builds.
 let m;
 try {
   m = module;


### PR DESCRIPTION
This hack, although works in webpack, breaks usage in the browser when packaging with rollup.
Adding a `try/catch` block fixes the issue. Fixes #1265

<!-- For all the PRs -->
#### Change List
- Surrounded hack in a `try/catch` block.
