### PR TITLE
Add attribute picking to the picking module

### DIFF
--- a/docs/api-reference/shadertools/shader-module-picking.md
+++ b/docs/api-reference/shadertools/shader-module-picking.md
@@ -61,7 +61,9 @@ Sets the color that will be returned by the fragment shader if color based picki
 
 Sets the attribute value that needs to be picked.
 
-`void picking_setPickingAttribute(vec3 pickingColor, float value)`
+`void picking_setPickingAttribute(float value)`
+`void picking_setPickingAttribute(vec2 value)`
+`void picking_setPickingAttribute(vec3 value)`
 
 ## Fragment Shader Functions
 

--- a/docs/api-reference/shadertools/shader-module-picking.md
+++ b/docs/api-reference/shadertools/shader-module-picking.md
@@ -7,7 +7,8 @@ Color based picking lets the application draw a primitive with a color that can 
 ## Usage
 
 In your vertex shader, your inform the picking module what object we are currently rendering by supplying a picking color, perhaps from an attribute.
-```
+
+```glsl
 attribute vec3 aPickingColor;
 main() {
   picking_setPickingColor(aPickingColor);
@@ -16,21 +17,22 @@ main() {
 ```
 
 In your fragment shader, you simply apply (call) the `picking_filterPickingColor` filter function at the very end of the shader. This will return the normal color, or the highlight color, or the picking color, as appropriate.
-```
+
+```glsl
 main() {
   gl_FragColor = ...
   gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
 ```
+
 If you would like to apply the highlight color to the currently selected element call `picking_filterHighlightColor` before calling `picking_filterPickingColor`. You can also apply other filters on the non-picking color (vertex or highlight color) by placing those instruction between these two function calls.
 
- ```
+```glsl
 main() {
-   gl_FragColor = picking_filterHighlightColor(color);
-    ... apply any filters on gl_FragColor ...
+  gl_FragColor = picking_filterHighlightColor(color);
+  //  ... apply any filters on gl_FragColor ...
   gl_FragColor = picking_filterPickingColor(gl_FragColor);
 }
-
 ```
 
 ## JavaScript Functions
@@ -39,22 +41,27 @@ main() {
 
 `getUniforms` returns an object with key/value pairs representing the uniforms that the `picking` module shaders need.
 
-`getUniforms({enabled, })`
+`getUniforms({pickingActive, ...})`
 
-* `enabled`=`true` (*boolean*) - Activates picking
-* `selectedIndex`=-1 (*number*) - The index of the selected item, or -1 if no selection.
-* `highlightColor`= (*array*)- Color used to highlight the currently selected
-* `active`=`false` (*boolean*) - Renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking.
-
-Note that the selected item will be rendered using `highlightColor`.
+* `pickingActive`=`false` (*boolean*) - Renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking.
+* `pickingSelectedColor`=`null` (*array|null*) - The picking color of the selected (highlighted) object.
+* `pickingHighlightColor`= `[0, 255, 255, 255]` (*array*) - Color used to highlight the currently selected object.
+* `pickingAttribute`=`false` (*boolean*) - Renders a color that encodes an attribute value. Normally only used with an off-screen framebuffer during picking.
 
 
 ## Vertex Shader Functions
 
-### `void picking_setPickingColor(vec3)`
+### picking_setPickingColor
 
 Sets the color that will be returned by the fragment shader if color based picking is enabled. Typically set from a `pickingColor` uniform or a `pickingColors` attribute (e.g. when using instanced rendering, to identify the actual instance that was picked).
 
+`void picking_setPickingColor(vec3 pickingColor)`
+
+### picking_setPickingAttribute
+
+Sets the attribute value that needs to be picked.
+
+`void picking_setPickingAttribute(vec3 pickingColor, float value)`
 
 ## Fragment Shader Functions
 

--- a/modules/shadertools/src/modules/picking/picking.js
+++ b/modules/shadertools/src/modules/picking/picking.js
@@ -31,9 +31,7 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
 
 const vs = `\
 uniform vec3 picking_uSelectedColor;
-uniform float picking_uThreshold;
 uniform bool picking_uSelectedColorValid;
-uniform bool picking_uAttribute;
 
 out vec4 picking_vRGBcolor_Aselected;
 

--- a/modules/shadertools/src/modules/picking/picking.js
+++ b/modules/shadertools/src/modules/picking/picking.js
@@ -49,7 +49,7 @@ bool isVertexPicked(vec3 vertexColor) {
 void picking_setPickingColor(vec3 pickingColor) {
   if (picking_uAttribute) {
     // Use alpha as the validity flag. If pickingColor is [0, 0, 0] fragment is non-pickable
-    picking_vRGBcolor_Aselected.a = step(0.001, length(pickingColor));
+    picking_vRGBcolor_Aselected.a = step(0.001, dot(pickingColor, vec3(1.0)));
   } else {
     // Do the comparison with selected item color in vertex shader as it should mean fewer compares
     picking_vRGBcolor_Aselected.a =
@@ -118,7 +118,7 @@ vec4 picking_filterPickingColor(vec4 color) {
   }
   if (picking_uActive) {
     vec3 pickingColor = picking_vRGBcolor_Aselected.rgb;
-    if (length(pickingColor) < 0.001) {
+    if (dot(pickingColor, vec3(1.0)) < 0.001) {
       discard;
     }
     return vec4(pickingColor, 1.0);

--- a/modules/shadertools/src/modules/picking/picking.js
+++ b/modules/shadertools/src/modules/picking/picking.js
@@ -3,35 +3,28 @@ const DEFAULT_HIGHLIGHT_COLOR = new Uint8Array([0, 255, 255, 255]);
 const DEFAULT_MODULE_OPTIONS = {
   pickingSelectedColor: null, //  Set to a picking color to visually highlight that item
   pickingHighlightColor: DEFAULT_HIGHLIGHT_COLOR, // Color of visual highlight of "selected" item
-  pickingThreshold: 1.0,
-  pickingActive: false // Set to true when rendering to off-screen "picking" buffer
+  pickingActive: false, // Set to true when rendering to off-screen "picking" buffer
+  pickingAttribute: false // Set to true when picking an attribute value instead of object index
 };
 
 /* eslint-disable camelcase */
 function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
   const uniforms = {};
   if (opts.pickingSelectedColor !== undefined) {
-    if (opts.pickingSelectedColor === null) {
+    if (!opts.pickingSelectedColor) {
       uniforms.picking_uSelectedColorValid = 0;
     } else {
-      const selectedColor = [
-        opts.pickingSelectedColor[0],
-        opts.pickingSelectedColor[1],
-        opts.pickingSelectedColor[2]
-      ];
+      const selectedColor = opts.pickingSelectedColor.slice(0, 3);
       uniforms.picking_uSelectedColorValid = 1;
       uniforms.picking_uSelectedColor = selectedColor;
     }
   }
-  if (opts.pickingHighlightColor !== undefined) {
-    uniforms.picking_uHighlightColor = opts.pickingHighlightColor;
-  }
-  // TODO - major hack - decide on normalization and remove
-  if (opts.pickingThreshold !== undefined) {
-    uniforms.picking_uThreshold = opts.pickingThreshold;
+  if (opts.pickingHighlightColor) {
+    uniforms.picking_uHighlightColor = opts.pickingHighlightColor.map(x => x / 255);
   }
   if (opts.pickingActive !== undefined) {
-    uniforms.picking_uActive = opts.pickingActive ? 1 : 0;
+    uniforms.picking_uActive = Boolean(opts.pickingActive);
+    uniforms.picking_uAttribute = Boolean(opts.pickingAttribute);
   }
   return uniforms;
 }
@@ -40,17 +33,21 @@ const vs = `\
 uniform vec3 picking_uSelectedColor;
 uniform float picking_uThreshold;
 uniform bool picking_uSelectedColorValid;
+uniform bool picking_uAttribute;
 
 out vec4 picking_vRGBcolor_Aselected;
 
 const float COLOR_SCALE = 1. / 255.;
+const vec3 PACK_SHIFT = vec3(65536.0, 256.0, 1.0);
+const float PACK_UPSCALE = 256.0 / 255.0;
+const float PACK_SHIFT_RIGHT = 1. / 256.;
 
 bool isVertexPicked(vec3 vertexColor) {
   return
     picking_uSelectedColorValid &&
-    abs(vertexColor.r - picking_uSelectedColor.r) < picking_uThreshold &&
-    abs(vertexColor.g - picking_uSelectedColor.g) < picking_uThreshold &&
-    abs(vertexColor.b - picking_uSelectedColor.b) < picking_uThreshold;
+    abs(vertexColor.r - picking_uSelectedColor.r) < 0.001 &&
+    abs(vertexColor.g - picking_uSelectedColor.g) < 0.001 &&
+    abs(vertexColor.b - picking_uSelectedColor.b) < 0.001;
 }
 
 void picking_setPickingColor(vec3 pickingColor) {
@@ -61,31 +58,40 @@ void picking_setPickingColor(vec3 pickingColor) {
   // Stores the picking color so that the fragment shader can render it during picking
   picking_vRGBcolor_Aselected.rgb = pickingColor * COLOR_SCALE;
 }
+
+void picking_setPickingAttribute(vec3 pickingColor, float value) {
+  // Encode attribute value into 3x8 bits
+  vec3 packedValue = fract(value * PACK_SHIFT);
+  packedValue.gb -= packedValue.rg * PACK_SHIFT_RIGHT;
+  picking_vRGBcolor_Aselected.rgb = packedValue * PACK_UPSCALE;
+  // Use alpha as the validity flag. If pickingColor is [0, 0, 0] fragment is non-pickable
+  picking_vRGBcolor_Aselected.a = step(0.5, length(pickingColor));
+}
 `;
 
 const fs = `\
 uniform bool picking_uActive; // true during rendering to offscreen picking buffer
+uniform bool picking_uAttribute;
 uniform vec3 picking_uSelectedColor;
 uniform vec4 picking_uHighlightColor;
 
 in vec4 picking_vRGBcolor_Aselected;
 
-const float COLOR_SCALE = 1. / 255.;
-
 /*
  * Returns highlight color if this item is selected.
  */
 vec4 picking_filterHighlightColor(vec4 color) {
+  if (picking_uActive) {
+    return color;
+  }
   bool selected = bool(picking_vRGBcolor_Aselected.a);
 
   if (selected) {
-    vec4 highLightColor = picking_uHighlightColor * COLOR_SCALE;
-
-    float highLightAlpha = highLightColor.a;
+    float highLightAlpha = picking_uHighlightColor.a;
     float blendedAlpha = highLightAlpha + color.a * (1.0 - highLightAlpha);
     float highLightRatio = highLightAlpha / blendedAlpha;
 
-    vec3 blendedRGB = mix(color.rgb, highLightColor.rgb, highLightRatio);
+    vec3 blendedRGB = mix(color.rgb, picking_uHighlightColor.rgb, highLightRatio);
     return vec4(blendedRGB, blendedAlpha);
   } else {
     return color;
@@ -96,11 +102,20 @@ vec4 picking_filterHighlightColor(vec4 color) {
  * Returns picking color if picking enabled else unmodified argument.
  */
 vec4 picking_filterPickingColor(vec4 color) {
-  vec3 pickingColor = picking_vRGBcolor_Aselected.rgb;
-  if (picking_uActive && length(pickingColor) < 0.001) {
-    discard;
+  if (picking_uAttribute) {
+    if (picking_vRGBcolor_Aselected.a == 0.0) {
+      discard;
+    }
+    return picking_vRGBcolor_Aselected;
   }
-  return picking_uActive ? vec4(pickingColor, 1.0) : color;
+  if (picking_uActive) {
+    vec3 pickingColor = picking_vRGBcolor_Aselected.rgb;
+    if (length(pickingColor) < 0.001) {
+      discard;
+    }
+    return vec4(pickingColor, 1.0);
+  }
+  return color;
 }
 
 /*

--- a/modules/shadertools/test/modules/picking/picking.spec.js
+++ b/modules/shadertools/test/modules/picking/picking.spec.js
@@ -133,22 +133,20 @@ test('picking#picking_setPickingColor', t => {
   }
   const VS = `\
   attribute vec3 vertexColor;
-  varying vec4 rgbColorASelected;
+  varying float rgbColorASelected;
 
   void main()
   {
     picking_setPickingColor(vertexColor);
-    rgbColorASelected = picking_vRGBcolor_Aselected;
+    rgbColorASelected = picking_vRGBcolor_Avalid.a;
   }
   `;
 
-  const COLOR_SCALE = 1 / 255;
-  const EPSILON = 0.00001;
   const vertexColorData = TEST_DATA.vertexColorData;
 
   const elementCount = vertexColorData.length / 3;
   const vertexColor = new Buffer(gl, vertexColorData);
-  const rgbColorASelected = new Buffer(gl, {byteLength: elementCount * 4 * 4});
+  const rgbColorASelected = new Buffer(gl, {byteLength: elementCount * 4});
 
   const transform = new Transform(gl, {
     sourceBuffers: {
@@ -171,20 +169,9 @@ test('picking#picking_setPickingColor', t => {
 
     transform.run({uniforms});
 
-    const expectedData = testCase.isPicked.reduce((result, element, index) => {
-      const pickingColor = TEST_DATA.vertexColorData
-        .slice(index * 3, index * 3 + 3)
-        .map(e => e * COLOR_SCALE);
-      result.push(pickingColor[0], pickingColor[1], pickingColor[2], element);
-      return result;
-    }, []);
     const outData = transform.getBuffer('rgbColorASelected').getData();
 
-    outData.forEach((out, index) => {
-      if (Math.abs(out - expectedData[index]) > EPSILON) {
-        t.ok(false, 'Vertex should correctly get picked');
-      }
-    });
+    t.deepEqual(outData, testCase.isPicked, 'Vertex should correctly get picked');
   });
   t.ok(true, 'picking_setPickingColor successful');
 

--- a/modules/shadertools/test/modules/picking/picking.spec.js
+++ b/modules/shadertools/test/modules/picking/picking.spec.js
@@ -69,12 +69,7 @@ const TEST_CASES = [
   },
   {
     pickingSelectedColor: [255, 100, 150],
-    isPicked: [0, 1, 0, 0, 0, 1, 0, 0, 1]
-  },
-  {
-    pickingSelectedColor: [255, 100, 150],
-    pickingThreshold: 5,
-    isPicked: [0, 1, 0, 1, 0, 1, 0, 0, 1]
+    isPicked: [0, 1, 0, 0, 0, 0, 0, 0, 0]
   }
 ];
 
@@ -115,8 +110,7 @@ test('picking#isVertexPicked(pickingSelectedColor invalid)', t => {
 
   TEST_CASES.forEach(testCase => {
     const uniforms = picking.getUniforms({
-      pickingSelectedColor: testCase.pickingSelectedColor,
-      pickingThreshold: testCase.pickingThreshold
+      pickingSelectedColor: testCase.pickingSelectedColor
     });
 
     transform.run({uniforms});


### PR DESCRIPTION
For https://github.com/uber/deck.gl/pull/3721

#### Background

Move generic-purpose shader code into the picking module.

#### Change List
- Add `pickingAttribute` module option
- Add `picking_setPickingAttribute` vertex shader function
