### PR TITLE
DevicePixelRatio: Cache canvas size to avoid expensive setting on each frame

### DIFF
--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -226,7 +226,8 @@ function setDevicePixelRatio(gl, devicePixelRatio, options) {
       const canvasHeight = Math.floor(clientHeight * clampedPixelRatio);
       gl.canvas.width = canvasWidth;
       gl.canvas.height = canvasHeight;
-      devicePixelRatioClamped = gl.drawingBufferWidth !== canvasWidth || gl.drawingBufferHeight !== canvasHeight;
+      devicePixelRatioClamped =
+        gl.drawingBufferWidth !== canvasWidth || gl.drawingBufferHeight !== canvasHeight;
       clampedPixelRatio = Math.max(clampedPixelRatio / 2, 1);
     } while (devicePixelRatioClamped);
     if (devicePixelRatioClamped) {

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -222,8 +222,8 @@ function setDevicePixelRatio(gl, devicePixelRatio, options) {
     // for those cases, reduce devicePixelRatio.
     let clampedPixelRatio = devicePixelRatio;
     do {
-      const canvasWidth = Math.ceil(clientWidth * clampedPixelRatio);
-      const canvasHeight = Math.ceil(clientHeight * clampedPixelRatio);
+      const canvasWidth = Math.floor(clientWidth * clampedPixelRatio);
+      const canvasHeight = Math.floor(clientHeight * clampedPixelRatio);
       gl.canvas.width = canvasWidth;
       gl.canvas.height = canvasHeight;
       devicePixelRatioClamped = gl.drawingBufferWidth !== canvasWidth || gl.drawingBufferHeight !== canvasHeight;

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -203,6 +203,7 @@ function getVersion(gl) {
 // use devicePixelRatio to set canvas width and height
 function setDevicePixelRatio(gl, devicePixelRatio, options) {
   let devicePixelRatioClamped = false;
+  let logWarning = false;
 
   // NOTE: if options.width and options.height not used remove in v8
   const clientWidth =
@@ -229,8 +230,9 @@ function setDevicePixelRatio(gl, devicePixelRatio, options) {
       devicePixelRatioClamped =
         gl.drawingBufferWidth !== canvasWidth || gl.drawingBufferHeight !== canvasHeight;
       clampedPixelRatio = Math.max(clampedPixelRatio / 2, 1);
+      logWarning = logWarning || devicePixelRatioClamped;
     } while (devicePixelRatioClamped);
-    if (devicePixelRatioClamped) {
+    if (logWarning) {
       log.warn(`Device pixel ratio clamped`)();
     }
     Object.assign(gl._canvasSizeInfo, {clientWidth, clientHeight, devicePixelRatio});

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -109,7 +109,8 @@ export function instrumentGLContext(gl, options = {}) {
   gl._version = gl._version || getVersion(gl);
 
   // Cache canvas size information to avoid setting it on every frame.
-  gl._canvasSizeInfo = {};
+  gl.luma = gl.luma || {};
+  gl.luma.canvasSizeInfo = gl.luma.canvasSizeInfo || {};
 
   options = Object.assign({}, contextDefaults, options);
   const {manageState, debug} = options;
@@ -202,39 +203,42 @@ function getVersion(gl) {
 
 // use devicePixelRatio to set canvas width and height
 function setDevicePixelRatio(gl, devicePixelRatio, options) {
-  let devicePixelRatioClamped = false;
-  let logWarning = false;
-
   // NOTE: if options.width and options.height not used remove in v8
   const clientWidth =
     'width' in options ? options.width : gl.canvas.clientWidth || gl.canvas.width || 1;
   const clientHeight =
     'height' in options ? options.height : gl.canvas.clientHeight || gl.canvas.height || 1;
 
-  const cachedSize = gl._canvasSizeInfo;
+  gl.luma = gl.luma || {};
+  gl.luma.canvasSizeInfo = gl.luma.canvasSizeInfo || {};
+  const cachedSize = gl.luma.canvasSizeInfo || {};
   // Check if canvas needs to be resized
   if (
     cachedSize.clientWidth !== clientWidth ||
     cachedSize.clientHeight !== clientHeight ||
     cachedSize.devicePixelRatio !== devicePixelRatio
   ) {
+    let clampedPixelRatio = devicePixelRatio;
+
+    const canvasWidth = Math.floor(clientWidth * clampedPixelRatio);
+    const canvasHeight = Math.floor(clientHeight * clampedPixelRatio);
+    gl.canvas.width = canvasWidth;
+    gl.canvas.height = canvasHeight;
+
     // Note: when devicePixelRatio is too high, it is possible we might hit system limit for
     // drawing buffer width and hight, in those cases they get clamped and resulting aspect ration may not be maintained
     // for those cases, reduce devicePixelRatio.
-    let clampedPixelRatio = devicePixelRatio;
-    do {
-      const canvasWidth = Math.floor(clientWidth * clampedPixelRatio);
-      const canvasHeight = Math.floor(clientHeight * clampedPixelRatio);
-      gl.canvas.width = canvasWidth;
-      gl.canvas.height = canvasHeight;
-      devicePixelRatioClamped =
-        gl.drawingBufferWidth !== canvasWidth || gl.drawingBufferHeight !== canvasHeight;
-      clampedPixelRatio = Math.max(clampedPixelRatio / 2, 1);
-      logWarning = logWarning || devicePixelRatioClamped;
-    } while (devicePixelRatioClamped);
-    if (logWarning) {
+    if (gl.drawingBufferWidth !== canvasWidth || gl.drawingBufferHeight !== canvasHeight) {
       log.warn(`Device pixel ratio clamped`)();
+      clampedPixelRatio = Math.min(
+        gl.drawingBufferWidth / clientWidth,
+        gl.drawingBufferHeight / clientHeight
+      );
+
+      gl.canvas.width = Math.floor(clientWidth * clampedPixelRatio);
+      gl.canvas.height = Math.floor(clientHeight * clampedPixelRatio);
     }
-    Object.assign(gl._canvasSizeInfo, {clientWidth, clientHeight, devicePixelRatio});
+
+    Object.assign(gl.luma.canvasSizeInfo, {clientWidth, clientHeight, devicePixelRatio});
   }
 }

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -211,7 +211,7 @@ function setDevicePixelRatio(gl, devicePixelRatio, options) {
 
   gl.luma = gl.luma || {};
   gl.luma.canvasSizeInfo = gl.luma.canvasSizeInfo || {};
-  const cachedSize = gl.luma.canvasSizeInfo || {};
+  const cachedSize = gl.luma.canvasSizeInfo;
   // Check if canvas needs to be resized
   if (
     cachedSize.clientWidth !== clientWidth ||

--- a/modules/webgl/test/context/context.spec.js
+++ b/modules/webgl/test/context/context.spec.js
@@ -45,8 +45,7 @@ test('WebGL#isWebGL2', t => {
 
 test('WebGL#resizeGLContext', t => {
   const glContext = {
-    canvas: {width: 10, height: 20},
-    _canvasSizeInfo: {}
+    canvas: {width: 10, height: 20}
   };
 
   // update drawing buffer size to simulate gl context

--- a/modules/webgl/test/context/context.spec.js
+++ b/modules/webgl/test/context/context.spec.js
@@ -55,7 +55,7 @@ test('WebGL#resizeGLContext', t => {
   resizeGLContext(glContext);
 
   t.deepEqual(
-    glContext._canvasSizeInfo,
+    glContext.luma.canvasSizeInfo,
     {clientWidth: 10, clientHeight: 20, devicePixelRatio: 1},
     'Canvas size info should be cached'
   );
@@ -66,7 +66,7 @@ test('WebGL#resizeGLContext', t => {
   resizeGLContext(glContext, {useDevicePixels: 12.5});
 
   t.deepEqual(
-    glContext._canvasSizeInfo,
+    glContext.luma.canvasSizeInfo,
     {clientWidth: 10, clientHeight: 20, devicePixelRatio: 12.5},
     'Canvas size info should be updated'
   );

--- a/modules/webgl/test/context/context.spec.js
+++ b/modules/webgl/test/context/context.spec.js
@@ -49,7 +49,7 @@ test('WebGL#resizeGLContext', t => {
     _canvasSizeInfo: {}
   };
 
-  // update drawing buffer size to emmuldate gl context
+  // update drawing buffer size to simulate gl context
   glContext.drawingBufferWidth = glContext.canvas.width;
   glContext.drawingBufferHeight = glContext.canvas.height;
   resizeGLContext(glContext);
@@ -60,7 +60,7 @@ test('WebGL#resizeGLContext', t => {
     'Canvas size info should be cached'
   );
 
-  // update drawing buffer size to emmuldate gl context
+  // update drawing buffer size to simulate gl context
   glContext.drawingBufferWidth = Math.floor(glContext.canvas.width * 12.5);
   glContext.drawingBufferHeight = Math.floor(glContext.canvas.height * 12.5);
   resizeGLContext(glContext, {useDevicePixels: 12.5});

--- a/modules/webgl/test/context/context.spec.js
+++ b/modules/webgl/test/context/context.spec.js
@@ -1,5 +1,5 @@
 const test = require('tape-catch');
-const {createGLContext, glGetDebugInfo, isWebGL, isWebGL2} = require('luma.gl');
+const {createGLContext, glGetDebugInfo, isWebGL, isWebGL2, resizeGLContext} = require('luma.gl');
 const {gl, glDebug, gl2, gl2Debug} = getWebGLContexts({webgl2: false});
 test('WebGL#headless context creation', t => {
   t.ok(isWebGL(gl), 'Context creation ok');
@@ -39,6 +39,37 @@ test('WebGL#isWebGL2', t => {
   }
   t.ok(isWebGL2(gl2), 'isWebGL2 should return true WebGL2 context');
   t.ok(isWebGL2(gl2Debug), 'isWebGL2 should return true on WebGL2 debug context');
+
+  t.end();
+});
+
+test('WebGL#resizeGLContext', t => {
+  const glContext = {
+    canvas: {width: 10, height: 20},
+    _canvasSizeInfo: {}
+  };
+
+  // update drawing buffer size to emmuldate gl context
+  glContext.drawingBufferWidth = glContext.canvas.width;
+  glContext.drawingBufferHeight = glContext.canvas.height;
+  resizeGLContext(glContext);
+
+  t.deepEqual(
+    glContext._canvasSizeInfo,
+    {clientWidth: 10, clientHeight: 20, devicePixelRatio: 1},
+    'Canvas size info should be cached'
+  );
+
+  // update drawing buffer size to emmuldate gl context
+  glContext.drawingBufferWidth = Math.floor(glContext.canvas.width * 12.5);
+  glContext.drawingBufferHeight = Math.floor(glContext.canvas.height * 12.5);
+  resizeGLContext(glContext, {useDevicePixels: 12.5});
+
+  t.deepEqual(
+    glContext._canvasSizeInfo,
+    {clientWidth: 10, clientHeight: 20, devicePixelRatio: 12.5},
+    'Canvas size info should be updated'
+  );
 
   t.end();
 });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For # https://github.com/uber/deck.gl/issues/3728
<!-- For other PRs without open issue -->
#### Background
- When custom device pixel ratio support is added, we would set canvas width/height multiple times, when device size limit is reached. Do this only once per given size and ratio.
- Cache `clientWidth`, `clientHeight` and `devicePixelRatio`,  resize canvas only when any of these prameters are changed.
- Use `Math.floor` when clamping width and height to avoid potential drawing buffer size clamping.
<!-- For all the PRs -->
#### Change List
- DevicePixelRatio: Cache canvas size to avoid expensive setting on each frame
