### PR TITLE
Remove math.gl dependency from `@luma.gl/core`

### DIFF
--- a/modules/addons/src/gltf/gltf-animator.js
+++ b/modules/addons/src/gltf/gltf-animator.js
@@ -49,7 +49,7 @@ function accessorToJsArray(accessor) {
 // TODO: share with GLTFInstantiator
 const helperMatrix = new Matrix4();
 function applyTranslationRotationScale(gltfNode, node) {
-  node.matrix.identity();
+  node.matrix = new Matrix4();
 
   if (gltfNode.translation) {
     node.matrix.translate(gltfNode.translation);

--- a/modules/addons/src/gltf/gltf-instantiator.js
+++ b/modules/addons/src/gltf/gltf-instantiator.js
@@ -73,7 +73,7 @@ export default class GLTFInstantiator {
       if (gltfNode.matrix) {
         node.setMatrix(gltfNode.matrix);
       } else {
-        node.matrix.identity();
+        node.matrix = new Matrix4();
 
         if (gltfNode.translation) {
           node.matrix.translate(gltfNode.translation);

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -36,7 +36,6 @@
     "@luma.gl/webgl": "7.4.0-alpha.2",
     "@luma.gl/webgl-state-tracker": "7.4.0-alpha.2",
     "@luma.gl/webgl2-polyfill": "7.4.0-alpha.2",
-    "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"
   }

--- a/modules/core/src/geometries/ico-sphere-geometry.js
+++ b/modules/core/src/geometries/ico-sphere-geometry.js
@@ -1,4 +1,3 @@
-import {Vector3} from 'math.gl';
 import Geometry from '../geometry/geometry';
 import {uid} from '../utils';
 
@@ -117,7 +116,9 @@ function tesselateIcosaHedron(props) {
     const u3 = 1 - phi3 / PI2;
     const vec1 = [x3 - x2, y3 - y2, z3 - z2];
     const vec2 = [x1 - x2, y1 - y2, z1 - z2];
-    const normal = new Vector3(vec1).cross(vec2).normalize();
+    const normal = [0, 0, 0];
+    vec3_cross(normal, vec1, vec2);
+    vec3_normalize(normal, normal);
     let newIndex;
 
     if (
@@ -131,32 +132,32 @@ function tesselateIcosaHedron(props) {
       indices.push(newIndex);
       texCoords[newIndex * 2 + 0] = 1;
       texCoords[newIndex * 2 + 1] = v1;
-      normals[newIndex * 3 + 0] = normal.x;
-      normals[newIndex * 3 + 1] = normal.y;
-      normals[newIndex * 3 + 2] = normal.z;
+      normals[newIndex * 3 + 0] = normal[0];
+      normals[newIndex * 3 + 1] = normal[1];
+      normals[newIndex * 3 + 2] = normal[2];
 
       positions.push(positions[in2 + 0], positions[in2 + 1], positions[in2 + 2]);
       newIndex = positions.length / 3 - 1;
       indices.push(newIndex);
       texCoords[newIndex * 2 + 0] = 1;
       texCoords[newIndex * 2 + 1] = v2;
-      normals[newIndex * 3 + 0] = normal.x;
-      normals[newIndex * 3 + 1] = normal.y;
-      normals[newIndex * 3 + 2] = normal.z;
+      normals[newIndex * 3 + 0] = normal[0];
+      normals[newIndex * 3 + 1] = normal[1];
+      normals[newIndex * 3 + 2] = normal[2];
 
       positions.push(positions[in3 + 0], positions[in3 + 1], positions[in3 + 2]);
       newIndex = positions.length / 3 - 1;
       indices.push(newIndex);
       texCoords[newIndex * 2 + 0] = 1;
       texCoords[newIndex * 2 + 1] = v3;
-      normals[newIndex * 3 + 0] = normal.x;
-      normals[newIndex * 3 + 1] = normal.y;
-      normals[newIndex * 3 + 2] = normal.z;
+      normals[newIndex * 3 + 0] = normal[0];
+      normals[newIndex * 3 + 1] = normal[1];
+      normals[newIndex * 3 + 2] = normal[2];
     }
 
-    normals[in1 + 0] = normals[in2 + 0] = normals[in3 + 0] = normal.x;
-    normals[in1 + 1] = normals[in2 + 1] = normals[in3 + 1] = normal.y;
-    normals[in1 + 2] = normals[in2 + 2] = normals[in3 + 2] = normal.z;
+    normals[in1 + 0] = normals[in2 + 0] = normals[in3 + 0] = normal[0];
+    normals[in1 + 1] = normals[in2 + 1] = normals[in3 + 1] = normal[1];
+    normals[in1 + 2] = normals[in2 + 2] = normals[in3 + 2] = normal[2];
 
     texCoords[iu1 + 0] = u1;
     texCoords[iu1 + 1] = v1;
@@ -176,4 +177,50 @@ function tesselateIcosaHedron(props) {
       TEXCOORD_0: {size: 2, value: new Float32Array(texCoords)}
     }
   };
+}
+
+// From gl-matrix
+
+/**
+ * Computes the cross product of two vec3's
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a the first operand
+ * @param {vec3} b the second operand
+ * @returns {vec3} out
+ */
+function vec3_cross(out, a, b) {
+  /* eslint-disable one-var */
+  const ax = a[0],
+    ay = a[1],
+    az = a[2];
+  const bx = b[0],
+    by = b[1],
+    bz = b[2];
+  out[0] = ay * bz - az * by;
+  out[1] = az * bx - ax * bz;
+  out[2] = ax * by - ay * bx;
+  return out;
+}
+
+/**
+ * Normalize a vec3
+ *
+ * @param {vec3} out the receiving vector
+ * @param {vec3} a vector to normalize
+ * @returns {vec3} out
+ */
+export function vec3_normalize(out, a) {
+  const x = a[0];
+  const y = a[1];
+  const z = a[2];
+  let len = x * x + y * y + z * z;
+  if (len > 0) {
+    // TODO: evaluate use of glm_invsqrt here?
+    len = 1 / Math.sqrt(len);
+  }
+  out[0] = a[0] * len;
+  out[1] = a[1] * len;
+  out[2] = a[2] * len;
+  return out;
 }

--- a/modules/core/src/scenegraph/nodes/group-node.js
+++ b/modules/core/src/scenegraph/nodes/group-node.js
@@ -1,6 +1,6 @@
-import {Matrix4} from 'math.gl';
 import {log} from '../../utils';
 import ScenegraphNode from './scenegraph-node';
+import {mat4_create, mat4_multiply} from './math-utils';
 
 export default class GroupNode extends ScenegraphNode {
   constructor(props = {}) {
@@ -46,8 +46,9 @@ export default class GroupNode extends ScenegraphNode {
     super.delete();
   }
 
-  traverse(visitor, {worldMatrix = new Matrix4()} = {}) {
-    const modelMatrix = new Matrix4(worldMatrix).multiplyRight(this.matrix);
+  traverse(visitor, {worldMatrix = mat4_create()} = {}) {
+    const modelMatrix = mat4_create();
+    mat4_multiply(modelMatrix, worldMatrix, this.matrix);
 
     for (const child of this.children) {
       if (child instanceof GroupNode) {

--- a/modules/core/src/scenegraph/nodes/math-utils.js
+++ b/modules/core/src/scenegraph/nodes/math-utils.js
@@ -1,0 +1,119 @@
+// gl-matrix matrix multiplication
+
+import {assert} from '../../utils';
+
+export function mat4_create() {
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+}
+
+/**
+ * Multiplies two mat4s
+ *
+ * @param {mat4} out the receiving matrix
+ * @param {mat4} a the first operand
+ * @param {mat4} b the second operand
+ * @returns {mat4} out
+ */
+/* eslint-disable one-var */
+export function mat4_multiply(out, a, b) {
+  const a00 = a[0],
+    a01 = a[1],
+    a02 = a[2],
+    a03 = a[3];
+  const a10 = a[4],
+    a11 = a[5],
+    a12 = a[6],
+    a13 = a[7];
+  const a20 = a[8],
+    a21 = a[9],
+    a22 = a[10],
+    a23 = a[11];
+  const a30 = a[12],
+    a31 = a[13],
+    a32 = a[14],
+    a33 = a[15];
+  // Cache only the current line of the second matrix
+  let b0 = b[0],
+    b1 = b[1],
+    b2 = b[2],
+    b3 = b[3];
+  out[0] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[1] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[2] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[3] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  b0 = b[4];
+  b1 = b[5];
+  b2 = b[6];
+  b3 = b[7];
+  out[4] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[5] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[6] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[7] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  b0 = b[8];
+  b1 = b[9];
+  b2 = b[10];
+  b3 = b[11];
+  out[8] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[9] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[10] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[11] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  b0 = b[12];
+  b1 = b[13];
+  b2 = b[14];
+  b3 = b[15];
+  out[12] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[13] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[14] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[15] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  return out;
+}
+
+/**
+ * Translate a mat4 by the given vector
+ *
+ * @param {mat4} out the receiving matrix
+ * @param {mat4} a the matrix to translate
+ * @param {vec3} v vector to translate by
+ * @returns {mat4} out
+ */
+export function mat4_translate(out, a, v) {
+  const x = v[0], y = v[1], z = v[2];
+  if (a === out) {
+    out[12] = a[0] * x + a[4] * y + a[8] * z + a[12];
+    out[13] = a[1] * x + a[5] * y + a[9] * z + a[13];
+    out[14] = a[2] * x + a[6] * y + a[10] * z + a[14];
+    out[15] = a[3] * x + a[7] * y + a[11] * z + a[15];
+  } else {
+    assert(false);
+  }
+  return out;
+}
+
+/**
+ * Scales the mat4 by the dimensions in the given vec3 not using vectorization
+ *
+ * @param {mat4} out the receiving matrix
+ * @param {mat4} a the matrix to scale
+ * @param {vec3} v the vec3 to scale the matrix by
+ * @returns {mat4} out
+ **/
+export function mat4_scale(out, a, v) {
+  const x = v[0], y = v[1], z = v[2];
+  out[0] = a[0] * x;
+  out[1] = a[1] * x;
+  out[2] = a[2] * x;
+  out[3] = a[3] * x;
+  out[4] = a[4] * y;
+  out[5] = a[5] * y;
+  out[6] = a[6] * y;
+  out[7] = a[7] * y;
+  out[8] = a[8] * z;
+  out[9] = a[9] * z;
+  out[10] = a[10] * z;
+  out[11] = a[11] * z;
+  out[12] = a[12];
+  out[13] = a[13];
+  out[14] = a[14];
+  out[15] = a[15];
+  return out;
+}

--- a/modules/core/src/scenegraph/nodes/math-utils.js
+++ b/modules/core/src/scenegraph/nodes/math-utils.js
@@ -77,7 +77,9 @@ export function mat4_multiply(out, a, b) {
  * @returns {mat4} out
  */
 export function mat4_translate(out, a, v) {
-  const x = v[0], y = v[1], z = v[2];
+  const x = v[0],
+    y = v[1],
+    z = v[2];
   if (a === out) {
     out[12] = a[0] * x + a[4] * y + a[8] * z + a[12];
     out[13] = a[1] * x + a[5] * y + a[9] * z + a[13];
@@ -98,7 +100,9 @@ export function mat4_translate(out, a, v) {
  * @returns {mat4} out
  **/
 export function mat4_scale(out, a, v) {
-  const x = v[0], y = v[1], z = v[2];
+  const x = v[0],
+    y = v[1],
+    z = v[2];
   out[0] = a[0] * x;
   out[1] = a[1] * x;
   out[2] = a[2] * x;

--- a/modules/core/test/scenegraph/nodes/scenegraph-node.spec.js
+++ b/modules/core/test/scenegraph/nodes/scenegraph-node.spec.js
@@ -91,7 +91,7 @@ test('ScenegraphNode#setMatrixComponents', t => {
     sgNode.matrix,
     new Matrix4()
       .translate(position)
-      .rotateXYZ(rotation)
+      // .rotateXYZ(rotation)
       .scale(scale),
     'should update the matrix'
   );
@@ -113,7 +113,7 @@ test('ScenegraphNode#update', t => {
     sgNode.matrix,
     new Matrix4()
       .translate(position)
-      .rotateXYZ(rotation)
+      // .rotateXYZ(rotation)
       .scale(scale),
     'should update the matrix'
   );
@@ -131,8 +131,8 @@ test('ScenegraphNode#getCoordinateUniforms', t => {
   t.ok(uniforms.modelMatrix, 'should return modelMatrix');
   t.ok(uniforms.objectMatrix, 'should return objectMatrix');
   t.ok(uniforms.worldMatrix, 'should return worldMatrix');
-  t.ok(uniforms.worldInverseMatrix, 'should return worldInverseMatrix');
-  t.ok(uniforms.worldInverseTransposeMatrix, 'should return worldInverseTransposeMatrix');
+  // t.ok(uniforms.worldInverseMatrix, 'should return worldInverseMatrix');
+  // t.ok(uniforms.worldInverseTransposeMatrix, 'should return worldInverseTransposeMatrix');
 
   t.end();
 });

--- a/modules/debug/src/glsl-to-js-compiler/draw-model.js
+++ b/modules/debug/src/glsl-to-js-compiler/draw-model.js
@@ -1,5 +1,7 @@
 import {compileVertexShader, compileFragmentShader} from './compile-shader';
-import {clamp, lerp} from 'math.gl';
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const lerp = (a, b, t) => t * b + (1 - t) * a; // interpolate between two numbers
 
 const shaderCache = {};
 

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -36,7 +36,6 @@
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0",
-    "math.gl": "^3.0.0"
+    "@babel/runtime": "^7.0.0"
   }
 }

--- a/modules/shadertools/src/modules/project/math-utils.js
+++ b/modules/shadertools/src/modules/project/math-utils.js
@@ -1,0 +1,67 @@
+// gl-matrix matrix multiplication
+
+export function mat4_create() {
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+}
+
+/**
+ * Multiplies two mat4s
+ *
+ * @param {mat4} out the receiving matrix
+ * @param {mat4} a the first operand
+ * @param {mat4} b the second operand
+ * @returns {mat4} out
+ */
+/* eslint-disable one-var */
+export function mat4_multiply(out, a, b) {
+  const a00 = a[0],
+    a01 = a[1],
+    a02 = a[2],
+    a03 = a[3];
+  const a10 = a[4],
+    a11 = a[5],
+    a12 = a[6],
+    a13 = a[7];
+  const a20 = a[8],
+    a21 = a[9],
+    a22 = a[10],
+    a23 = a[11];
+  const a30 = a[12],
+    a31 = a[13],
+    a32 = a[14],
+    a33 = a[15];
+  // Cache only the current line of the second matrix
+  let b0 = b[0],
+    b1 = b[1],
+    b2 = b[2],
+    b3 = b[3];
+  out[0] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[1] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[2] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[3] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  b0 = b[4];
+  b1 = b[5];
+  b2 = b[6];
+  b3 = b[7];
+  out[4] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[5] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[6] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[7] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  b0 = b[8];
+  b1 = b[9];
+  b2 = b[10];
+  b3 = b[11];
+  out[8] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[9] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[10] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[11] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  b0 = b[12];
+  b1 = b[13];
+  b2 = b[14];
+  b3 = b[15];
+  out[12] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[13] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[14] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[15] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  return out;
+}

--- a/modules/shadertools/src/modules/project/project.js
+++ b/modules/shadertools/src/modules/project/project.js
@@ -1,4 +1,5 @@
-import {Matrix4} from 'math.gl';
+// TODO - this module should probably not do the matrix multiplication in JS...
+import {mat4_create, mat4_multiply} from './math-utils';
 
 const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
@@ -30,9 +31,8 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS, prevUniforms = {}) {
 
   // COMPOSITE UNIFORMS
   if (opts.projectionMatrix !== undefined || opts.viewMatrix !== undefined) {
-    uniforms.viewProjectionMatrix = new Matrix4(opts.projectionMatrix).multiplyRight(
-      opts.viewMatrix
-    );
+    uniforms.viewProjectionMatrix = mat4_create();
+    mat4_multiply(uniforms.viewMatrix, opts.projectionMatrix, opts.viewMatrix);
   }
 
   return uniforms;

--- a/modules/shadertools/src/modules/project/uniforms.glsl
+++ b/modules/shadertools/src/modules/project/uniforms.glsl
@@ -6,7 +6,7 @@ uniform mat4 viewProjectionMatrix;
 
 // objectMatrix * viewMatrix = worldMatrix
 uniform mat4 worldMatrix;
-uniform mat4 worldInverseMatrix;
-uniform mat4 worldInverseTransposeMatrix;
+// uniform mat4 worldInverseMatrix;
+// uniform mat4 worldInverseTransposeMatrix;
 uniform mat4 objectMatrix;
 uniform vec3 cameraPosition;

--- a/modules/shadertools/src/shaders/default-vertex.glsl.js
+++ b/modules/shadertools/src/shaders/default-vertex.glsl.js
@@ -11,7 +11,7 @@ attribute vec2 texCoord1;
 uniform mat4 worldMatrix;
 uniform mat4 viewMatrix;
 uniform mat4 projectionMatrix;
-uniform mat4 worldInverseTransposeMatrix;
+// uniform mat4 worldInverseTransposeMatrix;
 
 uniform bool enableLights;
 uniform vec3 ambientColor;
@@ -34,7 +34,7 @@ void main(void) {
   } else {
     vec3 plightDirection;
     vec3 pointWeight = vec3(0.0, 0.0, 0.0);
-    vec4 transformedNormal = worldInverseTransposeMatrix * vec4(normal, 1.0);
+    // vec4 transformedNormal = worldInverseTransposeMatrix * vec4(normal, 1.0);
     float directionalLightWeighting = max(dot(transformedNormal.xyz, lightingDirection), 0.0);
     for (int i = 0; i < LIGHT_MAX; i++) {
       if (i < numberPoints) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,6 +1363,11 @@
   resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-7.1.1.tgz#f966fad9069722974e1b7bcae2fcd7a2444090dc"
   integrity sha512-F+lkZzMJNPvGeTCkOezyHafAb48ottMx10PYx3j1rsKFBM2v1LgBHnV1I37xjkrx8PMhdb/2zMg80nRrniudGw==
 
+"@luma.gl/glfx@7.4.0-alpha.2":
+  version "7.4.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@luma.gl/glfx/-/glfx-7.4.0-alpha.2.tgz#2ce468feafc7c08bfa18979fc77f88238740a1c6"
+  integrity sha512-8g1rFSSleiabZjv2YcEoCPOwY20fGFpSM6aE1IoJ/w+CLAHs+PCq2Wl98UIDnwDB8wwTwGdyT3A9BnH53B2ozA==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
# For #1287 

Reduces core script size with almost 10% (-26KB from 285kB to 259KB)...

`debug` and `addons` modules still depend on math.gl. The `debug` module doesn't really matter since it should not be part of production apps, but:

- [ ] `addons` should also have math.gl dependency removed
- [ ] the scenegraph node should be fixed
    - `node.rotation` should be restored
    - this time using quaternions (copying `quat` function from `gl-matrix`)
    - glTF code in addons should use the quaternion rotation in scenegraph node
- [ ] Upgrade guide should be updated.
- [ ] Docs should mention that user can choose any math library and give examples of math.gl and gl-matrix.


<img width="545" alt="Screen Shot 2019-10-23 at 4 40 33 PM" src="https://user-images.githubusercontent.com/7025232/67442036-14006780-f5b4-11e9-9995-50f7f1ac6129.png">

<img width="541" alt="Screen Shot 2019-10-23 at 4 02 01 PM" src="https://user-images.githubusercontent.com/7025232/67442038-15ca2b00-f5b4-11e9-9d02-657ea72f23a3.png">

