### PR TITLE
DevicePixelRatio: Handle invalid client sizes and remove custom width/height support.

### DIFF
--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -204,19 +204,16 @@ function getVersion(gl) {
 // use devicePixelRatio to set canvas width and height
 function setDevicePixelRatio(gl, devicePixelRatio, options) {
   // NOTE: if options.width and options.height not used remove in v8
-  let clientWidth =
-    'width' in options ? options.width : gl.canvas.clientWidth;
-  let clientHeight =
-    'height' in options ? options.height : gl.canvas.clientHeight;
+  let clientWidth = 'width' in options ? options.width : gl.canvas.clientWidth;
+  let clientHeight = 'height' in options ? options.height : gl.canvas.clientHeight;
 
   if (!clientWidth || !clientHeight) {
-    log.warn('Canvas clientWidht orclientHeight is 0, using devicePixelRatio of 1.0')();
+    log.warn('Canvas clientWidth/clientHeight is 0')();
     // by forcing devicePixel ratio to 1, we do not scale gl.canvas.width and height in each frame.
     devicePixelRatio = 1;
     clientWidth = gl.canvas.width || 1;
     clientHeight = gl.canvas.height || 1;
   }
-
 
   gl.luma = gl.luma || {};
   gl.luma.canvasSizeInfo = gl.luma.canvasSizeInfo || {};

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -204,10 +204,19 @@ function getVersion(gl) {
 // use devicePixelRatio to set canvas width and height
 function setDevicePixelRatio(gl, devicePixelRatio, options) {
   // NOTE: if options.width and options.height not used remove in v8
-  const clientWidth =
-    'width' in options ? options.width : gl.canvas.clientWidth || gl.canvas.width || 1;
-  const clientHeight =
-    'height' in options ? options.height : gl.canvas.clientHeight || gl.canvas.height || 1;
+  let clientWidth =
+    'width' in options ? options.width : gl.canvas.clientWidth;
+  let clientHeight =
+    'height' in options ? options.height : gl.canvas.clientHeight;
+
+  if (!clientWidth || !clientHeight) {
+    log.warn('Canvas clientWidht orclientHeight is 0, using devicePixelRatio of 1.0')();
+    // by forcing devicePixel ratio to 1, we do not scale gl.canvas.width and height in each frame.
+    devicePixelRatio = 1;
+    clientWidth = gl.canvas.width || 1;
+    clientHeight = gl.canvas.height || 1;
+  }
+
 
   gl.luma = gl.luma || {};
   gl.luma.canvasSizeInfo = gl.luma.canvasSizeInfo || {};

--- a/modules/webgl/src/context/context.js
+++ b/modules/webgl/src/context/context.js
@@ -208,7 +208,7 @@ function setDevicePixelRatio(gl, devicePixelRatio, options) {
   let clientHeight = 'height' in options ? options.height : gl.canvas.clientHeight;
 
   if (!clientWidth || !clientHeight) {
-    log.warn('Canvas clientWidth/clientHeight is 0')();
+    log.log(1, 'Canvas clientWidth/clientHeight is 0')();
     // by forcing devicePixel ratio to 1, we do not scale gl.canvas.width and height in each frame.
     devicePixelRatio = 1;
     clientWidth = gl.canvas.width || 1;

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -2,8 +2,12 @@
 
 // multiplier need to convert CSS size to Device size
 export function cssToDeviceRatio(gl) {
+  if (!gl.canvas.clientWidth || !gl.canvas.clientHeight) {
+    // canvas client size is not valid, use 1.0 to avoid invalid scaling.
+    return 1;
+  }
   if (gl.canvas) {
-    return gl.drawingBufferWidth / (gl.canvas.clientWidth || gl.canvas.width || 1);
+    return gl.drawingBufferWidth / (gl.canvas.clientWidth || 1);
   }
   // use default device pixel ratio
   return 1;

--- a/modules/webgl/src/utils/device-pixels.js
+++ b/modules/webgl/src/utils/device-pixels.js
@@ -2,12 +2,11 @@
 
 // multiplier need to convert CSS size to Device size
 export function cssToDeviceRatio(gl) {
-  if (!gl.canvas.clientWidth || !gl.canvas.clientHeight) {
-    // canvas client size is not valid, use 1.0 to avoid invalid scaling.
-    return 1;
-  }
-  if (gl.canvas) {
-    return gl.drawingBufferWidth / (gl.canvas.clientWidth || 1);
+  if (gl.canvas && gl.luma) {
+    // For headless gl we might have used custom width and height
+    // hence use cached clientWidth
+    const {clientWidth} = gl.luma.canvasSizeInfo;
+    return clientWidth ? gl.drawingBufferWidth / clientWidth : 1;
   }
   // use default device pixel ratio
   return 1;

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -10,9 +10,12 @@ const MAP_TEST_CASES = [
     gl: {
       drawingBufferWidth: 10,
       drawingBufferHeight: 10,
-      canvas: {
-        clientWidth: 10,
-        clientHeight: 10
+      canvas: {}, // To emulate real context
+      luma: {
+        canvasSizeInfo: {
+          clientWidth: 10,
+          clientHeight: 10
+        }
       }
     },
     ratio: 1,
@@ -63,9 +66,12 @@ const MAP_TEST_CASES = [
     gl: {
       drawingBufferWidth: 1,
       drawingBufferHeight: 1,
-      canvas: {
-        clientWidth: 1,
-        clientHeight: 1
+      canvas: {},
+      luma: {
+        canvasSizeInfo: {
+          clientWidth: 1,
+          clientHeight: 1
+        }
       }
     },
     ratio: 1,
@@ -92,9 +98,12 @@ const MAP_TEST_CASES = [
     gl: {
       drawingBufferWidth: 10 * HIGH_DPR,
       drawingBufferHeight: 10 * HIGH_DPR,
-      canvas: {
-        clientWidth: 10,
-        clientHeight: 10
+      canvas: {},
+      luma: {
+        canvasSizeInfo: {
+          clientWidth: 10,
+          clientHeight: 10
+        }
       }
     },
     ratio: HIGH_DPR,
@@ -148,9 +157,12 @@ const MAP_TEST_CASES = [
     gl: {
       drawingBufferWidth: 10 * HIGH_DPR_FRACTION,
       drawingBufferHeight: 10 * HIGH_DPR_FRACTION,
-      canvas: {
-        clientWidth: 10,
-        clientHeight: 10
+      canvas: {},
+      luma: {
+        canvasSizeInfo: {
+          clientWidth: 10,
+          clientHeight: 10
+        }
       }
     },
     ratio: HIGH_DPR_FRACTION,
@@ -208,9 +220,12 @@ const MAP_TEST_CASES = [
     gl: {
       drawingBufferWidth: 10 * LOW_DPR,
       drawingBufferHeight: 10 * LOW_DPR,
-      canvas: {
-        clientWidth: 10,
-        clientHeight: 10
+      canvas: {},
+      luma: {
+        canvasSizeInfo: {
+          clientWidth: 10,
+          clientHeight: 10
+        }
       }
     },
     ratio: LOW_DPR,
@@ -313,7 +328,7 @@ test('webgl#getDevicePixelRatio', t => {
   t.end();
 });
 
-test('webgl#cssToDevicePixels', t => {
+test.only('webgl#cssToDevicePixels', t => {
   MAP_TEST_CASES.forEach(tc => {
     tc.windowPositions.forEach((wPos, i) => {
       // by default yInvert is true

--- a/modules/webgl/test/utils/device-pixels.spec.js
+++ b/modules/webgl/test/utils/device-pixels.spec.js
@@ -328,7 +328,7 @@ test('webgl#getDevicePixelRatio', t => {
   t.end();
 });
 
-test.only('webgl#cssToDevicePixels', t => {
+test('webgl#cssToDevicePixels', t => {
   MAP_TEST_CASES.forEach(tc => {
     tc.windowPositions.forEach((wPos, i) => {
       // by default yInvert is true


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Related to deck.gl issue 3842
<!-- For other PRs without open issue -->
#### Background
- When canvas's `clientWidth` or `clientHeight` is 0 or `undefined` we are falling back to `gl.canvas.width/height`. But `gl.canvas.width/height` may have been scaled with device pixel ratio in previous frame. To avoid this continuous scaling, set `devicePixelRatio` to 1 in such cases.
- Add unit tests.

<!-- For all the PRs -->
#### Change List
- DevicePixelRatio: Handle the case when clientWidth/Height not available
