### PR TITLE
Fix deps, simplify materials

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -34,6 +34,7 @@
     "@luma.gl/constants": "8.0.0-alpha.3",
     "@luma.gl/shadertools": "8.0.0-alpha.3",
     "@luma.gl/webgl": "8.0.0-alpha.3",
+    "@luma.gl/engine": "8.0.0-alpha.3",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -83,6 +83,7 @@ export {
   Transform,
   ClipSpace,
   ProgramManager,
+  Timeline,
   Geometry,
   ConeGeometry,
   CubeGeometry,

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -115,8 +115,8 @@ export {
   dirlight,
   picking,
   diffuse,
-  gouraudlighting,
-  phonglighting,
+  gouraudLighting,
+  phongLighting,
   pbr,
   // experimental
   _transform,

--- a/modules/shadertools/src/modules/index.js
+++ b/modules/shadertools/src/modules/index.js
@@ -6,7 +6,7 @@ export {default as lights} from './lights/lights';
 export {default as dirlight} from './dirlight/dirlight';
 export {default as picking} from './picking/picking';
 export {default as diffuse} from './diffuse/diffuse';
-export {gouraudlighting, phonglighting} from './phong-lighting/phong-lighting';
+export {gouraudLighting, phongLighting} from './phong-lighting/phong-lighting';
 export {default as pbr} from './pbr/pbr';
 
 // experimental

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -21,22 +21,17 @@ const phongLighting = {
   getUniforms
 };
 
-const DEFAULT_MATERIAL_PROPERTIES = {
-  ambient: 0.35,
-  diffuse: 0.6,
-  shininess: 32,
-  specularColor: [30, 30, 30]
-};
-
 const INITIAL_MODULE_OPTIONS = {};
 
 function getMaterialUniforms(material) {
-  const materialUniforms = {};
-  materialUniforms.lighting_uAmbient = material.ambient;
-  materialUniforms.lighting_uDiffuse = material.diffuse;
-  materialUniforms.lighting_uShininess = material.shininess;
-  materialUniforms.lighting_uSpecularColor = material.specularColor.map(x => x / 255);
-  return materialUniforms;
+  const {ambient = 0.35, diffuse = 0.6, shininess = 32, specularColor = [30, 30, 30]} = material;
+
+  return {
+    lighting_uAmbient: ambient,
+    lighting_uDiffuse: diffuse,
+    lighting_uShininess: shininess,
+    lighting_uSpecularColor: specularColor.map(x => x / 255)
+  };
 }
 
 function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
@@ -50,7 +45,7 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
     return {lighting_uEnabled: false};
   }
 
-  return getMaterialUniforms(Object.assign({}, DEFAULT_MATERIAL_PROPERTIES, material));
+  return getMaterialUniforms(material);
 }
 
 export {gouraudLighting, phongLighting};

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -1,7 +1,7 @@
 import lights from '../lights/lights';
 import lightingShader from './phong-lighting.glsl';
 
-const gouraudlighting = {
+const gouraudLighting = {
   name: 'gouraud-lighting',
   dependencies: [lights],
   vs: lightingShader,
@@ -11,7 +11,7 @@ const gouraudlighting = {
   getUniforms
 };
 
-const phonglighting = {
+const phongLighting = {
   name: 'phong-lighting',
   dependencies: [lights],
   fs: lightingShader,
@@ -53,4 +53,4 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
   return getMaterialUniforms(Object.assign({}, DEFAULT_MATERIAL_PROPERTIES, material));
 }
 
-export {gouraudlighting, phonglighting};
+export {gouraudLighting, phongLighting};

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.js
@@ -21,6 +21,13 @@ const phonglighting = {
   getUniforms
 };
 
+const DEFAULT_MATERIAL_PROPERTIES = {
+  ambient: 0.35,
+  diffuse: 0.6,
+  shininess: 32,
+  specularColor: [30, 30, 30]
+};
+
 const INITIAL_MODULE_OPTIONS = {};
 
 function getMaterialUniforms(material) {
@@ -43,7 +50,7 @@ function getUniforms(opts = INITIAL_MODULE_OPTIONS) {
     return {lighting_uEnabled: false};
   }
 
-  return getMaterialUniforms(material);
+  return getMaterialUniforms(Object.assign({}, DEFAULT_MATERIAL_PROPERTIES, material));
 }
 
 export {gouraudlighting, phonglighting};

--- a/modules/shadertools/test/modules/phong-lighting/phong-lighting.spec.js
+++ b/modules/shadertools/test/modules/phong-lighting/phong-lighting.spec.js
@@ -23,5 +23,17 @@ test('shadertools#phonglighting', t => {
   });
   t.equal(uniforms.lighting_uEnabled, false, 'Disable lighting without material');
 
+  uniforms = phonglighting.getUniforms({
+    material: true
+  });
+  t.equal(uniforms.lighting_uAmbient, 0.35, `lighting_uAmbient`);
+  t.equal(uniforms.lighting_uDiffuse, 0.6, `lighting_uDiffuse`);
+  t.equal(uniforms.lighting_uShininess, 32, `lighting_uShininess`);
+  t.deepEqual(
+    uniforms.lighting_uSpecularColor,
+    [30 / 255, 30 / 255, 30 / 255],
+    `lighting_uSpecularColor`
+  );
+
   t.end();
 });

--- a/modules/shadertools/test/modules/phong-lighting/phong-lighting.spec.js
+++ b/modules/shadertools/test/modules/phong-lighting/phong-lighting.spec.js
@@ -1,11 +1,11 @@
 import test from 'tape-catch';
-import {phonglighting} from '@luma.gl/shadertools';
+import {phongLighting} from '@luma.gl/shadertools';
 
-test('shadertools#phonglighting', t => {
-  let uniforms = phonglighting.getUniforms();
+test('shadertools#phongLighting', t => {
+  let uniforms = phongLighting.getUniforms();
   t.deepEqual(uniforms, {}, `Default phong lighting uniforms ok`);
 
-  uniforms = phonglighting.getUniforms({
+  uniforms = phongLighting.getUniforms({
     material: {ambient: 0.0, diffuse: 0.0, shininess: 0.0, specularColor: [255, 0, 0]}
   });
   t.equal(
@@ -18,12 +18,12 @@ test('shadertools#phonglighting', t => {
   t.is(uniforms.lighting_uShininess, 0, `lighting_uShininess`);
   t.deepEqual(uniforms.lighting_uSpecularColor, [1, 0, 0], `lighting_uSpecularColor`);
 
-  uniforms = phonglighting.getUniforms({
+  uniforms = phongLighting.getUniforms({
     material: null
   });
   t.equal(uniforms.lighting_uEnabled, false, 'Disable lighting without material');
 
-  uniforms = phonglighting.getUniforms({
+  uniforms = phongLighting.getUniforms({
     material: true
   });
   t.equal(uniforms.lighting_uAmbient, 0.35, `lighting_uAmbient`);


### PR DESCRIPTION
- Fix missing core dependency on engine
- Export `Timeline` from core
- Allow for default material parameters in phong lighting by passing `material: true`
- Fix case of `gouraudLighting` and `phongLighting` module names