### PR TITLE
Small optimizations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     camelcase: 0,
     'max-statements': 0,
     'max-depth': 0,
+    complexity: 0,
     'luma-gl-custom-rules/check-log-call': 1,
     'import/no-unresolved': ['error'],
     'import/no-extraneous-dependencies': [

--- a/modules/gltools/src/state-tracker/track-context-state.js
+++ b/modules/gltools/src/state-tracker/track-context-state.js
@@ -71,6 +71,17 @@ function installSetterSpy(gl, functionName, setter) {
   });
 }
 
+function installProgramSpy(gl) {
+  const originalUseProgram = gl.useProgram.bind(gl);
+
+  gl.useProgram = function useProgramLuma(handle) {
+    if (gl.state.program !== handle) {
+      originalUseProgram(handle);
+      gl.state.program = handle;
+    }
+  };
+}
+
 // HELPER CLASS - GLState
 
 /* eslint-disable no-shadow */
@@ -83,6 +94,7 @@ class GLState {
     } = {}
   ) {
     this.gl = gl;
+    this.program = null;
     this.stateStack = [];
     this.enable = true;
     this.cache = copyState ? getParameters(gl) : Object.assign({}, GL_PARAMETER_DEFAULTS);
@@ -159,6 +171,8 @@ export default function trackContextState(gl, {enable = true, copyState} = {}) {
 
     // Create a state cache
     gl.state = new GLState(gl, {copyState, enable});
+
+    installProgramSpy(gl);
 
     // intercept all setter functions in the table
     for (const key in GL_HOOKED_SETTERS) {

--- a/modules/gltools/src/state-tracker/unified-parameter-api.js
+++ b/modules/gltools/src/state-tracker/unified-parameter-api.js
@@ -15,6 +15,10 @@ import {isObjectEmpty} from './utils';
 // Note: requires a `cache` object to be set on the context (gl.state.cache)
 // This object is used to fill in any missing values for composite setter functions
 export function setParameters(gl, values) {
+  if (isObjectEmpty(values)) {
+    return;
+  }
+
   const compositeSetters = {};
 
   // HANDLE PRIMITIVE SETTERS (and make note of any composite setters)

--- a/modules/webgl/src/classes/program.js
+++ b/modules/webgl/src/classes/program.js
@@ -70,7 +70,7 @@ export default class Program extends Resource {
     // uniforms
     this.uniforms = {};
 
-    this._texturesUniforms = {};
+    this._textureUniforms = {};
     this._texturesRenderable = true;
 
     // Setup varyings if supplied
@@ -227,12 +227,12 @@ export default class Program extends Resource {
               this._texturesRenderable = false;
             }
 
-            this._texturesUniforms[uniformName] = texture;
+            this._textureUniforms[uniformName] = texture;
           } else {
             value = uniformSetter.textureIndex;
           }
-        } else if (this._texturesUniforms[uniformName]) {
-          delete this._texturesUniforms[uniformName];
+        } else if (this._textureUniforms[uniformName]) {
+          delete this._textureUniforms[uniformName];
         }
 
         // NOTE(Tarek): uniformSetter returns whether
@@ -282,9 +282,9 @@ export default class Program extends Resource {
   // Binds textures
   // Note: This is currently done before every draw call
   _bindTextures() {
-    for (const uniformName in this._texturesUniforms) {
+    for (const uniformName in this._textureUniforms) {
       const textureIndex = this._uniformSetters[uniformName].textureIndex;
-      this.uniforms[uniformName].bind(textureIndex);
+      this._textureUniforms[uniformName].bind(textureIndex);
     }
   }
 

--- a/modules/webgl/src/classes/program.js
+++ b/modules/webgl/src/classes/program.js
@@ -70,6 +70,7 @@ export default class Program extends Resource {
     // uniforms
     this.uniforms = {};
 
+    this._texturesUniforms = {};
     this._texturesRenderable = true;
 
     // Setup varyings if supplied
@@ -202,6 +203,7 @@ export default class Program extends Resource {
       if (uniformSetter) {
         let value = uniform;
         let textureUpdate = false;
+
         if (value instanceof Framebuffer) {
           value = value.texture;
         }
@@ -224,9 +226,13 @@ export default class Program extends Resource {
             if (!texture.loaded) {
               this._texturesRenderable = false;
             }
+
+            this._texturesUniforms[uniformName] = texture;
           } else {
             value = uniformSetter.textureIndex;
           }
+        } else if (this._texturesUniforms[uniformName]) {
+          delete this._texturesUniforms[uniformName];
         }
 
         // NOTE(Tarek): uniformSetter returns whether
@@ -276,21 +282,9 @@ export default class Program extends Resource {
   // Binds textures
   // Note: This is currently done before every draw call
   _bindTextures() {
-    for (const uniformName in this.uniforms) {
-      const uniformSetter = this._uniformSetters[uniformName];
-
-      if (uniformSetter && uniformSetter.textureIndex !== undefined) {
-        let uniform = this.uniforms[uniformName];
-
-        if (uniform instanceof Framebuffer) {
-          uniform = uniform.texture;
-        }
-        if (uniform instanceof Texture) {
-          const texture = uniform;
-          // Bind texture to index
-          texture.bind(uniformSetter.textureIndex);
-        }
-      }
+    for (const uniformName in this._texturesUniforms) {
+      const textureIndex = this._uniformSetters[uniformName].textureIndex;
+      this.uniforms[uniformName].bind(textureIndex);
     }
   }
 


### PR DESCRIPTION
Three smaller optimizations:
- Track current program, only update if it changes
- Check for empty objects passed to `setParameters`
- Keep track of texture uniforms in `Program` so you don't have to loop through all uniforms to bind them (deck's tends to send a lot of uniforms, not many textures for rendering).

Total performance improvement over 7.3 on the stress test currently at:

|        |7.3  |Current|Improvement|
|--------|-----|-------|-----------|        
|CPU Time|43ms |17ms   |26ms (60%) |
|GPU Time|38ms |24ms   |14ms (37%) |
