### PR TITLE
Remove unpackFlipY option from Texture

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -18,6 +18,18 @@ The module structure has been significantly changed for v8.0 with the intention 
 | debug      | Debug tooling for the other modules | Same as before |
 | test-utils | Test tooling for the other modules | Same as before |
 
+### Breaking changes
+
+- `Texture2D`'s `unpackFlipY` option is removed. This change ensures that all data sources (Image, ImageBitmap, typed array) are treated consistently. As a result, textures created from Image objects and URL strings are now y-flipped from the v7.3 default. To get the old behavior, specify the `pixelStore` option:
+
+```js
+new Texture2D({
+  data,
+  pixelStore: {
+    [GL.UNPACK_FLIP_Y_WEBGL]: true
+  }
+});
+```
 
 ### Smaller changes
 

--- a/modules/addons/src/gltf/gltf-environment.js
+++ b/modules/addons/src/gltf/gltf-environment.js
@@ -73,9 +73,6 @@ export default class GLTFEnvironment {
           [GL.TEXTURE_MIN_FILTER]: GL.LINEAR,
           [GL.TEXTURE_MAG_FILTER]: GL.LINEAR
         },
-        pixelStore: {
-          [this.gl.UNPACK_FLIP_Y_WEBGL]: false
-        },
         // Texture2D accepts a promise that returns an image as data (Async Textures)
         data: loadImage(this.brdfLutUrl)
       });

--- a/modules/webgl/src/classes/texture.js
+++ b/modules/webgl/src/classes/texture.js
@@ -93,9 +93,7 @@ export default class Texture extends Resource {
       recreate = false,
       parameters = {},
       pixelStore = {},
-      textureUnit = undefined,
-      // Deprecated parameters
-      unpackFlipY = true
+      textureUnit = undefined
     } = props;
 
     let {mipmaps = true} = props;
@@ -137,14 +135,6 @@ export default class Texture extends Resource {
       this.gl.bindTexture(this.target, this.handle);
     }
 
-    // Note: luma.gl defaults to GL.UNPACK_FLIP_Y_WEBGL = true;
-    // TODO - compare v4 and v3
-    const DEFAULT_TEXTURE_SETTINGS = {
-      // Pixel store
-      [GL.UNPACK_FLIP_Y_WEBGL]: unpackFlipY
-    };
-    const glSettings = Object.assign({}, DEFAULT_TEXTURE_SETTINGS, pixelStore);
-
     if (mipmaps && this._isNPOT()) {
       log.warn(`texture: ${this} is Non-Power-Of-Two, disabling mipmaping`)();
       mipmaps = false;
@@ -164,7 +154,7 @@ export default class Texture extends Resource {
       dataFormat,
       border,
       mipmaps,
-      parameters: glSettings
+      parameters: pixelStore
     });
 
     if (mipmaps) {


### PR DESCRIPTION
#### Background

`unpackFlipY` only affects Image and Canvas data sources, and not typed arrays or `ImageBitmap`. This default behavior makes the resulting texture unpredictable when used with `@loaders.gl/images`, which automatically selects the image format at runtime.

#### Change List
- Remove the `unpackFlipY` option from `Texture`
- Upgrade guide
