### PR TITLE
ClipSpace, getParameters, resolveModules fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v8.0.0-alpha.7
+
+- ClipSpace, getParameters, resolveModules fixes (#1297)
+
+## v8.0.0-alpha.6
+
+- Remove unpackFlipY option from Texture (#1295)
+- Shadertools cleanup (#1296)
+- (more-luma-cleanup) Small optimizations (#1294)
+- Simplify and optimize state tracking (#1293)
+- DevicePixelRatio: Handle invalid client sizes and remove custom width/height support. (#1290)
+
+## v8.0.0-alpha.5
+
+- Fix deps, simplify materials (#1292)
+
 ## v8.0.0-alpha.3
 
 - Fix deps, simplify materials (#1292)

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "exact": true,

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "exact": true,

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "exact": true,

--- a/modules/addons/package.json
+++ b/modules/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/addons",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "Experimental classes for luma.gl",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "@loaders.gl/gltf": "^1.3.0",
     "@loaders.gl/images": "^1.3.0",
-    "@luma.gl/constants": "8.0.0-alpha.7",
+    "@luma.gl/constants": "8.0.0-alpha.8",
     "math.gl": "^3.0.0"
   },
   "peerDependencies": {
@@ -45,5 +45,5 @@
     "@loaders.gl/core": "^1.3.0",
     "@loaders.gl/polyfills": "^1.3.0"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/addons/package.json
+++ b/modules/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/addons",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "Experimental classes for luma.gl",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "@loaders.gl/gltf": "^1.3.0",
     "@loaders.gl/images": "^1.3.0",
-    "@luma.gl/constants": "8.0.0-alpha.8",
+    "@luma.gl/constants": "8.0.0-alpha.9",
     "math.gl": "^3.0.0"
   },
   "peerDependencies": {

--- a/modules/addons/package.json
+++ b/modules/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/addons",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "Experimental classes for luma.gl",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "@loaders.gl/gltf": "^1.3.0",
     "@loaders.gl/images": "^1.3.0",
-    "@luma.gl/constants": "8.0.0-alpha.6",
+    "@luma.gl/constants": "8.0.0-alpha.7",
     "math.gl": "^3.0.0"
   },
   "peerDependencies": {

--- a/modules/constants/package.json
+++ b/modules/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/constants",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "WebGL and WebGL2 constants",
   "license": "MIT",
   "repository": {
@@ -28,5 +28,5 @@
     "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/constants/package.json
+++ b/modules/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/constants",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "WebGL and WebGL2 constants",
   "license": "MIT",
   "repository": {

--- a/modules/constants/package.json
+++ b/modules/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/constants",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "WebGL and WebGL2 constants",
   "license": "MIT",
   "repository": {

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/core",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.6",
-    "@luma.gl/engine": "8.0.0-alpha.6",
-    "@luma.gl/shadertools": "8.0.0-alpha.6",
-    "@luma.gl/webgl": "8.0.0-alpha.6",
+    "@luma.gl/constants": "8.0.0-alpha.7",
+    "@luma.gl/engine": "8.0.0-alpha.7",
+    "@luma.gl/shadertools": "8.0.0-alpha.7",
+    "@luma.gl/webgl": "8.0.0-alpha.7",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/core",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.8",
-    "@luma.gl/engine": "8.0.0-alpha.8",
-    "@luma.gl/shadertools": "8.0.0-alpha.8",
-    "@luma.gl/webgl": "8.0.0-alpha.8",
+    "@luma.gl/constants": "8.0.0-alpha.9",
+    "@luma.gl/engine": "8.0.0-alpha.9",
+    "@luma.gl/shadertools": "8.0.0-alpha.9",
+    "@luma.gl/webgl": "8.0.0-alpha.9",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/core",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,13 +31,13 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.7",
-    "@luma.gl/engine": "8.0.0-alpha.7",
-    "@luma.gl/shadertools": "8.0.0-alpha.7",
-    "@luma.gl/webgl": "8.0.0-alpha.7",
+    "@luma.gl/constants": "8.0.0-alpha.8",
+    "@luma.gl/engine": "8.0.0-alpha.8",
+    "@luma.gl/shadertools": "8.0.0-alpha.8",
+    "@luma.gl/webgl": "8.0.0-alpha.8",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -81,6 +81,7 @@ export {
   ProgramManager,
   Timeline,
   Geometry,
+  ClipSpace,
   ConeGeometry,
   CubeGeometry,
   CylinderGeometry,

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -95,12 +95,6 @@ export {
 //  We should have a minimal set of forwarding exports from shadertools (ideally none)
 //  Analyze risk of breaking apps
 export {
-  registerShaderModules,
-  setDefaultShaderModules,
-  getDefaultShaderModules,
-  assembleShaders,
-  createShaderHook,
-  createModuleInjection,
   // HELPERS
   combineInjects,
   normalizeShaderModule,

--- a/modules/debug/package.json
+++ b/modules/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/debug",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "Debug utilities for luma.gl",
   "license": "MIT",
   "repository": {
@@ -30,7 +30,7 @@
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {
-    "@luma.gl/constants": "8.0.0-alpha.7",
+    "@luma.gl/constants": "8.0.0-alpha.8",
     "glsl-transpiler": "^1.8.5",
     "math.gl": "^3.0.0",
     "webgl-debug": "^2.0.1"
@@ -38,5 +38,5 @@
   "peerDependencies": {
     "@luma.gl/core": "^7.1.0"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/debug/package.json
+++ b/modules/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/debug",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "Debug utilities for luma.gl",
   "license": "MIT",
   "repository": {
@@ -30,7 +30,7 @@
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {
-    "@luma.gl/constants": "8.0.0-alpha.8",
+    "@luma.gl/constants": "8.0.0-alpha.9",
     "glsl-transpiler": "^1.8.5",
     "math.gl": "^3.0.0",
     "webgl-debug": "^2.0.1"

--- a/modules/debug/package.json
+++ b/modules/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/debug",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "Debug utilities for luma.gl",
   "license": "MIT",
   "repository": {
@@ -30,7 +30,7 @@
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {
-    "@luma.gl/constants": "8.0.0-alpha.6",
+    "@luma.gl/constants": "8.0.0-alpha.7",
     "glsl-transpiler": "^1.8.5",
     "math.gl": "^3.0.0",
     "webgl-debug": "^2.0.1"

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/engine",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.8",
-    "@luma.gl/shadertools": "8.0.0-alpha.8",
-    "@luma.gl/webgl": "8.0.0-alpha.8",
+    "@luma.gl/constants": "8.0.0-alpha.9",
+    "@luma.gl/shadertools": "8.0.0-alpha.9",
+    "@luma.gl/webgl": "8.0.0-alpha.9",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/engine",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.6",
-    "@luma.gl/shadertools": "8.0.0-alpha.6",
-    "@luma.gl/webgl": "8.0.0-alpha.6",
+    "@luma.gl/constants": "8.0.0-alpha.7",
+    "@luma.gl/shadertools": "8.0.0-alpha.7",
+    "@luma.gl/webgl": "8.0.0-alpha.7",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/engine",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,12 +31,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.7",
-    "@luma.gl/shadertools": "8.0.0-alpha.7",
-    "@luma.gl/webgl": "8.0.0-alpha.7",
+    "@luma.gl/constants": "8.0.0-alpha.8",
+    "@luma.gl/shadertools": "8.0.0-alpha.8",
+    "@luma.gl/webgl": "8.0.0-alpha.8",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/engine/src/index.js
+++ b/modules/engine/src/index.js
@@ -17,3 +17,6 @@ export {default as TruncatedConeGeometry} from './geometries/truncated-cone-geom
 // Animation
 export {Timeline} from './animation/timeline';
 export {KeyFrames} from './animation/key-frames';
+
+// Utils
+export {default as ClipSpace} from './utils/clip-space';

--- a/modules/engine/src/utils/clip-space.js
+++ b/modules/engine/src/utils/clip-space.js
@@ -1,0 +1,47 @@
+// ClipSpace
+import GL from '@luma.gl/constants';
+import Model from '../lib/model';
+import Geometry from '../geometry/geometry';
+
+const CLIPSPACE_VERTEX_SHADER = `\
+attribute vec2 aClipSpacePosition;
+attribute vec2 aTexCoord;
+attribute vec2 aCoordinate;
+
+varying vec2 position;
+varying vec2 coordinate;
+varying vec2 uv;
+
+void main(void) {
+  gl_Position = vec4(aClipSpacePosition, 0., 1.);
+  position = aClipSpacePosition;
+  coordinate = aCoordinate;
+  uv = aTexCoord;
+}
+`;
+
+/* eslint-disable indent, no-multi-spaces */
+const POSITIONS = [-1, -1, 1, -1, -1, 1, 1, 1];
+
+export default class ClipSpace extends Model {
+  constructor(gl, opts) {
+    const TEX_COORDS = POSITIONS.map(coord => (coord === -1 ? 0 : coord));
+
+    super(
+      gl,
+      Object.assign({}, opts, {
+        vs: CLIPSPACE_VERTEX_SHADER,
+        geometry: new Geometry({
+          drawMode: GL.TRIANGLE_STRIP,
+          vertexCount: 4,
+          attributes: {
+            aClipSpacePosition: {size: 2, value: new Float32Array(POSITIONS)},
+            aTexCoord: {size: 2, value: new Float32Array(TEX_COORDS)},
+            aCoordinate: {size: 2, value: new Float32Array(TEX_COORDS)}
+          }
+        })
+      })
+    );
+    this.setVertexCount(4);
+  }
+}

--- a/modules/gltools/package.json
+++ b/modules/gltools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/gltools",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "WebGL2 API Polyfills for WebGL1 WebGLRenderingContext",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.7"
+    "@luma.gl/constants": "8.0.0-alpha.8"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/gltools/package.json
+++ b/modules/gltools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/gltools",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "WebGL2 API Polyfills for WebGL1 WebGLRenderingContext",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.6"
+    "@luma.gl/constants": "8.0.0-alpha.7"
   },
   "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
 }

--- a/modules/gltools/package.json
+++ b/modules/gltools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/gltools",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "WebGL2 API Polyfills for WebGL1 WebGLRenderingContext",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.8"
+    "@luma.gl/constants": "8.0.0-alpha.9"
   },
   "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/gltools/src/state-tracker/unified-parameter-api.js
+++ b/modules/gltools/src/state-tracker/unified-parameter-api.js
@@ -71,6 +71,14 @@ export function getParameters(gl, parameters) {
   // default to querying all parameters
   parameters = parameters || GL_PARAMETER_DEFAULTS;
   // support both arrays of parameters and objects (keys represent parameters)
+
+  if (typeof parameters === 'number') {
+    // single GL enum
+    const key = parameters;
+    const getter = GL_PARAMETER_GETTERS[key];
+    return getter ? getter(gl, Number(key)) : gl.getParameter(Number(key));
+  }
+
   const parameterKeys = Array.isArray(parameters) ? parameters : Object.keys(parameters);
 
   const state = {};

--- a/modules/gltools/src/state-tracker/unified-parameter-api.js
+++ b/modules/gltools/src/state-tracker/unified-parameter-api.js
@@ -76,7 +76,7 @@ export function getParameters(gl, parameters) {
     // single GL enum
     const key = parameters;
     const getter = GL_PARAMETER_GETTERS[key];
-    return getter ? getter(gl, Number(key)) : gl.getParameter(Number(key));
+    return getter ? getter(gl, key) : gl.getParameter(key);
   }
 
   const parameterKeys = Array.isArray(parameters) ? parameters : Object.keys(parameters);

--- a/modules/gltools/test/state-tracker/state-tracking/context-state.spec.js
+++ b/modules/gltools/test/state-tracker/state-tracking/context-state.spec.js
@@ -20,10 +20,6 @@ const fixture = {
   gl2: createTestContext({webgl2: true, webgl1: false})
 };
 
-function getParameter(gl, param) {
-  return getParameters(gl, [param])[param];
-}
-
 test('WebGL#state', t => {
   t.ok(getParameters, 'getParameters imported ok');
   t.ok(setParameters, 'setParameters imported ok');
@@ -398,14 +394,14 @@ test('WebGLState#bindFramebuffer (WebGL1)', t => {
 
   resetParameters(gl);
 
-  fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
+  fbHandle = getParameters(gl, gl.FRAMEBUFFER_BINDING);
   t.equal(fbHandle, null, 'Initial draw frambuffer binding should be null');
 
   setParameters(gl, {
     framebuffer
   });
 
-  fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
+  fbHandle = getParameters(gl, gl.FRAMEBUFFER_BINDING);
   t.equal(fbHandle, framebuffer.handle, 'setParameters should set framebuffer binding');
 
   t.end();
@@ -480,26 +476,26 @@ test('WebGLState#withParameters framebuffer', t => {
   resetParameters(gl);
 
   let fbHandle;
-  fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
+  fbHandle = getParameters(gl, gl.FRAMEBUFFER_BINDING);
   t.equal(fbHandle, null, 'Initial draw frambuffer binding should be null');
 
   withParameters(gl, {framebuffer: framebufferOne}, () => {
-    fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
+    fbHandle = getParameters(gl, gl.FRAMEBUFFER_BINDING);
     t.deepEqual(fbHandle, framebufferOne.handle, 'withParameters should bind framebuffer');
 
     withParameters(gl, {framebuffer: framebufferTwo}, () => {
-      fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
+      fbHandle = getParameters(gl, gl.FRAMEBUFFER_BINDING);
       t.deepEqual(fbHandle, framebufferTwo.handle, 'Inner withParameters should bind framebuffer');
     });
 
-    fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
+    fbHandle = getParameters(gl, gl.FRAMEBUFFER_BINDING);
     t.deepEqual(
       fbHandle,
       framebufferOne.handle,
       'Inner withParameters should restore draw framebuffer binding'
     );
   });
-  fbHandle = getParameter(gl, gl.FRAMEBUFFER_BINDING);
+  fbHandle = getParameters(gl, gl.FRAMEBUFFER_BINDING);
   t.deepEqual(fbHandle, null, 'withParameters should restore framebuffer bidning');
 
   t.end();
@@ -515,20 +511,20 @@ test('WebGLState#withParameters empty parameters object', t => {
     [GL.BLEND]: false
   });
 
-  let clearColor = getParameter(gl, GL.COLOR_CLEAR_VALUE);
-  let blendState = getParameter(gl, GL.BLEND);
+  let clearColor = getParameters(gl, GL.COLOR_CLEAR_VALUE);
+  let blendState = getParameters(gl, GL.BLEND);
   t.deepEqual(clearColor, [0, 0, 0, 0], `got expected value ${stringifyTypedArray(clearColor)}`);
   t.deepEqual(blendState, false, `got expected value ${stringifyTypedArray(blendState)}`);
 
   withParameters(gl, {}, () => {
-    clearColor = getParameter(gl, GL.COLOR_CLEAR_VALUE);
-    blendState = getParameter(gl, GL.BLEND);
+    clearColor = getParameters(gl, GL.COLOR_CLEAR_VALUE);
+    blendState = getParameters(gl, GL.BLEND);
     t.deepEqual(clearColor, [0, 0, 0, 0], `got expected value ${stringifyTypedArray(clearColor)}`);
     t.deepEqual(blendState, false, `got expected value ${stringifyTypedArray(blendState)}`);
   });
 
-  clearColor = getParameter(gl, GL.COLOR_CLEAR_VALUE);
-  blendState = getParameter(gl, GL.BLEND);
+  clearColor = getParameters(gl, GL.COLOR_CLEAR_VALUE);
+  blendState = getParameters(gl, GL.BLEND);
   t.deepEqual(clearColor, [0, 0, 0, 0], `got expected value ${stringifyTypedArray(clearColor)}`);
   t.deepEqual(blendState, false, `got expected value ${stringifyTypedArray(blendState)}`);
 

--- a/modules/gltools/test/state-tracker/state-tracking/track-context-state.spec.js
+++ b/modules/gltools/test/state-tracker/state-tracking/track-context-state.spec.js
@@ -23,10 +23,6 @@ function stringifyTypedArray(v) {
   return JSON.stringify(v);
 }
 
-function getParameter(gl, param) {
-  return getParameters(gl, [param])[param];
-}
-
 // Settings test, don't reuse a context
 const fixture = {
   gl: createTestContext({debug: true})
@@ -183,19 +179,19 @@ test('WebGLState#intercept gl calls', t => {
   pushContextState(gl);
 
   gl.blendEquation(gl.FUNC_SUBTRACT, gl.FUNC_SUBTRACT);
-  t.is(getParameter(gl, gl.BLEND_EQUATION_RGB), gl.FUNC_SUBTRACT, 'direct gl call is tracked');
+  t.is(getParameters(gl, gl.BLEND_EQUATION_RGB), gl.FUNC_SUBTRACT, 'direct gl call is tracked');
 
   gl.blendFunc(gl.ONE, gl.ONE);
-  t.is(getParameter(gl, gl.BLEND_SRC_RGB), gl.ONE, 'direct gl call is tracked');
+  t.is(getParameters(gl, gl.BLEND_SRC_RGB), gl.ONE, 'direct gl call is tracked');
 
   gl.stencilMask(8);
-  t.is(getParameter(gl, gl.STENCIL_WRITEMASK), 8, 'direct gl call is tracked');
+  t.is(getParameters(gl, gl.STENCIL_WRITEMASK), 8, 'direct gl call is tracked');
 
   gl.stencilFunc(gl.NEVER, 0, 1);
-  t.is(getParameter(gl, gl.STENCIL_FUNC), gl.NEVER, 'direct gl call is tracked');
+  t.is(getParameters(gl, gl.STENCIL_FUNC), gl.NEVER, 'direct gl call is tracked');
 
   gl.stencilOp(gl.KEEP, gl.ZERO, gl.REPLACE);
-  t.is(getParameter(gl, gl.STENCIL_PASS_DEPTH_FAIL), gl.ZERO, 'direct gl call is tracked');
+  t.is(getParameters(gl, gl.STENCIL_PASS_DEPTH_FAIL), gl.ZERO, 'direct gl call is tracked');
 
   popContextState(gl);
   const parameters = getParameters(gl);

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/shadertools",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "Shader module system for luma.gl",
   "license": "MIT",
   "repository": {

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/shadertools",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "Shader module system for luma.gl",
   "license": "MIT",
   "repository": {

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/shadertools",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "Shader module system for luma.gl",
   "license": "MIT",
   "repository": {
@@ -39,5 +39,5 @@
     "@babel/runtime": "^7.0.0",
     "math.gl": "^3.0.0"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/shadertools/src/lib/resolve-modules.js
+++ b/modules/shadertools/src/lib/resolve-modules.js
@@ -59,14 +59,16 @@ function getDependencyGraph({modules, level, moduleMap, moduleDepth}) {
   }
 }
 
-// registers any supplied modules, resolves any names into modules
-// returns a list of modules
 function instantiateModules(modules, seen) {
   return modules.map(module => {
     if (module instanceof ShaderModule) {
       return module;
     }
 
+    assert(
+      typeof module !== 'string',
+      `Shader module use by name is deprecated. Import shader module '${module}' and use it directly.`
+    );
     assert(module.name, 'shader module has no name');
 
     module = new ShaderModule(module);

--- a/modules/shadertools/src/modules/fp64/test/fp64-test-utils.js
+++ b/modules/shadertools/src/modules/fp64/test/fp64-test-utils.js
@@ -24,7 +24,7 @@
 /* global window, document, */
 
 import {Buffer, Program} from '@luma.gl/webgl';
-import {assembleShaders, registerShaderModules, fp64} from '@luma.gl/shadertools';
+import {assembleShaders, fp64} from '@luma.gl/shadertools';
 import {
   initializeGL,
   initializeTexTarget,
@@ -109,7 +109,7 @@ function setupFloatTest(gl, {glslFunc, binary = false, limit = 256, op}) {
     assembleShaders(gl, {
       vs,
       fs: FS_RENDER_VCOLOR,
-      modules: ['fp64']
+      modules: [fp64]
     })
   );
 
@@ -157,7 +157,6 @@ canvas.height = 16;
 
 export const gl = initializeGL(canvas);
 initializeTexTarget(gl);
-registerShaderModules([fp64]);
 
 window.onload = () => {
   document.body.appendChild(canvas);

--- a/modules/shadertools/test/lib/resolve-modules.spec.js
+++ b/modules/shadertools/test/lib/resolve-modules.spec.js
@@ -35,6 +35,14 @@ test('ShaderModules#getShaderDependencies', t => {
     [fp32.name, project.name, fp64.name, project64.name],
     'Module order is correct'
   );
+
+  t.throws(
+    () => resolveModules(['project64']),
+    /deprecated.+project64/,
+    'Useful message for deprecated usage'
+  );
+  t.throws(() => resolveModules([{}]), /no name/, 'Alert about invalid modules');
+
   t.end();
 });
 

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/test-utils",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "Automated WebGL testing utilities with Puppeteer and image diffing",
   "license": "MIT",
   "publishConfig": {
@@ -35,5 +35,5 @@
     "@luma.gl/gltools": "^7.1.0",
     "@probe.gl/test-utils": "^3.1.1"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/test-utils",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "Automated WebGL testing utilities with Puppeteer and image diffing",
   "license": "MIT",
   "publishConfig": {

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/test-utils",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "Automated WebGL testing utilities with Puppeteer and image diffing",
   "license": "MIT",
   "publishConfig": {

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/webgl",
-  "version": "8.0.0-alpha.8",
+  "version": "8.0.0-alpha.9",
   "description": "WebGL2 Classes",
   "license": "MIT",
   "publishConfig": {
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.8",
-    "@luma.gl/gltools": "8.0.0-alpha.8",
+    "@luma.gl/constants": "8.0.0-alpha.9",
+    "@luma.gl/gltools": "8.0.0-alpha.9",
     "probe.gl": "^3.1.1"
   },
   "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/webgl",
-  "version": "8.0.0-alpha.6",
+  "version": "8.0.0-alpha.7",
   "description": "WebGL2 Classes",
   "license": "MIT",
   "publishConfig": {
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.6",
-    "@luma.gl/gltools": "8.0.0-alpha.6",
+    "@luma.gl/constants": "8.0.0-alpha.7",
+    "@luma.gl/gltools": "8.0.0-alpha.7",
     "probe.gl": "^3.1.1"
   },
   "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/webgl",
-  "version": "8.0.0-alpha.7",
+  "version": "8.0.0-alpha.8",
   "description": "WebGL2 Classes",
   "license": "MIT",
   "publishConfig": {
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.7",
-    "@luma.gl/gltools": "8.0.0-alpha.7",
+    "@luma.gl/constants": "8.0.0-alpha.8",
+    "@luma.gl/gltools": "8.0.0-alpha.8",
     "probe.gl": "^3.1.1"
   },
-  "gitHead": "1eb23cd12b4241742f6515daf4e0eaa5d6ee93a5"
+  "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"
 }


### PR DESCRIPTION
Fix some breakages caused in deck.gl:
- Restore ClipSpace
- Improve getParameters API so it can be used with a single parameter
- Update resolveModules to report when a string is passed in (deprecated usage)

