### PR TITLE
Reduce core to modules used by deck.gl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v8.0.0-alpha.11
+
+- Reduce core to modules used by deck.gl (#1303)
+- Rename addons to experimental (#1302)
+- Set parameters assert (#1301)
+
 ## v8.0.0-alpha.10
 
 - New module injection api (#1300)

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -35,6 +35,14 @@ new Texture2D({
 - `createShaderHook` and `createModuleInjection` have been removed. Use `ProgramManager.getDefaultProgramManger(gl).addShaderHook` && the shader module [inject field](/docs/developer-guide/shader-modules.md) instead.
 - `ProgramManager.getDefaultProgramManger(gl).addModuleInjection` been removed. Use the shader module [inject field](/docs/developer-guide/shader-modules.md) instead.
 - `getParameter` and `setParameter` have been removed. Use `getParameters` and `setParameters` instead.
+- The following are no longer exported by @luma.gl/core, but can still be imported from the modules indicated:
+
+| |Available in|
+|-|------------|
+|Query, VertexArrayObject, VertexArray, UniformBufferLayout, Shader, VertexShader, FragmentShader, clearBuffer, clearBuffer, copyToDataUrl, copyToImage, blit, setPathPrefix, loadFile, loadImage|@luma.gl/webgl|
+|resizeGLContext|@luma.gl/gltools|
+|combineInjects, lights, getQualifierDetails, getPassthroughFS, typeToChannelSuffix, typeToChannelCount, convertToVec4|@luma.gl/shadertools|
+
 
 ### Smaller changes
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.0.0",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "exact": true,

--- a/modules/constants/package.json
+++ b/modules/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/constants",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "WebGL and WebGL2 constants",
   "license": "MIT",
   "repository": {

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/core",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.11",
-    "@luma.gl/engine": "8.0.0-alpha.11",
-    "@luma.gl/shadertools": "8.0.0-alpha.11",
-    "@luma.gl/webgl": "8.0.0-alpha.11",
+    "@luma.gl/constants": "8.0.0-alpha.12",
+    "@luma.gl/engine": "8.0.0-alpha.12",
+    "@luma.gl/shadertools": "8.0.0-alpha.12",
+    "@luma.gl/webgl": "8.0.0-alpha.12",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -1,74 +1,43 @@
 // CORE MODULE EXPORTS FOR LUMA.GL
 
-// WEBGL CONTEXT
+// GLTOOLS
 export {
-  lumaStats,
-  getContextInfo,
-  getGLContextInfo,
-  getContextLimits,
-  FEATURES,
-  hasFeature,
-  hasFeatures,
-  getFeatures,
-  canCompileGLGSExtension,
-  cloneTextureFrom,
-  getKeyValue,
-  getKey
-} from '@luma.gl/webgl';
-
-export {
+  createGLContext,
+  instrumentGLContext,
   isWebGL,
   isWebGL2,
-  createGLContext,
-  resizeGLContext,
-  trackContextState,
-  resetParameters,
   getParameters,
   setParameters,
   withParameters,
+  resetParameters,
   cssToDeviceRatio,
   cssToDevicePixels
 } from '@luma.gl/gltools';
 
-// WEBGL1 OBJECTS/FUNCTIONS
+// WEBGL
 export {
+  lumaStats,
+  FEATURES,
+  hasFeature,
+  hasFeatures,
   Buffer,
-  Shader,
-  VertexShader,
-  FragmentShader,
   Program,
   Framebuffer,
   Renderbuffer,
   Texture2D,
   TextureCube,
   clear,
-  clearBuffer,
   // Copy and Blit
   readPixelsToArray,
   readPixelsToBuffer,
-  copyToDataUrl,
-  copyToImage,
+  cloneTextureFrom,
   copyToTexture,
-  blit
-} from '@luma.gl/webgl';
-
-export {
   // WebGL2 classes & Extensions
-  Query,
   Texture3D,
-  TransformFeedback,
-  VertexArrayObject,
-  VertexArray,
-  UniformBufferLayout,
-  setPathPrefix,
-  loadFile,
-  loadImage,
-  // experimental WebGL exports
-  Accessor as _Accessor,
-  clearBuffer as _clearBuffer
+  TransformFeedback
 } from '@luma.gl/webgl';
 
-// CORE - WEBGL INDEPENDENT
+// ENGINE
 export {
   AnimationLoop,
   Model,
@@ -91,25 +60,18 @@ export {
 //  Analyze risk of breaking apps
 export {
   // HELPERS
-  combineInjects,
   normalizeShaderModule,
   // SHADER MODULES
   fp32,
   fp64,
   project,
-  lights,
   dirlight,
   picking,
   gouraudLighting,
   phongLighting,
-  pbr,
-  getQualifierDetails,
-  getPassthroughFS,
-  typeToChannelSuffix,
-  typeToChannelCount,
-  convertToVec4
+  pbr
 } from '@luma.gl/shadertools';
 
 // UTILS: undocumented API for other luma.gl modules
 export {log, assert, uid} from '@luma.gl/webgl';
-export {window, global} from '@luma.gl/gltools';
+export {window, global, self} from '@luma.gl/gltools';

--- a/modules/debug/package.json
+++ b/modules/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/debug",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "Debug utilities for luma.gl",
   "license": "MIT",
   "repository": {
@@ -30,7 +30,7 @@
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {
-    "@luma.gl/constants": "8.0.0-alpha.11",
+    "@luma.gl/constants": "8.0.0-alpha.12",
     "glsl-transpiler": "^1.8.5",
     "math.gl": "^3.0.0",
     "webgl-debug": "^2.0.1"

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/engine",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "WebGL2 Components for High Performance Rendering and Computation",
   "license": "MIT",
   "publishConfig": {
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.11",
-    "@luma.gl/gltools": "8.0.0-alpha.11",
-    "@luma.gl/shadertools": "8.0.0-alpha.11",
-    "@luma.gl/webgl": "8.0.0-alpha.11",
+    "@luma.gl/constants": "8.0.0-alpha.12",
+    "@luma.gl/gltools": "8.0.0-alpha.12",
+    "@luma.gl/shadertools": "8.0.0-alpha.12",
+    "@luma.gl/webgl": "8.0.0-alpha.12",
     "math.gl": "^3.0.0",
     "probe.gl": "^3.1.1",
     "seer": "^0.2.4"

--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/experimental",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "Experimental classes for luma.gl",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
   "dependencies": {
     "@loaders.gl/gltf": "^1.3.0",
     "@loaders.gl/images": "^1.3.0",
-    "@luma.gl/constants": "8.0.0-alpha.11",
+    "@luma.gl/constants": "8.0.0-alpha.12",
     "math.gl": "^3.0.0"
   },
   "peerDependencies": {

--- a/modules/gltools/package.json
+++ b/modules/gltools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/gltools",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "WebGL2 API Polyfills for WebGL1 WebGLRenderingContext",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.11",
+    "@luma.gl/constants": "8.0.0-alpha.12",
     "probe.gl": "^3.1.1"
   },
   "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/shadertools",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "Shader module system for luma.gl",
   "license": "MIT",
   "repository": {

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/test-utils",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "Automated WebGL testing utilities with Puppeteer and image diffing",
   "license": "MIT",
   "publishConfig": {

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luma.gl/webgl",
-  "version": "8.0.0-alpha.11",
+  "version": "8.0.0-alpha.12",
   "description": "WebGL2 Classes",
   "license": "MIT",
   "publishConfig": {
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@luma.gl/constants": "8.0.0-alpha.11",
-    "@luma.gl/gltools": "8.0.0-alpha.11",
+    "@luma.gl/constants": "8.0.0-alpha.12",
+    "@luma.gl/gltools": "8.0.0-alpha.12",
     "probe.gl": "^3.1.1"
   },
   "gitHead": "8deca643b658ddf6d8fb279df6417b8901a6fc93"


### PR DESCRIPTION
Begin using deck.gl usage as the metric for what should be included in core.
