### PR TITLE
Export fp64-arithmetic shader module

### DIFF
--- a/modules/shadertools/src/lib/shader-module.js
+++ b/modules/shadertools/src/lib/shader-module.js
@@ -50,7 +50,7 @@ export default class ShaderModule {
     }
 
     return `\
-#define MODULE_${this.name.toUpperCase()}
+#define MODULE_${this.name.toUpperCase().replace(/[^0-9a-z]/gi, '_')}
 ${moduleSource}\
 // END MODULE_${this.name}
 

--- a/modules/shadertools/src/modules/fp64/fp64.js
+++ b/modules/shadertools/src/modules/fp64/fp64.js
@@ -23,7 +23,6 @@ import {fp64ify, fp64LowPart, fp64ifyMatrix4} from './fp64-utils';
 import fp64arithmeticShader from './fp64-arithmetic.glsl';
 import fp64functionShader from './fp64-functions.glsl';
 
-const fp64shader = `${fp64arithmeticShader}\n${fp64functionShader}`;
 const CONST_UNIFORMS = {
   // Used in LUMA_FP64_CODE_ELIMINATION_WORKAROUND
   ONE: 1.0
@@ -31,29 +30,33 @@ const CONST_UNIFORMS = {
 export {fp64ify, fp64LowPart, fp64ifyMatrix4};
 
 function getUniforms() {
-  return Object.assign({}, CONST_UNIFORMS);
+  return CONST_UNIFORMS;
 }
-
-export default {
-  name: 'fp64',
-  vs: fp64shader,
-  fs: null,
-  fp64ify,
-  fp64LowPart,
-  fp64ifyMatrix4,
-  getUniforms
-};
 
 // Arithmetic only
 export const fp64arithmetic = {
   name: 'fp64-arithmetic',
-  vs: `${fp64arithmeticShader}`,
-  fs: null
+  vs: fp64arithmeticShader,
+  fs: null,
+  getUniforms,
+  fp64ify,
+  fp64LowPart
+};
+
+// Full fp64 shader
+export default {
+  name: 'fp64',
+  vs: fp64functionShader,
+  fs: null,
+  dependencies: [fp64arithmetic],
+  fp64ify,
+  fp64LowPart,
+  fp64ifyMatrix4
 };
 
 // Fragment shader fp64
-export const fp64fs = {
-  name: 'fp64-fs',
-  vs: null,
-  fs: fp64shader
-};
+// export const fp64fs = {
+//   name: 'fp64-fs',
+//   vs: null,
+//   fs: `${fp64arithmeticShader}\n${fp64functionShader}`
+// };

--- a/modules/shadertools/src/modules/fp64/fp64.js
+++ b/modules/shadertools/src/modules/fp64/fp64.js
@@ -53,10 +53,3 @@ export default {
   fp64LowPart,
   fp64ifyMatrix4
 };
-
-// Fragment shader fp64
-// export const fp64fs = {
-//   name: 'fp64-fs',
-//   vs: null,
-//   fs: `${fp64arithmeticShader}\n${fp64functionShader}`
-// };

--- a/modules/shadertools/src/modules/index.js
+++ b/modules/shadertools/src/modules/index.js
@@ -1,5 +1,5 @@
 export {default as fp32} from './fp32/fp32';
-export {default as fp64} from './fp64/fp64';
+export {default as fp64, fp64arithmetic} from './fp64/fp64';
 export {default as project} from './project/project';
 export {default as lights} from './lights/lights';
 export {default as dirlight} from './dirlight/dirlight';


### PR DESCRIPTION
For deck.gl aggregation refactor

#### Change List
- Expose shader module `fp64arithmetic` for applications that do not need 64-bit trigonometry/matrix functions (drops 600+ lines of shader code from deck dependency)
- Fix invalid define generated in shader assembly (`#define MODULE_FP64-ARITHMETIC` -> `#define MODULE_FP64_ARITHMETIC`)
