### PR TITLE
Small optimizations to texture checks and program updates

### DIFF
--- a/modules/engine/src/lib/model.js
+++ b/modules/engine/src/lib/model.js
@@ -143,7 +143,8 @@ export default class Model {
   }
 
   setProgram(props) {
-    this.programProps = Object.assign({}, props);
+    const {program, vs, fs, modules, defines, inject, varyings, bufferMode} = props;
+    this.programProps = {program, vs, fs, modules, defines, inject, varyings, bufferMode};
     this._programDirty = true;
   }
 

--- a/modules/webgl/src/classes/program.js
+++ b/modules/webgl/src/classes/program.js
@@ -257,23 +257,9 @@ export default class Program extends Resource {
 
     this._texturesRenderable = true;
 
-    for (const uniformName in this.uniforms) {
-      const uniformSetter = this._uniformSetters[uniformName];
-
-      if (uniformSetter && uniformSetter.textureIndex !== undefined) {
-        let uniform = this.uniforms[uniformName];
-
-        if (uniform instanceof Framebuffer) {
-          const framebuffer = uniform;
-          uniform = framebuffer.texture;
-        }
-
-        if (uniform instanceof Texture) {
-          const texture = uniform;
-          // Check that texture is loaded
-          this._texturesRenderable = this._texturesRenderable && texture.loaded;
-        }
-      }
+    for (const uniformName in this._textureUniforms) {
+      const texture = this._textureUniforms[uniformName];
+      this._texturesRenderable = this._texturesRenderable && texture.loaded;
     }
 
     return this._texturesRenderable;


### PR DESCRIPTION
Texture load checking time reduced by 30-50% on a quick test with the cubemap example.
