### PR TITLE
[Chore]: Skip draw when when rendering 0 primitives

### DIFF
--- a/modules/webgl/src/classes/program.js
+++ b/modules/webgl/src/classes/program.js
@@ -147,10 +147,15 @@ export default class Program extends Resource {
 
     this.gl.useProgram(this.handle);
 
-    // Note: async textures set as uniforms might still be loading.
-    // Now that all uniforms have been updated, check if any texture
-    // in the uniforms is not yet initialized, then we don't draw
-    if (!this._areTexturesRenderable()) {
+    if (
+      // Note: async textures set as uniforms might still be loading.
+      // Now that all uniforms have been updated, check if any texture
+      // in the uniforms is not yet initialized, then we don't draw
+      !this._areTexturesRenderable() ||
+
+      // Avoid WebGL warning when vertexCount is 0
+      vertexCount <= 0
+    ) {
       return false;
     }
 

--- a/modules/webgl/src/classes/program.js
+++ b/modules/webgl/src/classes/program.js
@@ -152,8 +152,9 @@ export default class Program extends Resource {
       // Now that all uniforms have been updated, check if any texture
       // in the uniforms is not yet initialized, then we don't draw
       !this._areTexturesRenderable() ||
-      // Avoid WebGL warning when vertexCount is 0
-      vertexCount <= 0
+      // Avoid WebGL draw call when not rendering any data
+      vertexCount === 0 ||
+      (isInstanced && instanceCount === 0)
     ) {
       return false;
     }

--- a/modules/webgl/src/classes/program.js
+++ b/modules/webgl/src/classes/program.js
@@ -152,7 +152,6 @@ export default class Program extends Resource {
       // Now that all uniforms have been updated, check if any texture
       // in the uniforms is not yet initialized, then we don't draw
       !this._areTexturesRenderable() ||
-
       // Avoid WebGL warning when vertexCount is 0
       vertexCount <= 0
     ) {

--- a/modules/webgl/test/classes/program.spec.js
+++ b/modules/webgl/test/classes/program.spec.js
@@ -61,8 +61,12 @@ test('WebGL#Program draw', t => {
   program.draw({vertexArray, vertexCount: 3});
   t.ok(program instanceof Program, 'Program draw successful');
 
-  program.draw({vertexArray, vertexCount: 3, parameters: {blend: true}});
+  let didDraw = program.draw({vertexArray, vertexCount: 3, parameters: {blend: true}});
   t.ok(program instanceof Program, 'Program draw with parameters is successful');
+  t.ok(didDraw, 'Program draw successful');
+
+  didDraw = program.draw({vertexArray, vertexCount: 0});
+  t.notOk(didDraw, 'Program draw succesfully skipped');
 
   t.end();
 });

--- a/modules/webgl/test/classes/program.spec.js
+++ b/modules/webgl/test/classes/program.spec.js
@@ -68,6 +68,9 @@ test('WebGL#Program draw', t => {
   didDraw = program.draw({vertexArray, vertexCount: 0});
   t.notOk(didDraw, 'Program draw succesfully skipped');
 
+  didDraw = program.draw({vertexArray, vertexCount: 3, instanceCount: 0, isInstanced: true});
+  t.notOk(didDraw, 'Instanced Program draw succesfully skipped');
+
   t.end();
 });
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1339 
<!-- For other PRs without open issue -->
#### Background
Skip issuing `draw` call when vertex count is 0.
<!-- For all the PRs -->
#### Change List
- [Chore]: Skip draw when vertex count is 0
