### PR TITLE
Full shader transpilation

### DIFF
--- a/docs/api-reference/engine/model.md
+++ b/docs/api-reference/engine/model.md
@@ -175,15 +175,14 @@ when not provided will be deduced from `geometry` object.
 
 The constructor for the Model class. Use this to create a new Model.
 
-The following props can only be specified on construction:
-
 * `vs` - (VertexShader|*string*) - A vertex shader object, or source as a string.
 * `fs` - (FragmentShader|*string*) - A fragment shader object, or source as a string.
 * `varyings` (WebGL 2) - An array of vertex shader output variables, that needs to be recorded (used in TransformFeedback flow).
 * `bufferMode` (WebGL 2) - Mode to be used when recording vertex shader outputs (used in TransformFeedback flow). Default value is `gl.SEPARATE_ATTRIBS`.
 * `modules` - shader modules to be applied.
 * `program` - pre created program to use, when provided, vs, ps and modules are not used.
-* `shaderCache` - (ShaderCache) - Compiled shader (Vertex and Fragment) are cached in this object very first time they got compiled and then retrieved when same shader is used. When using multiple Model objects with duplicate shaders, use the same shaderCache object for better performance.
+* `programManager` - `ProgramManager` to use for program creation and caching.
+* `transpileShaders` - Transpile vertex and fragment shaders to GLSL 1.0.
 
 
 ### delete() : Model

--- a/docs/api-reference/engine/program-manager.md
+++ b/docs/api-reference/engine/program-manager.md
@@ -78,6 +78,7 @@ Get a program that fits the parameters provided. If one is already cached, retur
 * `defines`: Object indicating `#define` constants to include in the shaders.
 * `modules`: Array of module objects to include in the shaders.
 * `inject`: Object of hook injections to include in the shaders.
+* `transpileShaders`: Transpile shaders to GLSL 1.0.
 
 ### `addDefaultModule(module: Object)`
 

--- a/docs/api-reference/shadertools/assemble-shaders.md
+++ b/docs/api-reference/shadertools/assemble-shaders.md
@@ -14,6 +14,7 @@ Takes the source code of a vertex shader and a fragment shader, and a list of mo
 * `modules`=`[]` (Array) - list of shader modules (either objects defining the module, or names of previously registered modules)
 * `inject`=`{}` (Object) - map of substituions,
 * `hookFunctions`=`[]` Array of hook functions descriptions. Descriptions can simply be the hook function signature (with a prefix `vs` for vertex shader, or `fs` for fragment shader) or an object with the hook signature, and a header and footer that will always appear in the hook function. For example:
+* `transpile`: force transpilation to GLSL ES 1.0 (see below)
 
 ```js
 [
@@ -121,6 +122,31 @@ new Model(gl, {
   }
 });
 ```
+
+## Transpilation
+
+If the `transpile` option is used, `assembleShaders` will attempt to transpile shaders to GLSL ES 1.0. This is a limited text replacement and requires that certain conventions be followed:
+- Statements are written one per line.
+- Only one fragment shader output is supported.
+- GLSL 3.0-only features, such as 3D textures are not supported.
+
+Text transformations are performed according to the following tables:
+
+Vertex Shaders
+
+| 3.00 ES         | 1.00 ES     | Comment         |
+| ---             | ---         | ---             |
+| `in`            | `attribute` |                 |
+| `out`           | `varying`   |                 |
+
+Fragment Shaders
+
+| 3.00 ES         | 1.00 ES        | Comment |
+| ---             | ---            | ---     |
+| `in`            | `varying`      |         |
+| `out vec4 <varName>` | `gl_FragColor` | `<varName>` declaration is removed and uses in the code are replace with `gl_FragColor`|
+| `texture`       | `texture2D`    | `texture` will be replaced with `texture2D` to ensure 1.00 code is correct. See note on `textureCube` below. |
+| `textureCube` * | `textureCube`  | `textureCube` is not valid 3.00 syntax, but must be used to ensure 1.00 code is correct, because `texture` will be substituted with `texture2D` when transpiled to 100. Also `textureCube` will be replaced with correct `texture` syntax when transpiled to 300. |
 
 
 

--- a/docs/api-reference/shadertools/assemble-shaders.md
+++ b/docs/api-reference/shadertools/assemble-shaders.md
@@ -144,7 +144,7 @@ Fragment Shaders
 | 3.00 ES         | 1.00 ES        | Comment |
 | ---             | ---            | ---     |
 | `in`            | `varying`      |         |
-| `out vec4 <varName>` | `gl_FragColor` | `<varName>` declaration is removed and uses in the code are replace with `gl_FragColor`|
+| `out vec4 <varName>` | `gl_FragColor` | `<varName>` declaration is removed and usage in the code are replaced with `gl_FragColor`|
 | `texture`       | `texture2D`    | `texture` will be replaced with `texture2D` to ensure 1.00 code is correct. See note on `textureCube` below. |
 | `textureCube` * | `textureCube`  | `textureCube` is not valid 3.00 syntax, but must be used to ensure 1.00 code is correct, because `texture` will be substituted with `texture2D` when transpiled to 100. Also `textureCube` will be replaced with correct `texture` syntax when transpiled to 300. |
 

--- a/docs/developer-guide/shader-modules.md
+++ b/docs/developer-guide/shader-modules.md
@@ -154,38 +154,7 @@ For example:
 }
 ```
 
-## GLSL Syntax Conversion Reference
+## GLSL Versions
 
-Where possible, the shader assembler replaces keywords based on the version of the shader into which a module is inserted. While not all GLSL ES 3.0 features can be emulated, this allows many modules to be used across versions.
+Shader modules will undergo some basic text transformations in order to match the GLSL version of the shaders they are injected into. These transformations are generally limited to the naming of input variables, output variables and texture sampling functions. See [assembleShaders](/docs/api-reference/shadertools/assemble-shaders) documentation for more information.
 
-Syntax replacement tables are provided below:
-
-Vertex Shaders
-
-| 3.00 ES         | 1.00 ES     | Comment         |
-| ---             | ---         | ---             |
-| `in`            | `attribute` |                 |
-| `out`           | `varying`   |                 |
-
-Fragment Shaders
-
-| 3.00 ES         | 1.00 ES        | Comment |
-| ---             | ---            | ---     |
-| `in`            | `varying`      |         |
-| `out`           | `gl_FragColor` |         |
-| `out`           | `gl_FragData`  |         |
-| `texture`       | `texture2D`    | `texture` will be replaced with `texture2D` to ensure 1.00 code is correct. See note on `textureCube` below. |
-| `textureCube` * | `textureCube`  | `textureCube` is not valid 3.00 syntax, but must be used to ensure 1.00 code is correct, because `texture` will be substituted with `texture2D` when transpiled to 100. Also `textureCube` will be replaced with correct `texture` syntax when transpiled to 300. |
-| `gl_FragDepth`  | `gl_FragDepthEXT` | WebGL 1: **EXT_frag_depth** |
-
-
-| 3.00 ES             | 1.00 ES                | Comment |
-| ---                 | ---                    | --- |
-| `texture2DLod`      | `texture2DLodEXT`      | WebGL 1: **EXT_shader_texture_lod** |
-| `texture2DProjLod`  | `texture2DProjLodEXT`  | WebGL 1: **EXT_shader_texture_lod** |
-| `texture2DProjLod`  | `texture2DProjLodEXT`  | WebGL 1: **EXT_shader_texture_lod** |
-| `textureCubeLod`    | `textureCubeLodEXT`    | WebGL 1: **EXT_shader_texture_lod** |
-| `texture2DGrad`     | `texture2DGradEXT`     | WebGL 1: **EXT_shader_texture_lod** |
-| `texture2DProjGrad` | `texture2DProjGradEXT` | WebGL 1: **EXT_shader_texture_lod** |
-| `texture2DProjGrad` | `texture2DProjGradEXT` | WebGL 1: **EXT_shader_texture_lod** |
-| `textureCubeGrad`   | `textureCubeGradEXT`   | WebGL 1: **EXT_shader_texture_lod** |

--- a/modules/engine/src/lib/model.js
+++ b/modules/engine/src/lib/model.js
@@ -49,9 +49,29 @@ export default class Model {
     this._programManagerState = -1;
     this._managedProgram = false;
 
-    const {program = null, vs, fs, modules, defines, inject, varyings, bufferMode} = props;
+    const {
+      program = null,
+      vs,
+      fs,
+      modules,
+      defines,
+      inject,
+      varyings,
+      bufferMode,
+      transpileShaders
+    } = props;
 
-    this.programProps = {program, vs, fs, modules, defines, inject, varyings, bufferMode};
+    this.programProps = {
+      program,
+      vs,
+      fs,
+      modules,
+      defines,
+      inject,
+      varyings,
+      bufferMode,
+      transpileShaders
+    };
     this.program = null;
     this.vertexArray = null;
     this._programDirty = true;
@@ -143,8 +163,28 @@ export default class Model {
   }
 
   setProgram(props) {
-    const {program, vs, fs, modules, defines, inject, varyings, bufferMode} = props;
-    this.programProps = {program, vs, fs, modules, defines, inject, varyings, bufferMode};
+    const {
+      program,
+      vs,
+      fs,
+      modules,
+      defines,
+      inject,
+      varyings,
+      bufferMode,
+      transpileShaders
+    } = props;
+    this.programProps = {
+      program,
+      vs,
+      fs,
+      modules,
+      defines,
+      inject,
+      varyings,
+      bufferMode,
+      transpileShaders
+    };
     this._programDirty = true;
   }
 
@@ -376,8 +416,26 @@ export default class Model {
     if (program) {
       this._managedProgram = false;
     } else {
-      const {vs, fs, modules, inject, defines, varyings, bufferMode} = this.programProps;
-      program = this.programManager.get({vs, fs, modules, inject, defines, varyings, bufferMode});
+      const {
+        vs,
+        fs,
+        modules,
+        inject,
+        defines,
+        varyings,
+        bufferMode,
+        transpileShaders
+      } = this.programProps;
+      program = this.programManager.get({
+        vs,
+        fs,
+        modules,
+        inject,
+        defines,
+        varyings,
+        bufferMode,
+        transpileShaders
+      });
       if (this.program && this._managedProgram) {
         this.programManager.release(this.program);
       }

--- a/modules/engine/src/lib/program-manager.js
+++ b/modules/engine/src/lib/program-manager.js
@@ -49,7 +49,15 @@ export default class ProgramManager {
   }
 
   get(props = {}) {
-    const {vs = '', fs = '', defines = {}, inject = {}, varyings = [], bufferMode = 0x8c8d} = props; // varyings/bufferMode for xform feedback, 0x8c8d = SEPARATE_ATTRIBS
+    const {
+      vs = '',
+      fs = '',
+      defines = {},
+      inject = {},
+      varyings = [],
+      bufferMode = 0x8c8d,
+      transpileShaders = false
+    } = props; // varyings/bufferMode for xform feedback, 0x8c8d = SEPARATE_ATTRIBS
 
     const modules = this._getModuleList(props.modules); // Combine with default modules
 
@@ -75,7 +83,9 @@ export default class ProgramManager {
 
     const hash = `${vsHash}/${fsHash}D${defineHashes.join('/')}M${moduleHashes.join(
       '/'
-    )}I${injectHashes.join('/')}V${varyingHashes.join('/')}H${this.stateHash}B${bufferMode}`;
+    )}I${injectHashes.join('/')}V${varyingHashes.join('/')}H${this.stateHash}B${bufferMode}${
+      transpileShaders ? 'T' : ''
+    }`;
 
     if (!this._programCache[hash]) {
       const assembled = assembleShaders(this.gl, {
@@ -84,7 +94,8 @@ export default class ProgramManager {
         modules,
         inject,
         defines,
-        hookFunctions: this._hookFunctions
+        hookFunctions: this._hookFunctions,
+        transpile: transpileShaders
       });
 
       this._programCache[hash] = new Program(this.gl, {

--- a/modules/engine/test/lib/model.spec.js
+++ b/modules/engine/test/lib/model.spec.js
@@ -21,6 +21,32 @@ const DUMMY_FS = `
   void main() { gl_FragColor = vec4(1.0); }
 `;
 
+const VS_300 = `#version 300 es
+
+  in vec4 positions;
+  in vec2 uvs;
+
+  out vec2 vUV;
+
+  void main() {
+    vUV = uvs;
+    gl_Position = positions;
+  }
+`;
+
+const FS_300 = `#version 300 es
+  precision highp float;
+
+  in vec2 vUV;
+
+  uniform sampler2D tex;
+
+  out vec4 fragColor;
+  void main() {
+    fragColor = texture(tex, vUV);
+  }
+`;
+
 test('Model#construct/destruct', t => {
   const {gl} = fixture;
 
@@ -244,7 +270,7 @@ test('Model#program management - getModuleUniforms', t => {
   t.end();
 });
 
-test('getBuffersFromGeometry', t => {
+test('Model#getBuffersFromGeometry', t => {
   const {gl} = fixture;
 
   let buffers = getBuffersFromGeometry(gl, {
@@ -301,5 +327,29 @@ test('getBuffersFromGeometry', t => {
     'invalid size'
   );
 
+  t.end();
+});
+
+test('Model#transpileShaders', t => {
+  const {gl} = fixture;
+
+  let model;
+
+  t.throws(() => {
+    model = new Model(gl, {
+      vs: VS_300,
+      fs: FS_300
+    });
+  }, "Can't compile 300 shader with WebGL 1");
+
+  t.doesNotThrow(() => {
+    model = new Model(gl, {
+      vs: VS_300,
+      fs: FS_300,
+      transpileShaders: true
+    });
+  }, 'Can compile transpiled 300 shader with WebGL 1');
+
+  t.ok(model.program, 'Created a program');
   t.end();
 });

--- a/modules/shadertools/src/lib/assemble-shaders.js
+++ b/modules/shadertools/src/lib/assemble-shaders.js
@@ -4,7 +4,6 @@ import {getPlatformShaderDefines, getVersionDefines} from './platform-defines';
 import injectShader, {DECLARATION_INJECT_MARKER} from './inject-shader';
 import transpileShader from './transpile-shader';
 import {assert} from '../utils';
-/* eslint-disable max-depth, complexity */
 
 const INJECT_SHADER_DECLARATIONS = `\n\n${DECLARATION_INJECT_MARKER}\n\n`;
 

--- a/modules/shadertools/src/lib/assemble-shaders.js
+++ b/modules/shadertools/src/lib/assemble-shaders.js
@@ -2,6 +2,7 @@ import {VERTEX_SHADER, FRAGMENT_SHADER} from './constants';
 import {resolveModules} from './resolve-modules';
 import {getPlatformShaderDefines, getVersionDefines} from './platform-defines';
 import injectShader, {DECLARATION_INJECT_MARKER} from './inject-shader';
+import transpileShader from './transpile-shader';
 import {assert} from '../utils';
 /* eslint-disable max-depth, complexity */
 
@@ -35,7 +36,18 @@ export function assembleShaders(gl, opts) {
 // adding prologues, requested module chunks, and any final injections.
 function assembleShader(
   gl,
-  {id, source, type, modules, defines = {}, hookFunctions = [], inject = {}, prologue = true, log}
+  {
+    id,
+    source,
+    type,
+    modules,
+    defines = {},
+    hookFunctions = [],
+    inject = {},
+    transpile = false,
+    prologue = true,
+    log
+  }
 ) {
   assert(typeof source === 'string', 'shader source must be a string');
 
@@ -129,6 +141,8 @@ ${isVertex ? '' : FRAGMENT_SHADER_PROLOGUE}
 
   // Apply any requested shader injections
   assembledSource = injectShader(assembledSource, type, mainInjections);
+
+  assembledSource = transpileShader(assembledSource, transpile ? 100 : glslVersion, isVertex);
 
   return assembledSource;
 }

--- a/modules/shadertools/src/lib/shader-module.js
+++ b/modules/shadertools/src/lib/shader-module.js
@@ -35,7 +35,7 @@ export default class ShaderModule {
   }
 
   // Extracts the source code chunk for the specified shader type from the named shader module
-  getModuleSource(type, targetGLSLVersion) {
+  getModuleSource(type) {
     let moduleSource;
     switch (type) {
       case VERTEX_SHADER:

--- a/modules/shadertools/src/lib/shader-module.js
+++ b/modules/shadertools/src/lib/shader-module.js
@@ -1,4 +1,3 @@
-import transpileShader from './transpile-shader';
 import {assert} from '../utils';
 import {parsePropTypes} from './filters/prop-types';
 
@@ -40,10 +39,10 @@ export default class ShaderModule {
     let moduleSource;
     switch (type) {
       case VERTEX_SHADER:
-        moduleSource = transpileShader(this.vs || '', targetGLSLVersion, true);
+        moduleSource = this.vs || '';
         break;
       case FRAGMENT_SHADER:
-        moduleSource = transpileShader(this.fs || '', targetGLSLVersion, false);
+        moduleSource = this.fs || '';
         break;
       default:
         assert(false);

--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -12,8 +12,11 @@ export default function transpileShader(source, targetGLSLVersion, isVertex) {
   }
 }
 
+const FS_OUTPUT_REGEX = /\bout\s+vec4\s+(\w+)\s*;/;
+
 function convertVertexShaderTo300(source) {
   return source
+    .replace(/^(#version\s+(100|300)\s+es)?[ \t]*\n/, '#version 300 es\n')
     .replace(/attribute\s+/g, 'in ')
     .replace(/varying\s+/g, 'out ')
     .replace(/texture2D\(/g, 'texture(')
@@ -24,11 +27,12 @@ function convertVertexShaderTo300(source) {
 
 function convertFragmentShaderTo300(source) {
   return source
-    .replace(/varying\s+/g, 'in ')
-    .replace(/texture2D\(/g, 'texture(')
-    .replace(/textureCube\(/g, 'texture(')
-    .replace(/texture2DLodEXT\(/g, 'textureLod(')
-    .replace(/textureCubeLodEXT\(/g, 'textureLod(');
+    .replace(/^(#version\s+(100|300)\s+es)?[ \t]*\n/, '#version 300 es\n')
+    .replace(/\bvarying\s+/g, 'in ')
+    .replace(/\btexture2D\(/g, 'texture(')
+    .replace(/\btextureCube\(/g, 'texture(')
+    .replace(/\btexture2DLodEXT\(/g, 'textureLod(')
+    .replace(/\btextureCubeLodEXT\(/g, 'textureLod(');
 
   // Deal with fragColor
   // .replace(/gl_fragColor/g, 'fragColor ');
@@ -37,15 +41,26 @@ function convertFragmentShaderTo300(source) {
 function convertVertexShaderTo100(source) {
   // /gm - treats each line as a string, so that ^ matches after newlines
   return source
-    .replace(/^in\s+/gm, 'attribute ')
-    .replace(/^out\s+/gm, 'varying ')
-    .replace(/texture\(/g, 'texture2D(');
+    .replace(/^#version\s+300\s+es/, '#version 100 es')
+    .replace(/^[ \t]*in[ \t]+/gm, 'attribute ')
+    .replace(/^[ \t]*out[ \t]+/gm, 'varying ')
+    .replace(/\btexture\(/g, 'texture2D(');
 }
-
+/* eslint-disable */
 function convertFragmentShaderTo100(source) {
   // /gm - treats each line as a string, so that ^ matches after newlines
-  return source.replace(/^in\s+/gm, 'varying ').replace(/texture\(/g, 'texture2D(');
+  source = source
+    .replace(/^#version\s+300\s+es/, '#version 100 es')
+    .replace(/^[ \t]*in[ \t]+/gm, 'varying ')
+    .replace(/\btexture\(/g, 'texture2D(');
 
-  // Deal with fragColor
-  // .replace(/^out\s+/g, 'varying ')
+  const outputMatch = source.match(FS_OUTPUT_REGEX);
+  if (outputMatch) {
+    const outputName = outputMatch[1];
+    source = source
+      .replace(FS_OUTPUT_REGEX, '')
+      .replace(new RegExp(`\\b${outputName}\\b`, 'g'), 'gl_FragColor');
+  }
+
+  return source;
 }

--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -44,7 +44,7 @@ function convertVertexShaderTo100(source) {
     .replace(/\btexture\(/g, 'texture2D(')
     .replace(/\btextureLod\(/g, 'texture2DLodEXT(');
 }
-/* eslint-disable */
+
 function convertFragmentShaderTo100(source) {
   // /gm - treats each line as a string, so that ^ matches after newlines
   source = source

--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -17,12 +17,12 @@ const FS_OUTPUT_REGEX = /^[ \t]*out\s+vec4\s+(\w+)\s*;/m;
 function convertVertexShaderTo300(source) {
   return source
     .replace(/^(#version\s+(100|300\s+es))?[ \t]*\n/, '#version 300 es\n')
-    .replace(/attribute\s+/g, 'in ')
-    .replace(/varying\s+/g, 'out ')
-    .replace(/texture2D\(/g, 'texture(')
-    .replace(/textureCube\(+/g, 'texture(')
-    .replace(/texture2DLodEXT\(/g, 'textureLod(')
-    .replace(/textureCubeLodEXT\(/g, 'textureLod(');
+    .replace(/\battribute\s+/g, 'in ')
+    .replace(/\bvarying\s+/g, 'out ')
+    .replace(/\btexture2D\(/g, 'texture(')
+    .replace(/\btextureCube\(+/g, 'texture(')
+    .replace(/\btexture2DLodEXT\(/g, 'textureLod(')
+    .replace(/\btextureCubeLodEXT\(/g, 'textureLod(');
 }
 
 function convertFragmentShaderTo300(source) {
@@ -33,9 +33,6 @@ function convertFragmentShaderTo300(source) {
     .replace(/\btextureCube\(/g, 'texture(')
     .replace(/\btexture2DLodEXT\(/g, 'textureLod(')
     .replace(/\btextureCubeLodEXT\(/g, 'textureLod(');
-
-  // Deal with fragColor
-  // .replace(/gl_fragColor/g, 'fragColor ');
 }
 
 function convertVertexShaderTo100(source) {
@@ -44,7 +41,8 @@ function convertVertexShaderTo100(source) {
     .replace(/^#version\s+300\s+es/, '#version 100')
     .replace(/^[ \t]*in[ \t]+/gm, 'attribute ')
     .replace(/^[ \t]*out[ \t]+/gm, 'varying ')
-    .replace(/\btexture\(/g, 'texture2D(');
+    .replace(/\btexture\(/g, 'texture2D(')
+    .replace(/\btextureLod\(/g, 'texture2DLodEXT(');
 }
 /* eslint-disable */
 function convertFragmentShaderTo100(source) {
@@ -52,7 +50,8 @@ function convertFragmentShaderTo100(source) {
   source = source
     .replace(/^#version\s+300\s+es/, '#version 100')
     .replace(/^[ \t]*in[ \t]+/gm, 'varying ')
-    .replace(/\btexture\(/g, 'texture2D(');
+    .replace(/\btexture\(/g, 'texture2D(')
+    .replace(/\btextureLod\(/g, 'texture2DLodEXT(');
 
   const outputMatch = source.match(FS_OUTPUT_REGEX);
   if (outputMatch) {

--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -16,7 +16,7 @@ const FS_OUTPUT_REGEX = /\bout\s+vec4\s+(\w+)\s*;/;
 
 function convertVertexShaderTo300(source) {
   return source
-    .replace(/^(#version\s+(100|300)\s+es)?[ \t]*\n/, '#version 300 es\n')
+    .replace(/^(#version\s+(100|300\s+es))?[ \t]*\n/, '#version 300 es\n')
     .replace(/attribute\s+/g, 'in ')
     .replace(/varying\s+/g, 'out ')
     .replace(/texture2D\(/g, 'texture(')
@@ -27,7 +27,7 @@ function convertVertexShaderTo300(source) {
 
 function convertFragmentShaderTo300(source) {
   return source
-    .replace(/^(#version\s+(100|300)\s+es)?[ \t]*\n/, '#version 300 es\n')
+    .replace(/^(#version\s+(100|300\s+es))?[ \t]*\n/, '#version 300 es\n')
     .replace(/\bvarying\s+/g, 'in ')
     .replace(/\btexture2D\(/g, 'texture(')
     .replace(/\btextureCube\(/g, 'texture(')
@@ -41,7 +41,7 @@ function convertFragmentShaderTo300(source) {
 function convertVertexShaderTo100(source) {
   // /gm - treats each line as a string, so that ^ matches after newlines
   return source
-    .replace(/^#version\s+300\s+es/, '#version 100 es')
+    .replace(/^#version\s+300\s+es/, '#version 100')
     .replace(/^[ \t]*in[ \t]+/gm, 'attribute ')
     .replace(/^[ \t]*out[ \t]+/gm, 'varying ')
     .replace(/\btexture\(/g, 'texture2D(');
@@ -50,7 +50,7 @@ function convertVertexShaderTo100(source) {
 function convertFragmentShaderTo100(source) {
   // /gm - treats each line as a string, so that ^ matches after newlines
   source = source
-    .replace(/^#version\s+300\s+es/, '#version 100 es')
+    .replace(/^#version\s+300\s+es/, '#version 100')
     .replace(/^[ \t]*in[ \t]+/gm, 'varying ')
     .replace(/\btexture\(/g, 'texture2D(');
 

--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -12,7 +12,7 @@ export default function transpileShader(source, targetGLSLVersion, isVertex) {
   }
 }
 
-const FS_OUTPUT_REGEX = /\bout\s+vec4\s+(\w+)\s*;/;
+const FS_OUTPUT_REGEX = /^[ \t]*out\s+vec4\s+(\w+)\s*;/m;
 
 function convertVertexShaderTo300(source) {
   return source

--- a/modules/shadertools/test/lib/assemble-shaders.spec.js
+++ b/modules/shadertools/test/lib/assemble-shaders.spec.js
@@ -230,3 +230,20 @@ test('assembleShaders#shaderhooks', t => {
 
   t.end();
 });
+/* eslint-disable */
+test('assembleShaders#transpilation', t => {
+  const assembleResult = assembleShaders(fixture.gl, {
+    vs: VS_GLSL_300,
+    fs: FS_GLSL_300,
+    modules: [picking],
+    transpile: true
+  });
+
+  t.ok(assembleResult.vs.indexOf('#version 300 es') === -1, 'es 3.0 version directive removed');
+  t.ok(!assembleResult.vs.match(/\bin vec4\b/), '"in" keyword removed');
+
+  t.ok(assembleResult.fs.indexOf('#version 300 es') === -1, 'es 3.0 version directive removed');
+  t.ok(!assembleResult.fs.match(/\bout vec4\b/), '"out" keyword removed');
+
+  t.end();
+});

--- a/modules/shadertools/test/lib/transpile-shader.spec.js
+++ b/modules/shadertools/test/lib/transpile-shader.spec.js
@@ -1,6 +1,12 @@
 /* eslint-disable camelcase */
+import {createTestContext} from '@luma.gl/test-utils';
 import transpileShader from '@luma.gl/shadertools/lib/transpile-shader';
 import test from 'tape-catch';
+
+const fixture = {
+  gl: createTestContext({webgl2: false, webgl1: true, throwOnError: true}),
+  gl2: createTestContext({webgl2: true, webgl1: false})
+};
 
 // 300 version should use 'textureCube()'' instead of 'texture()'
 const VS_GLSL_300 = `\
@@ -45,7 +51,7 @@ void main(void) {
 `;
 
 const VS_GLSL_100 = `\
-#version 100 es
+#version 100
 
 attribute vec4 positions;
 uniform sampler2D sampler;
@@ -109,7 +115,7 @@ void main(void) {
 `;
 
 const FS_GLSL_100 = `\
-#version 100 es
+#version 100
 
 precision highp float;
 
@@ -125,6 +131,43 @@ void main(void) {
   vec4 texLod = texture2DLodEXT(sampler, texCoord, 1.0);
   vec4 texCubeLod = textureCubeLodEXT(sCube, cubeCoord, 1.0);
   gl_FragColor = vColor;
+}
+`;
+
+const VS_GLSL_300_VALID = `\
+#version 300 es
+
+in vec4 positions;
+uniform sampler2D sampler;
+uniform samplerCube sCube;
+out vec4 vColor;
+
+void f(out float a, in float b) {}
+
+void main(void) {
+  gl_Position = positions;
+  vec4 texColor = texture(sampler, vec2(1.0));
+  vec4 texCubeColor = textureCube(sCube, vec3(1.0));
+  vColor = vec4(1., 0., 0., 1.);
+}
+`;
+
+const FS_GLSL_300_VALID = `\
+#version 300 es
+
+precision highp float;
+
+out vec4 fragmentColor;
+uniform sampler2D sampler;
+uniform samplerCube sCube;
+in vec4 vColor;
+
+void f(out float a, in float b) {}
+
+void main(void) {
+  vec4 texColor = texture(sampler, vec2(1.0));
+  vec4 texCubeColor = textureCube(sCube, vec3(1.0));
+  fragmentColor = vColor;
 }
 `;
 
@@ -154,6 +197,62 @@ test('transpileShader#versions', t => {
   t.equal(stripSpaces(assembleResult), stripSpaces(FS_GLSL_300_transpiled), 'correctly transpiled');
 
   t.throws(() => transpileShader(VS_GLSL_300, 400, true), /version/, 'unknown glsl version');
+
+  t.end();
+});
+
+/* eslint-disable */
+test('transpileShader#compilation', t => {
+  const {gl, gl2} = fixture;
+
+  const vs300_100 = transpileShader(VS_GLSL_300_VALID, 100, true);
+  const fs300_100 = transpileShader(FS_GLSL_300_VALID, 100, false);
+  const vs300_300 = transpileShader(VS_GLSL_300_VALID, 300, true);
+  const fs300_300 = transpileShader(FS_GLSL_300_VALID, 300, false);
+
+  let vShader = gl.createShader(gl.VERTEX_SHADER);
+  gl.shaderSource(vShader, vs300_100);
+  gl.compileShader(vShader);
+
+  let fShader = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(fShader, fs300_100);
+  gl.compileShader(fShader);
+
+  let program = gl.createProgram();
+  gl.attachShader(program, vShader);
+  gl.attachShader(program, fShader);
+
+  gl.linkProgram(program);
+
+  console.log(gl.getProgramInfoLog(program));
+
+  t.ok(gl.getProgramParameter(program, gl.LINK_STATUS), 'Transpile 300 to 100 valid program');
+
+  gl.deleteShader(vShader);
+  gl.deleteShader(fShader);
+  gl.deleteProgram(program);
+
+  if (gl2) {
+    vShader = gl2.createShader(gl2.VERTEX_SHADER);
+    gl2.shaderSource(vShader, vs300_300);
+    gl2.compileShader(vShader);
+
+    fShader = gl2.createShader(gl2.FRAGMENT_SHADER);
+    gl2.shaderSource(fShader, fs300_300);
+    gl2.compileShader(fShader);
+
+    program = gl2.createProgram();
+    gl2.attachShader(program, vShader);
+    gl2.attachShader(program, fShader);
+
+    gl2.linkProgram(program);
+
+    t.ok(gl2.getProgramParameter(program, gl2.LINK_STATUS), 'Transpile 300 to 300 valid program');
+
+    gl2.deleteShader(vShader);
+    gl2.deleteShader(fShader);
+    gl2.deleteProgram(program);
+  }
 
   t.end();
 });

--- a/modules/shadertools/test/lib/transpile-shader.spec.js
+++ b/modules/shadertools/test/lib/transpile-shader.spec.js
@@ -201,7 +201,6 @@ test('transpileShader#versions', t => {
   t.end();
 });
 
-/* eslint-disable */
 test('transpileShader#compilation', t => {
   const {gl, gl2} = fixture;
 
@@ -223,8 +222,6 @@ test('transpileShader#compilation', t => {
   gl.attachShader(program, fShader);
 
   gl.linkProgram(program);
-
-  console.log(gl.getProgramInfoLog(program));
 
   t.ok(gl.getProgramParameter(program, gl.LINK_STATUS), 'Transpile 300 to 100 valid program');
 

--- a/modules/shadertools/test/lib/transpile-shader.spec.js
+++ b/modules/shadertools/test/lib/transpile-shader.spec.js
@@ -45,7 +45,7 @@ void main(void) {
 `;
 
 const VS_GLSL_100 = `\
-#version 300 es
+#version 100 es
 
 attribute vec4 positions;
 uniform sampler2D sampler;
@@ -109,11 +109,10 @@ void main(void) {
 `;
 
 const FS_GLSL_100 = `\
-#version 300 es
+#version 100 es
 
 precision highp float;
 
-out vec4 fragmentColor;
 uniform sampler2D sampler;
 uniform samplerCube sCube;
 varying vec4 vColor;
@@ -125,128 +124,9 @@ void main(void) {
   vec4 texCubeColor = textureCube(sCube, cubeCoord);
   vec4 texLod = texture2DLodEXT(sampler, texCoord, 1.0);
   vec4 texCubeLod = textureCubeLodEXT(sCube, cubeCoord, 1.0);
-  fragmentColor = vColor;
+  gl_FragColor = vColor;
 }
 `;
-/*
-const VS_GLSL_300 = `\
-#version 300 es
-
-in vec4 positions;
-uniform sampler2D sampler;
-uniform samplerCube sCube;
-out vec4 vColor;
-
-void f(out float a, in float b) {}
-
-void main(void) {
-  gl_Position = positions;
-  vec4 texColor = texture(sampler, texCoord);
-  vec4 texCubeColor = textureCube(sCube, cubeCoord);
-  vColor = vec4(1., 0., 0., 1.);
-}
-`;
-
-// 300 version should also be writtend with 'textureCube()'' instead of 'texture()'
-const VS_GLSL_300_textureCube = `\
-#version 300 es
-
-in vec4 positions;
-uniform samplerCube sCube;
-out vec4 vColor;
-
-void main(void) {
-  gl_Position = positions;
-  vec4 texCubeColor = textureCube(sCube, cubeCoord);
-  vColor = vec4(1., 0., 0., 1.);
-}
-`;
-
-// transpiled version should have correct `texture(` syntax
-const VS_GLSL_300_textureCube_transpiled = `\
-#version 300 es
-
-in vec4 positions;
-uniform samplerCube sCube;
-out vec4 vColor;
-
-void main(void) {
-  gl_Position = positions;
-  vec4 texCubeColor = texture(sCube, cubeCoord);
-  vColor = vec4(1., 0., 0., 1.);
-}
-`;
-
-const VS_GLSL_100_textureCube = `\
-#version 300 es
-
-attribute vec4 positions;
-uniform samplerCube sCube;
-varying vec4 vColor;
-
-void main(void) {
-  gl_Position = positions;
-  vec4 texCubeColor = textureCube(sCube, cubeCoord);
-  vColor = vec4(1., 0., 0., 1.);
-}
-`;
-
-const FS_GLSL_300 = `\
-#version 300 es
-
-precision highp float;
-
-out vec4 fragmentColor;
-uniform sampler2D sampler;
-uniform samplerCube sCube;
-in vec4 vColor;
-
-void f(out float a, in float b) {}
-
-void main(void) {
-  vec4 texColor = texture(sampler, texCoord);
-  vec4 texCubeColor = textureCube(sCube, cubeCoord);
-  fragmentColor = vColor;
-}
-`;
-
-const FS_GLSL_100 = `\
-#version 300 es
-
-precision highp float;
-
-out vec4 fragmentColor;
-uniform sampler2D sampler;
-uniform samplerCube sCube;
-varying vec4 vColor;
-
-void f(out float a, in float b) {}
-
-void main(void) {
-  vec4 texColor = texture2D(sampler, texCoord);
-  vec4 texCubeColor = textureCube(sCube, cubeCoord);
-  fragmentColor = vColor;
-}
-`;
-
-const VS_GLSL_300 = `\
-#version 300 es
-
-in vec4 positions;
-uniform sampler2D sampler;
-uniform samplerCube sCube;
-out vec4 vColor;
-
-void f(out float a, in float b) {}
-
-void main(void) {
-  gl_Position = positions;
-  vec4 texColor = texture(sampler, texCoord);
-  vec4 texCubeColor = textureCube(sCube, cubeCoord);
-  vColor = vec4(1., 0., 0., 1.);
-}
-`;
-*/
 
 test('transpileShader#import', t => {
   t.ok(transpileShader !== undefined, 'transpileShader import successful');
@@ -257,26 +137,27 @@ test('transpileShader#versions', t => {
   let assembleResult;
 
   assembleResult = transpileShader(VS_GLSL_300, 100, true);
-  t.equal(assembleResult, VS_GLSL_100, 'correctly transpiled');
+  t.equal(stripSpaces(assembleResult), stripSpaces(VS_GLSL_100), 'correctly transpiled');
 
   assembleResult = transpileShader(FS_GLSL_300, 100, false);
-  t.equal(assembleResult, FS_GLSL_100, 'correctly transpiled');
+  t.equal(stripSpaces(assembleResult), stripSpaces(FS_GLSL_100), 'correctly transpiled');
 
   assembleResult = transpileShader(VS_GLSL_100, 300, true);
-  t.equal(assembleResult, VS_GLSL_300_transpiled, 'correctly transpiled');
-
-  assembleResult = transpileShader(FS_GLSL_100, 300, false);
-  t.equal(assembleResult, FS_GLSL_300_transpiled, 'correctly transpiled');
+  t.equal(stripSpaces(assembleResult), stripSpaces(VS_GLSL_300_transpiled), 'correctly transpiled');
 
   // test 300 to 300 transpilation, textureCube() should be replaced with texture()
 
   assembleResult = transpileShader(VS_GLSL_300, 300, true);
-  t.equal(assembleResult, VS_GLSL_300_transpiled, 'correctly transpiled');
+  t.equal(stripSpaces(assembleResult), stripSpaces(VS_GLSL_300_transpiled), 'correctly transpiled');
 
   assembleResult = transpileShader(FS_GLSL_300, 300, false);
-  t.equal(assembleResult, FS_GLSL_300_transpiled, 'correctly transpiled');
+  t.equal(stripSpaces(assembleResult), stripSpaces(FS_GLSL_300_transpiled), 'correctly transpiled');
 
   t.throws(() => transpileShader(VS_GLSL_300, 400, true), /version/, 'unknown glsl version');
 
   t.end();
 });
+
+function stripSpaces(text) {
+  return text.replace(/\s+/g, '');
+}


### PR DESCRIPTION
- Perform transpilation on full shader rather than just shader modules in `assembleShaders`.
- Add options to `Model`, `ProgramManager` and `assembleShaders` to force transpilation to GLSL 1.0.
- Add transpilation rules to fix GLSL version declaration and fragment shader output.

Tested with a simplified version of the deck.gl GLSL 3.0 mesh layer shaders.
