### PR TITLE
Fix broken link

### DIFF
--- a/docs/api-reference/engine/animation/timeline.md
+++ b/docs/api-reference/engine/animation/timeline.md
@@ -99,7 +99,7 @@ Reset timeline time to `0`.
 
 ### attachAnimation(animation: Object, [channelHandle : Number]) : Number
 
-Attach an animation object (can be any object with a `setTime` method, e.g. [KeyFrames](/docs/api-reference/engine/animation/key-frames), `GLTFAnimator`) to the timeline, optionally attached to a specific channel referenced by `channelHandle`.
+Attach an animation object (can be any object with a `setTime` method, e.g. [KeyFrames](/docs/api-reference/engine/animation/key-frames.md), `GLTFAnimator`) to the timeline, optionally attached to a specific channel referenced by `channelHandle`.
 The animation object's time will be updated whenever the timeline updates. Returns a handle that can be used to reference the animation attachement.
 
 ### detachAnimation(handle : Number)


### PR DESCRIPTION


<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
The current link for Frames navigates to https://github.com/uber/luma.gl/blob/master/docs/api-reference/engine/animation/key-frames, which gives a 404. 

Updating it to https://github.com/uber/luma.gl/blob/master/docs/api-reference/engine/animation/key-frames.md

<!-- For all the PRs -->
#### Change List
- Update Frames link in Timeline Readme
