### PR TITLE
Fix SphereGeometry indices

### DIFF
--- a/examples/showcase/persistence/app.js
+++ b/examples/showcase/persistence/app.js
@@ -144,7 +144,7 @@ export default class AppAnimationLoop extends AnimationLoop {
       id: 'electron',
       geometry: new SphereGeometry({
         nlat: 20,
-        nlong: 30  // To test that sphere generation is working properly.
+        nlong: 30 // To test that sphere generation is working properly.
       }),
       program: new Program(gl, {vs: SPHERE_VS, fs: SPHERE_FS})
     });

--- a/examples/showcase/persistence/app.js
+++ b/examples/showcase/persistence/app.js
@@ -1,4 +1,4 @@
-import {AnimationLoop, Model, Geometry, IcoSphereGeometry} from '@luma.gl/engine';
+import {AnimationLoop, Model, Geometry, SphereGeometry} from '@luma.gl/engine';
 import {clear, Framebuffer, Program} from '@luma.gl/webgl';
 import {setParameters} from '@luma.gl/gltools';
 import {Matrix4, Vector3, radians} from 'math.gl';
@@ -142,8 +142,9 @@ export default class AppAnimationLoop extends AnimationLoop {
 
     sphere = new Model(gl, {
       id: 'electron',
-      geometry: new IcoSphereGeometry({
-        iterations: 4
+      geometry: new SphereGeometry({
+        nlat: 20,
+        nlong: 30  // To test that sphere generation is working properly.
       }),
       program: new Program(gl, {vs: SPHERE_VS, fs: SPHERE_FS})
     });

--- a/modules/engine/src/geometries/sphere-geometry.js
+++ b/modules/engine/src/geometries/sphere-geometry.js
@@ -76,10 +76,10 @@ function tesselateSphere(props) {
   }
 
   // Create indices
-  const numVertsAround = nlat + 1;
-  for (let x = 0; x < nlat; x++) {
-    for (let y = 0; y < nlong; y++) {
-      const index = (x * nlong + y) * 6;
+  const numVertsAround = nlong + 1;
+  for (let x = 0; x < nlong; x++) {
+    for (let y = 0; y < nlat; y++) {
+      const index = (x * nlat + y) * 6;
 
       indices[index + 0] = y * numVertsAround + x;
       indices[index + 1] = y * numVertsAround + x + 1;


### PR DESCRIPTION
- Fix index generation in sphere geometry.
- Use SphereGeometry in persistence example so it can act as a test for sphere coordinate generation.

Fixes #1349 