### PR TITLE
Delete VAO when vertex array is deleted

### DIFF
--- a/modules/webgl/src/classes/vertex-array.js
+++ b/modules/webgl/src/classes/vertex-array.js
@@ -58,6 +58,8 @@ export default class VertexArray {
     if (this.buffer) {
       this.buffer.delete();
     }
+
+    this.vertexArrayObject.delete();
   }
 
   initialize(props = {}) {


### PR DESCRIPTION
Looks like a long-standing resource leak. I suspect this was to avoid deleting the the default VAO, but that's no longer necessary with the polyfill.
