### PR TITLE
Assemble shader variables to top of source

### DIFF
--- a/modules/shadertools/src/lib/assemble-shaders.js
+++ b/modules/shadertools/src/lib/assemble-shaders.js
@@ -5,7 +5,7 @@ import injectShader, {DECLARATION_INJECT_MARKER} from './inject-shader';
 import transpileShader from './transpile-shader';
 import {assert} from '../utils';
 
-const REGEX_START_OF_MAIN = /void main\s*\([^)]*\)\s*\{\n?/;
+const REGEX_FIRST_FUNCTION = /[ \t]*\w+[ \t]+\w+\s*\([^)]*\)\s*\{\n?/;
 const INJECT_SHADER_DECLARATIONS = `\n\n${DECLARATION_INJECT_MARKER}\n\n`;
 
 const SHADER_TYPE = {
@@ -67,9 +67,14 @@ function assembleShader(
     versionLine = `#version ${glslVersion}`;
   }
 
-  const mainIndex = sourceLines.findIndex(l => l.match(REGEX_START_OF_MAIN));
-  const corePreamble = sourceLines.slice(0, mainIndex).join('\n');
-  const coreMain = sourceLines.slice(mainIndex).join('\n');
+  let functionIndex = sourceLines.findIndex(l => l.match(REGEX_FIRST_FUNCTION));
+
+  if (functionIndex === -1) {
+    functionIndex = 0;
+  }
+
+  const corePreamble = sourceLines.slice(0, functionIndex).join('\n');
+  const coreMain = sourceLines.slice(functionIndex).join('\n');
 
   // Combine Module and Application Defines
   const allDefines = {};

--- a/modules/shadertools/src/lib/assemble-shaders.js
+++ b/modules/shadertools/src/lib/assemble-shaders.js
@@ -5,7 +5,7 @@ import injectShader, {DECLARATION_INJECT_MARKER} from './inject-shader';
 import transpileShader from './transpile-shader';
 import {assert} from '../utils';
 
-const REGEX_FIRST_FUNCTION = /[ \t]*\w+[ \t]+\w+\s*\([^)]*\)\s*\{\n?/;
+const REGEX_FIRST_FUNCTION = /^[ \t]*\w+[ \t]+\w+\s*\([^)]*\)/;
 const INJECT_SHADER_DECLARATIONS = `\n\n${DECLARATION_INJECT_MARKER}\n\n`;
 
 const SHADER_TYPE = {

--- a/modules/shadertools/src/lib/assemble-shaders.js
+++ b/modules/shadertools/src/lib/assemble-shaders.js
@@ -5,7 +5,7 @@ import injectShader, {DECLARATION_INJECT_MARKER} from './inject-shader';
 import transpileShader from './transpile-shader';
 import {assert} from '../utils';
 
-const REGEX_FIRST_FUNCTION = /^[ \t]*\w+[ \t]+\w+\s*\([^)]*\)/;
+const REGEX_FIRST_FUNCTION = /^[ \t]*\w+[ \t]+\w+\s*\(/;
 const INJECT_SHADER_DECLARATIONS = `\n\n${DECLARATION_INJECT_MARKER}\n\n`;
 
 const SHADER_TYPE = {

--- a/modules/shadertools/src/lib/inject-shader.js
+++ b/modules/shadertools/src/lib/inject-shader.js
@@ -10,7 +10,7 @@ const MODULE_INJECTORS = {
 
 export const DECLARATION_INJECT_MARKER = '__LUMA_INJECT_DECLARATIONS__'; // Uniform/attribute declarations
 
-const REGEX_START_OF_MAIN = /void main\s*\([^)]*\)\s*\{\n?/; // Beginning of main
+const REGEX_START_OF_MAIN = /void\s+main\s*\([^)]*\)\s*\{\n?/; // Beginning of main
 const REGEX_END_OF_MAIN = /}\n?[^{}]*$/; // End of main, assumes main is last function
 const fragments = [];
 


### PR DESCRIPTION
Change that pulls base shader variables to the top of the assembled source so they can be accessed by hook functions. Requested for deck.gl.

Order of assembled source is now:
- Base source attributes, varyings, uniforms
- Module source
- Hook functions
- Base source functions and main.

Note: this solution assumes that base source variables are all defined before the first function.
