### PR TITLE
Rename constants bundle namespace

### DIFF
--- a/modules/constants/src/bundle.js
+++ b/modules/constants/src/bundle.js
@@ -1,8 +1,8 @@
-const moduleExports = require('./index');
+const GLConstants = require('./index').default;
 
 const _global = typeof window === 'undefined' ? global : window;
 // @ts-ignore
 _global.luma = _global.luma || {};
 
 // @ts-ignore
-module.exports = Object.assign(_global.luma, moduleExports);
+module.exports = Object.assign(_global.luma, {GL: GLConstants});


### PR DESCRIPTION
Constants are currently exported under `luma.default`.

This PR moves them to `luma.GL`.