### PR TITLE
Work around fp32 compile error in Safari 15

### DIFF
--- a/modules/shadertools/src/modules/fp32/fp32.js
+++ b/modules/shadertools/src/modules/fp32/fp32.js
@@ -79,7 +79,7 @@ float tan_taylor_fp32(float a) {
     int j = int(q);
 
     if (j < -2 || j > 2) {
-        return 0.0 / 0.0;
+        return 1.0 / 0.0;
     }
 
     t = r - PI_2 * q;
@@ -89,7 +89,7 @@ float tan_taylor_fp32(float a) {
     int abs_k = int(abs(float(k)));
 
     if (abs_k > 4) {
-        return 0.0 / 0.0;
+        return 1.0 / 0.0;
     } else {
         t = t - PI_16 * q;
     }


### PR DESCRIPTION
For #1490 

From [spec](https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf) $5.9:

```
Dividing by zero does not cause an exception but does result in an unspecified value. 
```

See minimal test here: https://codepen.io/Pessimistress/pen/dyRPjOd
