### PR TITLE
fix(core): Add back pure type exports to core (no impact on deck bundle)

### DIFF
--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -130,7 +130,7 @@ export type {UniformValue} from './adapter/types/uniforms';
 
 // GPU TYPE UTILS - GPU MEMORY LAYOUT TYPES - EXTERNAL
 
-export type {NumberArray} from './types';
+export type {NumberArray, TypedArray, TypedArrayConstructor} from './types';
 export type {VertexFormat, VertexType} from './gpu-type-utils/vertex-formats';
 export type {
   ShaderDataType,

--- a/modules/core/src/utils/is-array.ts
+++ b/modules/core/src/utils/is-array.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {TypedArray, NumberArray} from '../types';
+import type {TypedArray, NumberArray} from '../types';
 
 /**
  * Check is an array is a typed array


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- TypedArray, NumberArray exports had been removed in the purge of core exports. Maked luma.gl@9.1.0-alpha.1 break deck.gl master
#### Change List
-
