### PR TITLE
fix(postprocessing): Remove pre-multiplied alpha

### DIFF
--- a/modules/effects/src/passes/postprocessing/image-blur-filters/tiltshift.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/tiltshift.ts
@@ -37,18 +37,11 @@ fn tiltShift_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) -> vec4f
     float weight = 1.0 - abs(percent);
     vec4 offsetColor = texture(source, texCoord + tiltShift_getDelta(texSize) / texSize * percent * radius);
 
-    /* switch to pre-multiplied alpha to correctly blur transparent images */
-    offsetColor.rgb *= offsetColor.a;
-
     color += offsetColor * weight;
     total += weight;
   }
 
   color = color / total;
-
-  /* switch back from pre-multiplied alpha */
-  color.rgb /= color.a + 0.00001;
-
   return color;
 }
 `;
@@ -82,19 +75,11 @@ vec4 tiltShift_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
     float percent = (t + offset - 0.5) / 30.0;
     float weight = 1.0 - abs(percent);
     vec4 offsetColor = texture(source, texCoord + tiltShift_getDelta(texSize) / texSize * percent * radius);
-
-    /* switch to pre-multiplied alpha to correctly blur transparent images */
-    offsetColor.rgb *= offsetColor.a;
-
     color += offsetColor * weight;
     total += weight;
   }
 
   color = color / total;
-
-  /* switch back from pre-multiplied alpha */
-  color.rgb /= color.a + 0.00001;
-
   return color;
 }
 `;

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/zoomblur.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/zoomblur.ts
@@ -26,19 +26,11 @@ fn zoomBlur_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) -> vec4f 
     float percent = (t + offset) / 40.0;
     float weight = 4.0 * (percent - percent * percent);
     vec4 offsetColor = texture(source, texCoord + toCenter * percent * zoomBlur.strength / texSize);
-
-    /* switch to pre-multiplied alpha to correctly blur transparent images */
-    offsetColor.rgb *= offsetColor.a;
-
     color += offsetColor * weight;
     total += weight;
   }
 
   color = color / total;
-
-  /* switch back from pre-multiplied alpha */
-  color.rgb /= color.a + 0.00001;
-
   return color;
 }
 `;
@@ -61,19 +53,11 @@ vec4 zoomBlur_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
     float percent = (t + offset) / 40.0;
     float weight = 4.0 * (percent - percent * percent);
     vec4 offsetColor = texture(source, texCoord + toCenter * percent * zoomBlur.strength / texSize);
-
-    /* switch to pre-multiplied alpha to correctly blur transparent images */
-    offsetColor.rgb *= offsetColor.a;
-
     color += offsetColor * weight;
     total += weight;
   }
 
   color = color / total;
-
-  /* switch back from pre-multiplied alpha */
-  color.rgb /= color.a + 0.00001;
-
   return color;
 }
 `;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/pull/9642
<!-- For other PRs without open issue -->
#### Background

Pre-multiplying alpha in shaders leads to incorrect blending in deck.gl. See background: https://github.com/visgl/deck.gl/pull/9642

<!-- For all the PRs -->
#### Change List
- Do not premultiply colors in postprocess effects
