### PR TITLE
fix: correct test description spelling

### DIFF
--- a/modules/webgl/test/context/state-tracker/context-state.spec.ts
+++ b/modules/webgl/test/context/state-tracker/context-state.spec.ts
@@ -76,7 +76,7 @@ test.skip('WebGLState#setGLParameters (Mixing enum and function style keys)', as
 });
 
 // TODO - restore asap
-test('WebGLState#setGLParameters (Argument expansion for ***SeperateFunc setters))', async t => {
+test('WebGLState#setGLParameters (Argument expansion for ***SeparateFunc setters))', async t => {
   const webglDevice = await getWebGLTestDevice();
 
   const expectedValues = {


### PR DESCRIPTION
## Summary
- fix typo in context state tracker test description

## Testing
- `yarn test node`

------
https://chatgpt.com/codex/tasks/task_e_68a1ff36ebe88328ad688a49a908a16f