### PR TITLE
fix(webgl): WebGLAdapter.attach support passing DeviceProps

### DIFF
--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -46,6 +46,7 @@ export class WebGLAdapter extends Adapter {
   /**
    * Get a device instance from a GL context
    * Creates a WebGLCanvasContext against the contexts canvas
+   * @note autoResize will be disabled, assuming that whoever created the external context will be handling resizes.
    * @param gl
    * @returns
    */
@@ -66,10 +67,11 @@ export class WebGLAdapter extends Adapter {
     const createCanvasContext = props.createCanvasContext === true ? {} : props.createCanvasContext;
 
     // We create a new device using the provided WebGL context and its canvas
+    // Assume that whoever created the external context will be handling resizes.
     return new WebGLDevice({
       ...props,
       _handle: gl,
-      createCanvasContext: {canvas: gl.canvas, ...createCanvasContext}
+      createCanvasContext: {canvas: gl.canvas, autoResize: false, ...createCanvasContext}
     });
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/issues/9172
<!-- For other PRs without open issue -->
#### Background

When using interleaved rendering in with `MapboxOverlay`, the `Deck` [instance is created](https://github.com/visgl/deck.gl/blob/master/modules/mapbox/src/mapbox-overlay.ts#L125-L132) with the `gl` prop, [which in turn](https://github.com/visgl/deck.gl/blob/master/modules/core/src/lib/deck.ts#L367-L373) means `WebGLAdapter.attach()` is used to configure the device.

This code path has `autoResize` hardcoded to `false` which means that rendering breaks when the window is resized, as can be seen: https://felixpalmer.github.io/deck.gl/examples/maplibre

I tried to find a way to fix this purely from the deck.gl side, but it just leads to more errors and this seems the cleanest fix.

<!-- For all the PRs -->
#### Change List
- Remove `autoResize: false`
- Pass through `DeviceProps`