### PR TITLE
fix(webgl): WebGLAdapter.attach support passing DeviceProps (#2453)

### DIFF
--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -50,7 +50,7 @@ export class WebGLAdapter extends Adapter {
    * @param gl
    * @returns
    */
-  async attach(gl: Device | WebGL2RenderingContext): Promise<WebGLDevice> {
+  async attach(gl: Device | WebGL2RenderingContext, props: DeviceProps = {}): Promise<WebGLDevice> {
     const {WebGLDevice} = await import('./webgl-device');
     if (gl instanceof WebGLDevice) {
       return gl;
@@ -64,11 +64,14 @@ export class WebGLAdapter extends Adapter {
       throw new Error('Invalid WebGL2RenderingContext');
     }
 
+    const createCanvasContext = props.createCanvasContext === true ? {} : props.createCanvasContext;
+
     // We create a new device using the provided WebGL context and its canvas
     // Assume that whoever created the external context will be handling resizes.
     return new WebGLDevice({
+      ...props,
       _handle: gl,
-      createCanvasContext: {canvas: gl.canvas, autoResize: false}
+      createCanvasContext: {canvas: gl.canvas, autoResize: false, ...createCanvasContext}
     });
   }
 


### PR DESCRIPTION
Cherry pick fix from 9.2: https://github.com/visgl/luma.gl/pull/2453
