### PR TITLE
fix(webgl): Fix GL.UNPACK_ROW_LENGTH in WebGLTexture.copyImageData

### DIFF
--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -99,6 +99,44 @@ test('Texture#copyImageData updates correct cubemap face on WebGL', async t => {
   t.end();
 });
 
+test('Texture#copyImageData triggers row-length error for large rgba8unorm textures on WebGL', async t => {
+  const device = await getWebGLTestDevice();
+  if (!device) {
+    t.comment('WebGL not available');
+    t.end();
+    return;
+  }
+
+  const width = 1440;
+  const height = 721;
+  const tex = device.createTexture({
+    format: 'rgba8unorm',
+    width,
+    height
+  });
+
+  const data = new Uint8Array(width * height * 4);
+  const gl = device.gl;
+
+  // Clear any existing GL error state before issuing the copy.
+  while (gl.getError()) {
+    // no-op
+  }
+
+  debugger
+  t.doesNotThrow(() => tex.copyImageData({data}), 'copyImageData throws error');
+
+  // const error = gl.getError();
+  // t.equal(
+  //   error,
+  //   GL.INVALID_OPERATION,
+  //   'copyImageData issues INVALID_OPERATION due to mismatched UNPACK_ROW_LENGTH'
+  // );
+
+  tex.destroy();
+  t.end();
+});
+
 test('Texture#writeData & readDataAsync round-trip', async t => {
   for (const device of await getTestDevices()) {
     t.comment(`Testing ${device.type}`);

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -209,7 +209,9 @@ export class WEBGLTexture extends Texture {
 
     const glParameters: GLValueParameters = !this.compressed
       ? {
-          [GL.UNPACK_ROW_LENGTH]: options.bytesPerRow,
+          // Describe the data being copied to the texture
+          // Note: This value is pixels per image, not bytes per image
+          [GL.UNPACK_ROW_LENGTH]: width,
           [GL.UNPACK_IMAGE_HEIGHT]: options.rowsPerImage
         }
       : {};


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background

https://openjs-foundation.slack.com/archives/C05JCDKHQUE/p1760131685179339

<!-- For all the PRs -->
#### Change List
- Fix GL.UNPACK_ROW_LENGTH
- Add test case
