### PR TITLE
chore: update vite to 7.2.4

### DIFF
--- a/examples/api/animation/package.json
+++ b/examples/api/animation/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/api/cubemap/package.json
+++ b/examples/api/cubemap/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/api/texture-3d/package.json
+++ b/examples/api/texture-3d/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/api/texture-compressed/package.json
+++ b/examples/api/texture-compressed/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/showcase/instancing/package.json
+++ b/examples/showcase/instancing/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/showcase/persistence/package.json
+++ b/examples/showcase/persistence/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/showcase/postprocessing/package.json
+++ b/examples/showcase/postprocessing/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/hello-cube/package.json
+++ b/examples/tutorials/hello-cube/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/hello-gltf/package.json
+++ b/examples/tutorials/hello-gltf/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/hello-instanced-cubes/package.json
+++ b/examples/tutorials/hello-instanced-cubes/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/hello-instancing/package.json
+++ b/examples/tutorials/hello-instancing/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/hello-triangle-geometry/package.json
+++ b/examples/tutorials/hello-triangle-geometry/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/hello-triangle/package.json
+++ b/examples/tutorials/hello-triangle/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/hello-two-cubes/package.json
+++ b/examples/tutorials/hello-two-cubes/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/lighting/package.json
+++ b/examples/tutorials/lighting/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/shader-hooks/package.json
+++ b/examples/tutorials/shader-hooks/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/shader-modules/package.json
+++ b/examples/tutorials/shader-modules/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/transform-feedback/package.json
+++ b/examples/tutorials/transform-feedback/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/examples/tutorials/transform/package.json
+++ b/examples/tutorials/transform/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^7.2.2"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/api-v8/program-management/package.json
+++ b/wip/examples-wip/api-v8/program-management/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/api-v8/stress-test/package.json
+++ b/wip/examples-wip/api-v8/stress-test/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/notready/dof/package.json
+++ b/wip/examples-wip/notready/dof/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/notready/geospatial/package.json
+++ b/wip/examples-wip/notready/geospatial/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/notready/gltf/package.json
+++ b/wip/examples-wip/notready/gltf/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/notready/instanced-transform/package.json
+++ b/wip/examples-wip/notready/instanced-transform/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/rotating-cube/package.json
+++ b/wip/examples-wip/rotating-cube/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/webgl/external-webgl-context/package.json
+++ b/wip/examples-wip/webgl/external-webgl-context/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/webgl/hello-instancing-webgl/package.json
+++ b/wip/examples-wip/webgl/hello-instancing-webgl/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/webgl/shader-modules-webgl/package.json
+++ b/wip/examples-wip/webgl/shader-modules-webgl/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^5.1.6",
-    "vite": "^3.2.4"
+    "vite": "^7.2.4"
   }
 }

--- a/wip/examples-wip/webgpu/computeboids/package.json
+++ b/wip/examples-wip/webgpu/computeboids/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^5.0.0",
+    "vite": "^7.2.4",
     "vite-plugin-string": "^1.1.1"
   }
 }

--- a/wip/examples-wip/webgpu/textured-cube/package.json
+++ b/wip/examples-wip/webgpu/textured-cube/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- update all example package.json files to use Vite ^7.2.4

## Testing
- yarn lint fix *(fails: existing unresolved module imports)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920507beeac83288233961c33c5b95e)