### PR TITLE
fix(engine): Factory warnings now level 3 logs

### DIFF
--- a/modules/engine/src/factories/pipeline-factory.ts
+++ b/modules/engine/src/factories/pipeline-factory.ts
@@ -69,12 +69,13 @@ export class PipelineFactory {
       pipeline.hash = hash;
       cache[hash] = {pipeline, useCount: 1};
       if (this.debug) {
-        log.warn(`${this}: ${pipeline} created, count=${cache[hash].useCount}`)();
+        log.log(3, `${this}: ${pipeline} created, count=${cache[hash].useCount}`)();
       }
     } else {
       cache[hash].useCount++;
       if (this.debug) {
-        log.warn(
+        log.log(
+          3,
           `${this}: ${cache[hash].pipeline} reused, count=${cache[hash].useCount}, (id=${props.id})`
         )();
       }
@@ -103,12 +104,13 @@ export class PipelineFactory {
       pipeline.hash = hash;
       cache[hash] = {pipeline, useCount: 1};
       if (this.debug) {
-        log.warn(`${this}: ${pipeline} created, count=${cache[hash].useCount}`)();
+        log.log(3, `${this}: ${pipeline} created, count=${cache[hash].useCount}`)();
       }
     } else {
       cache[hash].useCount++;
       if (this.debug) {
-        log.warn(
+        log.log(
+          3,
           `${this}: ${cache[hash].pipeline} reused, count=${cache[hash].useCount}, (id=${props.id})`
         )();
       }
@@ -130,13 +132,13 @@ export class PipelineFactory {
     if (cache[hash].useCount === 0) {
       this._destroyPipeline(pipeline);
       if (this.debug) {
-        log.warn(`${this}: ${pipeline} released and destroyed`)();
+        log.log(3, `${this}: ${pipeline} released and destroyed`)();
       }
     } else if (cache[hash].useCount < 0) {
       log.error(`${this}: ${pipeline} released, useCount < 0, resetting`)();
       cache[hash].useCount = 0;
     } else if (this.debug) {
-      log.warn(`${this}: ${pipeline} released, count=${cache[hash].useCount}`)();
+      log.log(3, `${this}: ${pipeline} released, count=${cache[hash].useCount}`)();
     }
   }
 

--- a/modules/engine/src/factories/shader-factory.ts
+++ b/modules/engine/src/factories/shader-factory.ts
@@ -53,12 +53,15 @@ export class ShaderFactory {
       });
       this._cache[key] = cacheEntry = {shader, useCount: 1};
       if (this.debug) {
-        log.warn(`${this}: Created new shader ${shader.id}`)();
+        log.log(3, `${this}: Created new shader ${shader.id}`)();
       }
     } else {
       cacheEntry.useCount++;
       if (this.debug) {
-        log.warn(`${this}: Reusing shader ${cacheEntry.shader.id} count=${cacheEntry.useCount}`)();
+        log.log(
+          3,
+          `${this}: Reusing shader ${cacheEntry.shader.id} count=${cacheEntry.useCount}`
+        )();
       }
     }
 
@@ -81,13 +84,13 @@ export class ShaderFactory {
           delete this._cache[key];
           cacheEntry.shader.destroy();
           if (this.debug) {
-            log.warn(`${this}: Releasing shader ${shader.id}, destroyed`)();
+            log.log(3, `${this}: Releasing shader ${shader.id}, destroyed`)();
           }
         }
       } else if (cacheEntry.useCount < 0) {
         throw new Error(`ShaderFactory: Shader ${shader.id} released too many times`);
       } else if (this.debug) {
-        log.warn(`${this}: Releasing shader ${shader.id} count=${cacheEntry.useCount}`)();
+        log.log(3, `${this}: Releasing shader ${shader.id} count=${cacheEntry.useCount}`)();
       }
     }
   }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->

#### Background
- The shader/pipeline caching had excessive logging using `log.warn()` instead of `log.log(logLevel)`
- We enabled the shader/pipeline caching by default.

#### Change List
- Move factory logging to `log.log(3, ...)`

#### Notes
- Should be cherry-picked to 9.2 patch
