### PR TITLE
Remove WebGL version tagging

### DIFF
--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -125,8 +125,7 @@ function isWebGL(gl: any): gl is WebGL2RenderingContext {
   if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
     return true;
   }
-  // Look for debug contexts, headless gl etc
-  return Boolean(gl && Number.isFinite(gl._version));
+  return Boolean(gl && typeof gl.createVertexArray === 'function');
 }
 
 export const webgl2Adapter = new WebGLAdapter();

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -215,8 +215,6 @@ export class WebGLDevice extends Device {
 
     // Instrument context
     (this.gl as any).device = this; // Update GL context: Link webgl context back to device
-    // TODO - remove, this is only used to detect debug contexts.
-    (this.gl as any)._version = 2; // Update GL context: Store WebGL version field on gl context (HACK to identify debug contexts)
 
     // initialize luma Device fields
     this.info = getDeviceInfo(this.gl, this._extensions);


### PR DESCRIPTION
Related to https://github.com/visgl/deck.gl/issues/9950

### Motivation
- Remove the custom `_version` field set on WebGL contexts and rely on API feature detection since we always create WebGL2 contexts now.

### Description
- Stop assigning `(this.gl as any)._version = 2` when initializing `WebGLDevice` and keep only the device reference on the context via `(this.gl as any).device`.
- Replace the `_version`-based debug/headless detection in `isWebGL` with a check for a WebGL2 API (`typeof gl.createVertexArray === 'function'`).

### Testing
- Ran `yarn lint fix`, which failed due to missing `node_modules` state (dependency install needed), so no further automated checks were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972390ce1248328837c79c2a6c16864)