### PR TITLE
fix(gltf): add HAS_COLORS define for COLOR_0 vertex attribute

### DIFF
--- a/modules/gltf/src/parsers/parse-pbr-material.ts
+++ b/modules/gltf/src/parsers/parse-pbr-material.ts
@@ -106,6 +106,7 @@ export function parsePBRMaterial(
   if (attributes['NORMAL']) parsedMaterial.defines['HAS_NORMALS'] = true;
   if (attributes['TANGENT'] && options?.useTangents) parsedMaterial.defines['HAS_TANGENTS'] = true;
   if (attributes['TEXCOORD_0']) parsedMaterial.defines['HAS_UV'] = true;
+  if (attributes['COLOR_0']) parsedMaterial.defines['HAS_COLORS'] = true;
 
   if (options?.imageBasedLightingEnvironment) parsedMaterial.defines['USE_IBL'] = true;
   if (options?.lights) parsedMaterial.defines['USE_LIGHTS'] = true;
@@ -322,6 +323,7 @@ export class PBRMaterialParser {
     this.defineIfPresent(attributes.NORMAL, 'HAS_NORMALS');
     this.defineIfPresent(attributes.TANGENT && useTangents, 'HAS_TANGENTS');
     this.defineIfPresent(attributes.TEXCOORD_0, 'HAS_UV');
+    this.defineIfPresent(attributes.COLOR_0, 'HAS_COLORS');
 
     this.defineIfPresent(imageBasedLightingEnvironment, 'USE_IBL');
     this.defineIfPresent(lights, 'USE_LIGHTS');


### PR DESCRIPTION
#### Background

When a glTF mesh contains a `COLOR_0` vertex attribute (e.g. point cloud data with per-vertex colors), `parsePBRMaterial()` did not set the `HAS_COLORS` shader define. The existing code already handled analogous attributes using the same `#ifdef` pattern.

```typescript
if (attributes['NORMAL'])     parsedMaterial.defines['HAS_NORMALS'] = true;
if (attributes['TANGENT'] ..) parsedMaterial.defines['HAS_TANGENTS'] = true;
if (attributes['TEXCOORD_0']) parsedMaterial.defines['HAS_UV'] = true;
// COLOR_0 was missing
```

Without HAS_COLORS, the vertex shader's #ifdef HAS_COLORS block was excluded at compile time, so the in vec3 colors declaration was absent. The COLOR_0 data was uploaded to the GPU but never read by the shader — all vertices were rendered with the default instance color (white).

Downstream consumers such as deck.gl's ScenegraphLayer do not currently handle per-vertex colors from glTF meshes, but would need this define to conditionally declare vertex attribute inputs and blend per-vertex colors with instance colors (e.g. for rendering colored point clouds via 3D Tiles).
The Khronos https://github.com/KhronosGroup/glTF-Sample-Renderer also uses the same compile-time define pattern (HAS_COLOR_0_VEC3 / HAS_COLOR_0_VEC4) for vertex color support.

#### Change List

- Add HAS_COLORS define when COLOR_0 attribute is present in parsePBRMaterial() function
- Add equivalent in the commented-out PBRMaterialParser class for consistency