### PR TITLE
fix(core): apply drawing buffer resize immediately for WebGL

### DIFF
--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -259,7 +259,11 @@ export abstract class CanvasContext {
     // TODO(ib) - temporarily makes drawingBufferWidth/Height out of sync with canvas.width/height, could that cause issues?
     this.drawingBufferWidth = Math.floor(width);
     this.drawingBufferHeight = Math.floor(height);
+    // Apply resize immediately - deferred resize via getCurrentFramebuffer() is not
+    // always triggered (e.g. WebGL rendering to default framebuffer), which can leave
+    // the canvas at its default 300x150 size indefinitely.
     this._needsDrawingBufferResize = true;
+    this._resizeDrawingBufferIfNeeded();
   }
 
   /**


### PR DESCRIPTION
#### Background

Commit 939287e3e ("Fix flicker when resizing CanvasContext") deferred the actual canvas resize from `setDrawingBufferSize()` to `getCurrentFramebuffer()` to avoid flicker caused by clearing the drawing buffer on resize.

However, on WebGL this deferred resize never fires. When `beginRenderPass({framebuffer: null})` is called, the two backends behave differently.

WebGPU (`webgpu-render-pass.ts`) — calls `getCurrentFramebuffer()`:
```typescript
const framebuffer = (props.framebuffer as WebGPUFramebuffer) || device.getCanvasContext().getCurrentFramebuffer();
```

WebGL (webgl-render-pass.ts) — only calls getDrawingBufferSize():
```typescript
const [width, height] = device.getDefaultCanvasContext().getDrawingBufferSize();
viewport = [0, 0, width, height];
```

As a result, on WebGL canvas.width/canvas.height are never updated from their initial values, while drawingBufferWidth/drawingBufferHeight are correctly set by ResizeObserver. The viewport is set to the intended size but the actual drawing buffer remains at the initial canvas size, causing a resolution mismatch.

#### Change List

- Call _resizeDrawingBufferIfNeeded() immediately after setting _needsDrawingBufferResize = true in setDrawingBufferSize()
- The deferred path in getCurrentFramebuffer() becomes a harmless no-op (flag is already cleared)